### PR TITLE
cert-manager - Enable HTTP-01 challenges

### DIFF
--- a/cluster_config/cert-manager/README.md
+++ b/cluster_config/cert-manager/README.md
@@ -7,7 +7,7 @@ In order to get a certificate from Let's Encrypt, it is necessary to prove the c
 * HTTP-01 challenge: requires to put a specific value in a file on the web server at a specific path;
 * DNS-01 challenge: requires to put a specific value in a TXT record under that domain name.
 
-In the following, the DNS-01 challenge is adopted. Although being a bit more complex to configure, it is more flexible (does not require the web server to be accessible at port 80) and allows to issue wildcard certificates.
+In the following, both types of challenges are configured and made available. Indeed, the former is easier to use but it requires port 80 to be open and reachable. The latter, on the other hand, does not suffer from this limitation and allows to issue wildcard certificates, but it can be used only for the DNS names under our control.
 
 ## Configure bind9
 
@@ -73,7 +73,15 @@ A valid certificate associated with the `Ingress` host is automatically generate
 ### Certificate Resources
 A `Certificate` resource can be created to manually request the issuance of a digital certificate for a specific host name belonging to the DNS zone under control. [certificate-example.yaml](certificate-example.yaml) provides an example configuration to request a certificate; please refer to the official documentation [[4]](https://cert-manager.io/docs/usage/certificate/) for more information.
 
+### Select the type of challenge to use (i.e. HTTP-01 or DNS-01)
+By default, cert-manager has been configured to prove the control of the domain names to be certified using HTTP-01 challenges. To use DNS-01 challenges, instead, it is necessary to add the ad-hoc label to the `Ingress` or `Certificate` resource:
+```yaml
+labels:
+    use-dns01-solver: "true"
+```
+
 ## Additional References
 1. [cert-manager documentation](https://cert-manager.io/docs/)
-2. [cert-manager configuration with DNS01](https://cert-manager.io/docs/configuration/acme/dns01/)
-3. [cert-manager usage](https://cert-manager.io/docs/usage/)
+2. [cert-manager configuration with HTTP01](https://cert-manager.io/docs/configuration/acme/http01/)
+3. [cert-manager configuration with DNS01](https://cert-manager.io/docs/configuration/acme/dns01/)
+4. [cert-manager usage](https://cert-manager.io/docs/usage/)

--- a/cluster_config/cert-manager/certificate-example.yaml
+++ b/cluster_config/cert-manager/certificate-example.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -6,13 +7,13 @@ metadata:
 spec:
   # The secret where the generated certificate is stored
   secretName: example-certificate-secret
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2160h  # 90d
+  renewBefore: 360h  # 15d
   commonName: example.crown-labs.ipv6.polito.it
   dnsNames:
-  - example.crown-labs.ipv6.polito.it
+    - example.crown-labs.ipv6.polito.it
   uriSANs:
-  - example.crown-labs.ipv6.polito.it
+    - example.crown-labs.ipv6.polito.it
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer

--- a/cluster_config/cert-manager/lets-encrypt-issuer-production.yaml
+++ b/cluster_config/cert-manager/lets-encrypt-issuer-production.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -12,13 +13,18 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-production-private-key
-    # Use bind as the challenge solver
     solvers:
-    - dns01:
-        rfc2136:
-          nameserver: 130.192.225.79
-          tsigKeyName: k8s-ladispe-cert-manager
-          tsigAlgorithm: HMACSHA512
-          tsigSecretSecretRef:
-            name: cert-manager-tsig-secret
-            key: cert-manager-tsig-secret-key
+      - http01:
+          ingress:
+            class: nginx
+      - dns01:
+          rfc2136:
+            nameserver: 130.192.225.79
+            tsigKeyName: k8s-ladispe-cert-manager
+            tsigAlgorithm: HMACSHA512
+            tsigSecretSecretRef:
+              name: cert-manager-tsig-secret
+              key: cert-manager-tsig-secret-key
+        selector:
+          matchLabels:
+            use-dns01-solver: "true"

--- a/cluster_config/cert-manager/lets-encrypt-issuer-staging.yaml
+++ b/cluster_config/cert-manager/lets-encrypt-issuer-staging.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -12,13 +13,18 @@ spec:
     privateKeySecretRef:
       # Secret resource used to store the account's private key.
       name: letsencrypt-staging-private-key
-    # Use bind as the challenge solver
     solvers:
-    - dns01:
-        rfc2136:
-          nameserver: 130.192.225.79
-          tsigKeyName: k8s-ladispe-cert-manager
-          tsigAlgorithm: HMACSHA512
-          tsigSecretSecretRef:
-            name: cert-manager-tsig-secret
-            key: cert-manager-tsig-secret-key
+      - http01:
+          ingress:
+            class: nginx
+      - dns01:
+          rfc2136:
+            nameserver: 130.192.225.79
+            tsigKeyName: k8s-ladispe-cert-manager
+            tsigAlgorithm: HMACSHA512
+            tsigSecretSecretRef:
+              name: cert-manager-tsig-secret
+              key: cert-manager-tsig-secret-key
+        selector:
+          matchLabels:
+            use-dns01-solver: "true"


### PR DESCRIPTION
This PR modifies the cert-manager configuration to use HTTP-01 challenges to prove the control of the domain name to be certificated. Hence, it is possible to obtain valid digital certificates for names outside the `ipv6.polito.it` domain. The DNS-01 challenge remains available but needs to be manually selected through an ad-hoc label. The documentation is updated accordingly.