### PR TITLE
Remove ClusterRoleBinding from Kustomization.yaml

### DIFF
--- a/operators/labInstance-operator/k8s/operator/kustomization.yaml
+++ b/operators/labInstance-operator/k8s/operator/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- clusterrole-binding.yaml
 - deployment.yaml


### PR DESCRIPTION
I think it is better remove the ClusterRoleBinding from the Kustomization, and let assign the privileges manually.