### PR TITLE
setup_courses.py - Relax the VMs limit

### DIFF
--- a/cluster_config/script/k8s_templates/resourcequota_template.yaml
+++ b/cluster_config/script/k8s_templates/resourcequota_template.yaml
@@ -9,4 +9,4 @@ spec:
     limits.memory: 30Gi
     requests.cpu: "20"
     requests.memory: 30Gi
-    count/labinstances.instance.crown.team.com: "1"
+    count/labinstances.instance.crown.team.com: "5"


### PR DESCRIPTION
This PR increases to 5 the number of VMs that can be created by each tenant