### PR TITLE
setup-crownlabs-vms - Move GNS3 README to CrownOps

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/files/README_GNS3
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/files/README_GNS3
@@ -1,33 +1,10 @@
-Operations to perform in order to complete the setup of GNS3
+In order to complete the setup of GNS3, it is necessary to manually perform
+some additional operations. Most importantly, you have to own a valid Cisco
+IOS image, that needs to be imported in GNS3 and made available through the
+creation of a new template.
 
-0) Add GNS3 to the list of favorites (if desired)
-   - Ctrl+Esc -> Education -> GNS3 -> Right click -> Add to favorites
-1) Start GNS3
-   - Run appliances on my local computer
-   - Check "Don't show this again"
-2) Create a new template for the Cisco 2691 router
-   - File -> New Template -> Manually create a new template
-   - Dynamips -> IOS Router -> New
-   - Select the IOS image from the desktop and decompress it
-   - Name: Cisco c2691
-   - Default RAM: 192MiB
-   - Network Adapters -- Slot 0: GT96100-FE, Slot 1: NM-16ESW (*)
-   - Idle-PC: click on Idle-PC finder
-   - Edit the template -> Memories and disks
-   - Set NVRAM: 256KB
-   - Set PCMCIA disk0: 4MB (otherwise the VLAN database does not work)
-3) Configure the Xfce4 terminal in GNS3
-   - Edit -> Preferences -> General -> Console applications
-   - Click Edit and select the Xfce4 Terminal
-4) Add the network-multitool docker image to the list of end devices
-   - Edit -> Preferences -> Docker containers
-   - Click New and select Existing image -> praqma/network-multitool:tatest (**)
-   - Click next and leave the other settings with default values
-   - Under "Start Command:" insert "sh", then complete the procedure close the window
-   - Ensure that the network-multitool item is available in under end devices
-5) Delete this README file and the Cisco IOS image from the Desktop
+The complete instructions for the setup of GNS3 as used for the networking
+laboratories at Politecnico di Torino are available on a private GitHub repository:
+https://github.com/netgroup-polito/CrownOps/tree/master/crownlabs-vms/setup-gns3.md
 
-(*) Remember that the NM-16ESW module has limited switching features,
-    e.g., no Rapid STP: http://forum.gns3.net/topic6289.html
-
-(**) You may need to logout/login (or reboot) to have your user in the docker group
+Please, remember to delete this file before exporting the virtual machine.

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/gns3/tasks/main.yml
@@ -58,14 +58,6 @@
     regexp: '^After=network.target'
     line: 'After=network-online.target'
 
-- name: Download the Cisco IOS image
-  get_url:
-    url: https://owncloud.ipv6.polito.it:8080/index.php/s/T4Wj9E5jOuAzCJK/download
-    dest: /home/{{ ansible_user }}/Desktop/c2691-advipservicesk9-mz.124-25c.bin
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0644'
-    
 - name: Pull the network-multitool docker image
   docker_image:
     name: praqma/network-multitool


### PR DESCRIPTION
This PR replaces the complete README file describing the manual operations to perform to complete the setup of GNS3 with a more generic one. The complete README is moved to CrownOps, since it contains private information.