### PR TITLE
added docker image to be used as end device on gns3

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/docker/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/docker/tasks/main.yml
@@ -29,6 +29,7 @@
     - docker-ce
     - docker-ce-cli
     - containerd.io
+    - python3-docker
 
 - name: Install Docker-compose
   get_url:

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/files/README_GNS3
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/files/README_GNS3
@@ -19,7 +19,15 @@ Operations to perform in order to complete the setup of GNS3
 3) Configure the Xfce4 terminal in GNS3
    - Edit -> Preferences -> General -> Console applications
    - Click Edit and select the Xfce4 Terminal
-4) Delete this README file and the Cisco IOS image from the Desktop
+4) Add the network-multitool docker image to the list of end devices
+   - Edit -> Preferences -> Docker containers
+   - Click New and select Existing image -> praqma/network-multitool:tatest (**)
+   - Click next and leave the other settings with default values
+   - Under "Start Command:" insert "sh", then complete the procedure close the window
+   - Ensure that the network-multitool item is available in under end devices
+5) Delete this README file and the Cisco IOS image from the Desktop
 
 (*) Remember that the NM-16ESW module has limited switching features,
     e.g., no Rapid STP: http://forum.gns3.net/topic6289.html
+
+(**) You may need to logout/login (or reboot) to have your user in the docker group

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/tasks/main.yml
@@ -65,6 +65,11 @@
     owner: "{{ ansible_user }}"
     group: "{{ ansible_user }}"
     mode: '0644'
+    
+- name: Pull the network-multitool docker image
+  docker_image:
+    name: praqma/network-multitool
+    source: pull
 
 - name: Copy the README file
   copy:


### PR DESCRIPTION
- the image is pulled during the playbook execution
- instructions for the post-setup are provided to include the image as end device in gns3