### PR TITLE
network-multitool docker image for gns3

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/polycube/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/polycube/tasks/main.yml
@@ -140,17 +140,6 @@
     chdir: "{{ polycube_build }}"
     target: install
 
-
-- name: Install iperf
-  apt:
-    name: "{{ to_install }}"
-    state: present
-  vars:
-    to_install:
-    - iperf
-    - iperf3
-
-
 - name: Install hping3p dependencies
   apt:
     name: "{{ hping3p_dependencies }}"

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/polycube/vars/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/polycube/vars/main.yml
@@ -15,9 +15,12 @@ polycube_dependencies:
 - golang-go
 - jq
 - kmod
+- iperf
+- iperf3
 - libclang-6.0-dev
 - libelf-dev
 - libllvm6.0
+- libpcap-dev
 - libssl-dev
 - libtool
 - libyang-dev


### PR DESCRIPTION
- fixed polycube dependencies
- added docker image to be used within gns3 as end devices