### PR TITLE
Operator - Lower the VM status update delays

### DIFF
--- a/operators/labInstance-operator/controllers/labinstance_controller.go
+++ b/operators/labInstance-operator/controllers/labinstance_controller.go
@@ -262,7 +262,7 @@ func getVmiStatus(r *LabInstanceReconciler, ctx context.Context, log logr.Logger
 				}
 			}
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	// when the vm status is Running, it is still not available for some seconds
@@ -285,7 +285,7 @@ func getVmiStatus(r *LabInstanceReconciler, ctx context.Context, log logr.Logger
 				break
 			}
 		}
-		time.Sleep(5 * time.Second)
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	return


### PR DESCRIPTION
# Description

This small PR lowers the update times of the operator concerning the VM status update process, for benchmarking purposes.

# How Has This Been Tested?

Untested :(
