### PR TITLE
infrastructure -- add requests and limits

### DIFF
--- a/infrastructure/docker-registry/docker-registry-configuration.yaml
+++ b/infrastructure/docker-registry/docker-registry-configuration.yaml
@@ -36,17 +36,17 @@ ingress:
   tls:
   - hosts:
     - registry.crown-labs.ipv6.polito.it
-resources: {}
+resources:
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little
 # resources, such as Minikube. If you do want to specify resources, uncomment the following
 # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-# limits:
-#  cpu: 100m
-#  memory: 128Mi
-# requests:
-#  cpu: 100m
-#  memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 4Gi
+  requests:
+    cpu: 100m
+    memory: 2Gi
 persistence:
   accessMode: 'ReadWriteOnce'
   enabled: true

--- a/infrastructure/external-dns-synchronization/external-dns.yaml
+++ b/infrastructure/external-dns-synchronization/external-dns.yaml
@@ -81,3 +81,10 @@ spec:
         - --source=ingress
         - --source=service
         - --txt-owner-id=k8s-ladispe-externaldns
+        resources:
+          requests:
+            cpu: "10m"
+            memory: 50Mi
+          limits:
+            cpu: "100m"
+            memory: 150Mi

--- a/infrastructure/ingress-controller/manifests/custom-error-pages.yaml
+++ b/infrastructure/ingress-controller/manifests/custom-error-pages.yaml
@@ -29,6 +29,13 @@ spec:
           value: "/error-page"
         - name: ERROR_STATIC_URI
           value: "https://crownlabs.polito.it/error-page"
+        resources:
+          requests:
+            cpu: "10m"
+            memory: 25Mi
+          limits:
+            cpu: "50m"
+            memory: 50Mi
 ---
 apiVersion: v1
 kind: Service

--- a/infrastructure/ingress-controller/manifests/ingress-controller-external.yaml
+++ b/infrastructure/ingress-controller/manifests/ingress-controller-external.yaml
@@ -260,6 +260,13 @@ spec:
         - --annotations-prefix=nginx.ingress.kubernetes.io
         - --default-backend-service=ingress-nginx/nginx-custom-error-pages
         - --enable-ssl-passthrough
+        resources:
+          requests:
+            cpu: 500m
+            memory: 4Gi
+          limits:
+            cpu: 2000m
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:
@@ -309,18 +316,3 @@ spec:
             exec:
               command:
               - /wait-shutdown
----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: ingress-nginx
-  namespace: ingress-nginx
-  labels:
-    app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
-spec:
-  limits:
-  - min:
-      memory: 90Mi
-      cpu: 100m
-    type: Container

--- a/infrastructure/ingress-controller/manifests/ingress-controller-internal.yaml
+++ b/infrastructure/ingress-controller/manifests/ingress-controller-internal.yaml
@@ -229,6 +229,13 @@ spec:
         - --annotations-prefix=nginx.ingress.kubernetes.io
         - --ingress-class=nginx-internal
         - --enable-ssl-passthrough
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: 1000m
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:
@@ -278,18 +285,3 @@ spec:
             exec:
               command:
               - /wait-shutdown
----
-apiVersion: v1
-kind: LimitRange
-metadata:
-  name: ingress-nginx
-  namespace: ingress-nginx-internal
-  labels:
-    app.kubernetes.io/name: ingress-nginx-internal
-    app.kubernetes.io/part-of: ingress-nginx-internal
-spec:
-  limits:
-  - min:
-      memory: 90Mi
-      cpu: 100m
-    type: Container

--- a/infrastructure/monitoring/manifests/monitoring-oauth2-proxy-deployment.yaml
+++ b/infrastructure/monitoring/manifests/monitoring-oauth2-proxy-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: monitoring-oauth2-proxy
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: monitoring-oauth2-proxy
@@ -15,18 +15,6 @@ spec:
       labels:
         app: monitoring-oauth2-proxy
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - ingress-nginx
-              topologyKey: kubernetes.io/hostname
-            weight: 100
       containers:
       - name: monitoring-oauth2-proxy
         image: crownlabs/oauth2_proxy:v5.1.0-crown
@@ -54,3 +42,10 @@ spec:
         # Restrictions
         - --keycloak-group=/monitoring
         - --email-domain=*
+        resources:
+          requests:
+            cpu: "10m"
+            memory: 25Mi
+          limits:
+            cpu: "50m"
+            memory: 100Mi

--- a/infrastructure/monitoring/manifests/node-exporter-daemonset.yaml
+++ b/infrastructure/monitoring/manifests/node-exporter-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         name: node-exporter
         resources:
           limits:
-            cpu: 250m
+            cpu: 500m
             memory: 180Mi
           requests:
             cpu: 102m

--- a/operators/labInstance-operator/pkg/creation.go
+++ b/operators/labInstance-operator/pkg/creation.go
@@ -215,12 +215,12 @@ func CreateOauth2Deployment(name string, namespace string, urlUUID string, clien
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
-									corev1.ResourceMemory: resource.MustParse("512Mi"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
-									corev1.ResourceMemory: resource.MustParse("256Mi"),
+									corev1.ResourceCPU:    resource.MustParse("10m"),
+									corev1.ResourceMemory: resource.MustParse("25Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
# Description

This PR adds the definition of resources specifications (requests and limits) to some infrastructural components (most notably, the ingress controller and the docker registry). It also lower the resources assigned to the oauth2 proxies in front of the VMs. Thank to this modifications, the results of the benchmarks should be more consistent (now memory requests are lower than memory usage).

# How Has This Been Tested?

Deploying the changes in the cluster
