### PR TITLE
Add Configmap to operator deployment

### DIFF
--- a/operators/labInstance-operator/k8s/operator/configmap.yaml
+++ b/operators/labInstance-operator/k8s/operator/configmap.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: operator-config
+  namespace: lab-operator
+data:
+  webdavSecretName: nextcloud-credentials
+  nextcloudBaseUrl: https://crownlabs.polito.it/cloud
+  oidcClientSecret: xxx-xxx-xxx-xxx
+  websiteBaseUrl: crownlabs.polito.it
+  whitelistLabels: production=true

--- a/operators/labInstance-operator/k8s/operator/deployment.yaml
+++ b/operators/labInstance-operator/k8s/operator/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           valueFrom:
            configMapKeyRef:
             name: operator-config
-            key: WebdavSecretName
+            key: webdavSecretName
         - name: OIDC_CLIENT_SECRET
           valueFrom:
             configMapKeyRef:

--- a/operators/labInstance-operator/k8s/operator/kustomization.yaml
+++ b/operators/labInstance-operator/k8s/operator/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
+- configmap.yaml


### PR DESCRIPTION
Add configmap to kustomization.yaml to complete the labOperator deployment