### PR TITLE
operator - cloud-init - quote variables

### DIFF
--- a/operators/labInstance-operator/pkg/creation.go
+++ b/operators/labInstance-operator/pkg/creation.go
@@ -49,9 +49,9 @@ network:
   id0:
     dhcp4: true
 mounts:
-  - [` + nextCloudBaseUrl + `/remote.php/dav/files/` + nextUsername + `, /media/MyDrive, davfs, "_netdev,auto,user,rw,uid=1000,gid=1000","0","0" ]
+  - [ "` + nextCloudBaseUrl + `/remote.php/dav/files/` + nextUsername + `", "/media/MyDrive", "davfs", "_netdev,auto,user,rw,uid=1000,gid=1000","0","0" ]
 write_files:
--   content: |
+  - content: |
       /media/MyDrive ` + nextUsername + " " + nextPassword + `
     path: /etc/davfs2/secrets
     permissions: '0600'


### PR DESCRIPTION
This PR adds the quotes around the entries of the mounts section in the cloud-init file, to prevent errors during the parsing. It should fix the problem described in #214.