### PR TITLE
Fix issue #257

### DIFF
--- a/webservice/src/components/LabTemplatesList.jsx
+++ b/webservice/src/components/LabTemplatesList.jsx
@@ -55,8 +55,11 @@ export default function LabTemplatesList(props) {
                 selected={selectedIndex === finalIndex}
                 disableRipple={props.isAdmin}
                 onClick={() => {
-                  setSelectedIndex(finalIndex);
-                  props.func(courseLab, courseName);
+                  if (!props.isAdmin) {
+                    console.log('clicked');
+                    setSelectedIndex(finalIndex);
+                    props.func(courseLab, courseName);
+                  }
                 }}
               >
                 <Tooltip title="Select it">


### PR DESCRIPTION
When selecting a LabInstance sometimes, due to wrong indexes assigned to those rows, multiple laboratories are selected the same time. This happens when you are a Professor, meaning that there are both LabInstances as a normal user and as a privileged one.

Fixes #257