### PR TITLE
Added .gitattributes to remove library from stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+webservice/k8s_library/**/* linguist-vendored


### PR DESCRIPTION
This PR should remove library code in k8s_library from statistics

| before                | after                 |
| --------------------- | --------------------- |
| **93.14%** Typescript | **60.83%** Go         |
| **4.10%** Go          | **13.60%** JavaScript |
| **1.04%** JavaScript  | **9.67%** CSS         |
| **0.65%** CSS         | **8.57%** Shell       |
| **0.58%** Shell       | **5.14%** Python      |
| **0.35%** Python      | **1.15%** Makefile    |
| **0.08%** Makefile    | **0.59%** FreeMarker  |
| **0.04%** FreeMarker  | **0.45%** Dockerfile  |
| **0.03%** Dockerfile  |

I tried it by installing locally [github linguist](https://github.com/github/linguist#overrides)
