### PR TITLE
Add auto-labelling for automatic triage of PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+sig-api:
+  - operators/**/*
+
+sig-ui:
+  - webservice/**/*
+
+sig-operations:
+  - infrastructure/**/*
+  - provisioning/courses/*
+
+sig-user-environment:
+  - provisioning/virtual-machines/**/*
+
+sig-devops:
+  - .github/**/*
+
+sig-community:
+  - AUTHORS
+  - ./**/*/README.md
+  - LICENSE
+  - README.md
+  - documentation/**/*

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.CI_TOKEN }}"


### PR DESCRIPTION
This PR adds a new pipeline to auto-add labels in new PRs. When a file is modified in a specific path, a corresponding label is added to contextualize the new contribution.