### PR TITLE
Enable Prometheus metrics for Bind9

### DIFF
--- a/cluster_config/kube-prometheus/manifests/prometheus-bind-exporter.yaml
+++ b/cluster_config/kube-prometheus/manifests/prometheus-bind-exporter.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: prometheus-bind-exporter
+  namespace: monitoring
+subsets:
+- addresses:
+  - ip: 130.192.225.79
+  ports:
+  - name: metrics
+    port: 9153
+    protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-bind-exporter
+  namespace: monitoring
+  labels:
+    app: prometheus-bind-exporter
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9153
+    protocol: TCP
+    targetPort: 9153
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}
+
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-bind-exporter
+  namespace: monitoring
+  labels:
+    app: prometheus-bind-exporter
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 15s
+    port: metrics
+  selector:
+    matchLabels:
+      app: prometheus-bind-exporter


### PR DESCRIPTION
This PR describes and provides the configuration to enable bind_exporter and integrate the metrics obtained with Prometheus and Grafana.