### PR TITLE
Pod anti affinity configuration

### DIFF
--- a/cluster_config/Ingress_controller/mandatory.yaml
+++ b/cluster_config/Ingress_controller/mandatory.yaml
@@ -215,6 +215,19 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       nodeSelector:
         kubernetes.io/os: linux
+      affinity:
+        # Ask the scheduler to schedule different replicas on different nodes
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 99
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - ingress-nginx
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: nginx-ingress-controller
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0

--- a/cluster_config/kube-prometheus/manifests/alertmanager-alertmanager.yaml
+++ b/cluster_config/kube-prometheus/manifests/alertmanager-alertmanager.yaml
@@ -16,3 +16,15 @@ spec:
     runAsUser: 1000
   serviceAccountName: alertmanager-main
   version: v0.20.0
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 99
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - alertmanager
+          topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
This PR configures the pod anti affinity property for the ingress
controller and prometheus to prevent different pods of the same
deployment or stateful set to be deployed on the same host.