### PR TITLE
Monitoring - Keycloak authentication

### DIFF
--- a/cluster_config/Ingress_controller/ingress-monitoring.yaml
+++ b/cluster_config/Ingress_controller/ingress-monitoring.yaml
@@ -3,10 +3,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/auth-realm: Authentication Required - ok
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth
-    nginx.ingress.kubernetes.io/auth-type: basic
     cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
   name: alertmanager
   namespace: monitoring
 spec:
@@ -18,6 +17,28 @@ spec:
           serviceName: alertmanager-main
           servicePort: 9093
         path: /
+  tls:
+  - hosts:
+    - alertmanager.crown-labs.ipv6.polito.it
+    secretName: alertmanager-cert
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  name: alertmanager-oauth2
+  namespace: monitoring
+spec:
+  rules:
+  - host: alertmanager.crown-labs.ipv6.polito.it
+    http:
+      paths:
+      - backend:
+          serviceName: monitoring-oauth2-proxy
+          servicePort: 4180
+        path: /oauth2
   tls:
   - hosts:
     - alertmanager.crown-labs.ipv6.polito.it
@@ -55,10 +76,9 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/auth-realm: Authentication Required - ok
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth
-    nginx.ingress.kubernetes.io/auth-type: basic
     cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
   generation: 1
   name: prometheus
   namespace: monitoring
@@ -71,6 +91,29 @@ spec:
           serviceName: prometheus-k8s
           servicePort: 9090
         path: /
+  tls:
+  - hosts:
+    - prometheus.crown-labs.ipv6.polito.it
+    secretName: prometheus-cert
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  generation: 1
+  name: prometheus-oauth2
+  namespace: monitoring
+spec:
+  rules:
+  - host: prometheus.crown-labs.ipv6.polito.it
+    http:
+      paths:
+      - backend:
+          serviceName: monitoring-oauth2-proxy
+          servicePort: 4180
+        path: /oauth2
   tls:
   - hosts:
     - prometheus.crown-labs.ipv6.polito.it

--- a/cluster_config/kube-prometheus/manifests/grafana-configuration.yaml
+++ b/cluster_config/kube-prometheus/manifests/grafana-configuration.yaml
@@ -13,8 +13,8 @@ data:
   # Allow access via OAuth only to already existing accounts
   GF_AUTH_GENERIC_OAUTH_ALLOW_SIGN_UP: "false"
   # Client configuration in Keycloak (ID and Secret)
-  GF_AUTH_GENERIC_OAUTH_CLIENT_ID: grafana
-  GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: <grafana-secret>
+  GF_AUTH_GENERIC_OAUTH_CLIENT_ID: monitoring
+  GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: <monitoring-secret>
   # Keycloak URLs
   GF_AUTH_GENERIC_OAUTH_AUTH_URL: https://auth.crown-labs.ipv6.polito.it/auth/realms/virtlabs/protocol/openid-connect/auth
   GF_AUTH_GENERIC_OAUTH_TOKEN_URL: https://auth.crown-labs.ipv6.polito.it/auth/realms/virtlabs/protocol/openid-connect/token

--- a/cluster_config/kube-prometheus/manifests/monitoring-oauth2-proxy-deployment.yaml
+++ b/cluster_config/kube-prometheus/manifests/monitoring-oauth2-proxy-deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monitoring-oauth2-proxy
+  namespace: monitoring
+  labels:
+    app: monitoring-oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: monitoring-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app: monitoring-oauth2-proxy
+    spec:
+      containers:
+      - name: monitoring-oauth2-proxy
+        image: quay.io/pusher/oauth2_proxy:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+        args:
+        # General configurations
+        - --http-address=0.0.0.0:4180
+        - --reverse-proxy=true
+        # Cookie configurations
+        - --cookie-secret=<cookie-secret>
+        - --cookie-expire=1h
+        - --cookie-refresh=45m
+        # Use Keycloak as provider
+        - --provider=keycloak
+        # Client configuration in Keycloak (ID and Secret)
+        - --client-id=monitoring
+        - --client-secret=<monitoring-secret>
+        # Keycloak URLs
+        - --login-url=https://auth.crown-labs.ipv6.polito.it/auth/realms/virtlabs/protocol/openid-connect/auth
+        - --redeem-url=https://auth.crown-labs.ipv6.polito.it/auth/realms/virtlabs/protocol/openid-connect/token
+        - --validate-url=https://auth.crown-labs.ipv6.polito.it/auth/realms/virtlabs/protocol/openid-connect/userinfo
+        # Restrictions
+        - --keycloak-group=/monitoring
+        - --email-domain=*

--- a/cluster_config/kube-prometheus/manifests/monitoring-oauth2-proxy-service.yaml
+++ b/cluster_config/kube-prometheus/manifests/monitoring-oauth2-proxy-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monitoring-oauth2-proxy
+  namespace: monitoring
+  labels:
+    app: monitoring-oauth2-proxy
+spec:
+  ports:
+  - name: http
+    port: 4180
+    targetPort: 4180
+  selector:
+    app: monitoring-oauth2-proxy


### PR DESCRIPTION
This PR introduces OAuth2 authentication for Alertmanager and
Prometheus, through oauth2_proxy and the ingress controller.