### PR TITLE
Fixing ingresses to enable website and frontend

### DIFF
--- a/webservice/kubernetes/ingress-content.yaml
+++ b/webservice/kubernetes/ingress-content.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  namespace: frontend
+spec:
+  rules:
+    - host: crownlabs.polito.it
+      http:
+        paths:
+          - backend:
+              serviceName: frontend
+              servicePort: 80
+            path: /config.js
+          - backend:
+              serviceName: frontend
+              servicePort: 80
+            path: /bundle.js
+          - backend:
+              serviceName: frontend
+              servicePort: 80
+            path: /c0995264e0b7a6a048e3e8cdc92c4f7b.png
+          - backend:
+              serviceName: frontend
+              servicePort: 80
+            path: /183b14c6350152eea9a170e2607e8c44.png
+  tls:
+    - hosts:
+        - crownlabs.polito.it
+      secretName: frontend-cert

--- a/webservice/kubernetes/kustomization.yaml
+++ b/webservice/kubernetes/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - deployment.yaml
 - svc.yaml
 - ns.yaml
-- ingress.yaml
+- ingress-content.yaml
 - ingress-callback.yaml
 - configmap.yaml
 


### PR DESCRIPTION
This PR adds ingress entries to make frontend application reachable, in presence of a website on "/". This is TEMPORARILY done by explicitly list endpoints and files. 