### PR TITLE
setup-crownlabs-vm - Bug fixing

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/crownlabs/tasks/main.yml
@@ -229,6 +229,8 @@
     masked: yes
   with_items: >
     {{ unnecessary_services }}
+  register: result
+  failed_when: result is failed and not 'Could not find the requested service' in result.msg
 
 - name: Delete the NetworkManager configuration from netplan
   file:

--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/xubuntu-pre/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/xubuntu-pre/tasks/main.yml
@@ -5,6 +5,8 @@
   systemd:
     name: unattended-upgrades
     state: stopped
+    enabled: no
+    masked: yes
   register: result
   failed_when: result is failed and not 'Could not find the requested service' in result.msg
 
@@ -32,6 +34,10 @@
     autoremove: yes
     purge: yes
 
+- name: Upgrade all packages
+  apt:
+    upgrade: yes
+
 # Not the best ansible way to solve this problem
 # but it seems to achieve the intended purpose
 - name: Get old kernel packages
@@ -53,10 +59,6 @@
     autoremove: yes
     purge: yes
   when: kernel_packages.stdout_lines
-
-- name: Upgrade all packages
-  apt:
-    upgrade: yes
 
 - name: Make sure the Desktop directory does exist
   file:


### PR DESCRIPTION
# Description

This PR introduces three small bug fixes to the setup-crownlabs-vm ansible scripts:
- Prevent service disabling from failing when the services do not exist (e.g. in xubuntu 18.04)
- Mask the unattended-upgrades service to prevent it from starting
- Move the deletion of old kernels after packages upgrade 

# How Has This Been Tested?

This PR has been tested by configuring a new VM with xubuntu 18.04 (with the `xubuntu-base-crownlabs-playbook.yml` playbook. The configuration completed correctly
