### PR TITLE
setup-crownlabs-vm - optimizations

### DIFF
--- a/provisioning/virtual-machines/scripts/prepare-vm.sh
+++ b/provisioning/virtual-machines/scripts/prepare-vm.sh
@@ -65,6 +65,7 @@ After=syslog.target network.target
 Type=forking
 User=${USER}
 Group=${USER}
+WorkingDirectory=${HOME}
 ExecStartPre=/bin/sh -c '/usr/bin/vncserver -kill %i > /dev/null 2>&1 || :'
 ExecStart=/usr/bin/vncserver %i -SecurityTypes None -localhost
 ExecStop=/usr/bin/vncserver -kill %i
@@ -87,10 +88,10 @@ Description=NoVNC service
 After=network.target
 
 [Service]
-Type=oneshot
+Type=simple
 User=${USER}
 Group=${USER}
-ExecStart=${NOVNC_PATH}/utils/launch.sh --listen 6080 --vnc localhost:5901
+ExecStart=${NOVNC_PATH}/utils/websockify/run --web ${NOVNC_PATH} 6080 localhost:5901
 RemainAfterExit=yes
 Nice=-10
 
@@ -135,3 +136,8 @@ sudo systemctl daemon-reload
 sudo systemctl enable $PNE_SERVICE
 sudo systemctl enable $NOVNC_SERVICE
 sudo systemctl enable $VNC_SERVICE
+
+# Since the graphical desktop is accessed through VNC,
+# it is useless to start the default xfce session that is not
+# "seen" by anybody, but consumes memory (about 200M)
+sudo systemctl set-default multi-user.target

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/handlers/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: Run update-grub
+  command: update-grub

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/tasks/main.yml
@@ -166,3 +166,27 @@
     name: "{{ nodeexporter_service_name }}"
     enabled: yes
     daemon_reload: yes
+
+
+# Since the graphical desktop is accessed through VNC,
+# it is useless to start the default xfce session that is not
+# "seen" by anybody, but consumes memory (about 200M)
+- name: Disable the graphical target
+  # This operation cannot be performed with the systemd module
+  # https://github.com/ansible/ansible/issues/65785
+  command:
+    cmd: systemctl set-default multi-user.target
+
+- name: Disable the ubuntu splash screen
+  lineinfile:
+    state: present
+    dest: /etc/default/grub
+    backrefs: yes
+    regexp: '^(GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*?)[ ]?splash(.*)$'
+    line: '\1\2'
+  notify: Run update-grub
+
+- name: Uninstall the VirtualBox Guest Additions
+  command:
+    cmd: /opt/VBoxGuestAdditions-*/uninstall.sh
+    removes: /opt/VBoxGuestAdditions-*/uninstall.sh

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/templates/novnc.service
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/templates/novnc.service
@@ -3,10 +3,10 @@ Description=NoVNC service
 After=network.target
 
 [Service]
-Type=oneshot
+Type=simple
 User={{ ansible_user }}
 Group={{ ansible_user }}
-ExecStart={{ novnc_path }}/utils/launch.sh --listen {{ novnc_port }} --vnc localhost:5901
+ExecStart={{ novnc_websockify_path }}/run --web {{ novnc_path }} {{ novnc_port }} localhost:5901
 RemainAfterExit=yes
 Nice=-10
 

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/templates/vncserver.service
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/templates/vncserver.service
@@ -6,6 +6,7 @@ After=syslog.target network.target
 Type=forking
 User={{ ansible_user }}
 Group={{ ansible_user }}
+WorkingDirectory=/home/{{ ansible_user }}
 ExecStartPre=/bin/sh -c '/usr/bin/vncserver -kill %i > /dev/null 2>&1 || :'
 ExecStart=/usr/bin/vncserver %i -SecurityTypes None -localhost
 ExecStop=/usr/bin/vncserver -kill %i


### PR DESCRIPTION
This PR introduces different optimizations during the configuration of the CrownLabs VMs:
- [x] Improves the NoVNC service file for better management with systemctl (e.g. stop, restart).
- [x] Configures the vncserver working directory to the user's home (i.e. the terminal starts in `~` instead of `/`)
- [x] Configures the VM to boot in text mode. Indeed, a second graphical session is started by vncserver (i.e. the one used by the final users), while the *original* one is not seen by anybody. Yet, it increases the RAM usage of an idle VM by almost 200M (350M -> 520M), as well as increases the CPU usage and the boot time.
- [x] Disables the ubuntu splash screen. As above, it is never seen by the users but consumes resources during the boot.
- [x] Removes the vbox guest additions (if present), since they are useless in KVM (apparently, it saves 20-25 seconds at boot time).

All optimizations are available when configuring a VM with the `setup-crownlabs-vm` script, while some have been backported to `prepare-vm.sh`.