### PR TITLE
prepare-vm.sh - Increase NoVNC priority

### DIFF
--- a/vms/scripts/prepare-vm.sh
+++ b/vms/scripts/prepare-vm.sh
@@ -86,6 +86,7 @@ User=${USER}
 Group=${USER}
 ExecStart=${NOVNC_PATH}/utils/launch.sh --listen 6080 --vnc localhost:5901
 RemainAfterExit=yes
+Nice=-10
 
 [Install]
 WantedBy=multi-user.target
@@ -106,13 +107,13 @@ sudo tee "${SYSTEMD_PATH}/${PNE_SERVICE}" > /dev/null <<EOT
 [Unit]
 Description=Prometheus Node Exporter
 After=network.target
- 
+
 [Service]
 Type=simple
 User=pne_user
 Group=pne_user
 ExecStart=/usr/local/bin/node_exporter
- 
+
 [Install]
 WantedBy=multi-user.target
 EOT
@@ -131,10 +132,10 @@ sudo chmod +x $PERSISTENCE_SCRIPT
 sudo tee "${SYSTEMD_PATH}/${PERS_SERVICE}" > /dev/null <<EOT
 [Unit]
 Description=Change permissions to the persistent disk
- 
+
 [Service]
 ExecStart=${PERSISTENCE_SCRIPT}
- 
+
 [Install]
 WantedBy=multi-user.target
 EOT


### PR DESCRIPTION
This PR changes the `prepare-vm.sh` script to assign a higher priority to the NoVNC processes, in order to increase the responsiveness of the system when under high load. 
Tested with two cores at 100% (`while true: do n=$((n+1)); done`), the system remained responsive. 
The same modification cannot be applied to the vncserver, otherwise all user process are launched with that priority. 
References #118 