### PR TITLE
setup-courses - Add labtemplate admin rolebinding

### DIFF
--- a/provisioning/courses/setup-courses.py
+++ b/provisioning/courses/setup-courses.py
@@ -241,6 +241,9 @@ class Course:
         k8s_templates["rolebinding-course"].apply_template(
             namespace_name=self.namespace,
             course_group=Course.get_group_name(self.course_code))
+        k8s_templates["rolebinding-courseadmin"].apply_template(
+            namespace_name=self.namespace,
+            course_group_admin=Course.get_group_name_admin(self.course_code))
         k8s_templates["clusterrolebinding-courseadmin"].apply_template(
             course_group_admin=Course.get_group_name_admin(self.course_code))
 
@@ -454,6 +457,7 @@ if __name__ == "__main__":
             "clusterrolebinding-courseadmin": KubernetesTemplateHandler("clusterrolebinding-courseadmin.yaml.tmpl", "templates/"),
             "rolebinding-tenant": KubernetesTemplateHandler("rolebindingtenant.yaml.tmpl", "templates/"),
             "rolebinding-course": KubernetesTemplateHandler("rolebindingcourse.yaml.tmpl", "templates/"),
+            "rolebinding-courseadmin": KubernetesTemplateHandler("rolebindingcourseadmin.yaml.tmpl", "templates/"),
             "resourcequota": KubernetesTemplateHandler("resourcequota.yaml.tmpl", "templates/"),
             "nextcloudcredentials": KubernetesTemplateHandler("nextcloudcredentials.yaml.tmpl", "templates/"),
             "labtemplate": KubernetesTemplateHandler("labtemplate.yaml.tmpl", "templates/"),

--- a/provisioning/courses/templates/rolebindingcourseadmin.yaml.tmpl
+++ b/provisioning/courses/templates/rolebindingcourseadmin.yaml.tmpl
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manage-labs
+  namespace: {{ namespace_name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: labtemplate-consumer-course-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: kubernetes:{{ course_group_admin }}


### PR DESCRIPTION
# Description

This PR introduces the creation of a rolebinding to allow course administrators to create, edit and delete labtemplates of their courses.

This modification is required to enable #221 

# How Has This Been Tested?

Executing the `setup-course` to create the rolebinding for the already existing courses