### PR TITLE
setup_courses.py - Remove pvc from labtemplate

### DIFF
--- a/cluster_config/script/k8s_templates/labtemplate_template.yaml
+++ b/cluster_config/script/k8s_templates/labtemplate_template.yaml
@@ -28,9 +28,6 @@ spec:
           - disk:
               bus: virtio
             name: cloudinitdisk
-          - disk:
-              bus: virtio
-            name: pvcdisk
         memory:
           guest: "{{ memory }}G"
         resources:
@@ -50,6 +47,3 @@ spec:
           secretRef:
             name: {{ course_code }}-lab{{ lab_name }}
         name: cloudinitdisk
-      - name: pvcdisk
-        persistentVolumeClaim:
-          claimName: xxx


### PR DESCRIPTION
This PR remove the pvc associated with *MyDrive* from the labtemplate template used by the scripts