### PR TITLE
setup-crownlabs-vm - Bug fixing

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm/ansible/xubuntu-pre/tasks/main.yml
+++ b/provisioning/virtual-machines/setup-crownlabs-vm/ansible/xubuntu-pre/tasks/main.yml
@@ -36,19 +36,19 @@
 
 - name: Upgrade all packages
   apt:
-    upgrade: yes
+    upgrade: 'yes'
 
 # Not the best ansible way to solve this problem
 # but it seems to achieve the intended purpose
 - name: Get old kernel packages
   shell: |
     dpkg --list | \
-      egrep -i "linux-image" | \
-      awk '/ii/{ print $2 }' | \
-      sed 's/linux-image-//' | \
-      egrep '[0-9]\.'        | \
-      sort --version-sort    | \
-      head -n -1             | \
+      egrep -i "linux-image"          | \
+      awk '/ii/{ print $2 }'          | \
+      sed 's/linux-image-//'          | \
+      egrep '^[0-9]+\.[0-9]+\.[0-9]+' | \
+      sort --version-sort             | \
+      head -n -1                      | \
       sed 's/^/linux-*-/'
   register: kernel_packages
 


### PR DESCRIPTION
# Description

This PR introduces two small bug fixes to the setup-crownlabs-vm ansible scripts:
- Enhance a regex to prevent deleting all kernel packages
- Quote a variable to prevent an ansible warning

# How Has This Been Tested?

This PR has been tested by configuring a new VM with xubuntu 18.04 (with the xubuntu-omnetpp-crownlabs-playbook.yml playbook). The configuration completed correctly
