### PR TITLE
Updated readme and ingress service

### DIFF
--- a/cluster_config/Ingress_controller/README.md
+++ b/cluster_config/Ingress_controller/README.md
@@ -36,7 +36,4 @@ Once everything is checked we can apply the ingress rules:
 kubectl apply -f ingress.yaml
 ```
 
-The file `ingress.yaml` contains all the ingress rules for Prometheus, Grafana and Alert Manager. In particular the following DNS name are associated to them:
- - Prometheus https://prometheus.crown-labs.ipv6.polito.it:4443
- - Grafana https://grafana.crown-labs.ipv6.polito.it:4443
- - AlertManager https://alertmanager.crown-labs.ipv6.polito.it:4443
+The file `ingress.yaml` contains all the ingress rules for Prometheus, Grafana and Alert Manager.

--- a/cluster_config/Ingress_controller/ingress_nginx.yaml
+++ b/cluster_config/Ingress_controller/ingress_nginx.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-controller
     app.kubernetes.io/part-of: ingress-controller
+  annotations:
+    metallb.universe.tf/address-pool: public
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
I've removed from the documentation file of the ingress controller any external link to services we expose on public internet (Prometheus, ...).
I've also updated the yaml file that describe the LoadBalancer service related to the ingress controller with an annotation that specify to metallb that the service must have a public IP