### PR TITLE
infrastructure -- update deprecated ingress API group

### DIFF
--- a/infrastructure/docker-registry/docker-registry-internal-ingress.yaml
+++ b/infrastructure/docker-registry/docker-registry-internal-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: docker-registry-internal

--- a/infrastructure/file-sharing/manifests/nextcloud-ingress.yaml
+++ b/infrastructure/file-sharing/manifests/nextcloud-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/identity-provider/manifests/keycloak-ingress.yaml
+++ b/infrastructure/identity-provider/manifests/keycloak-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/ingress-controller/api-server/ingress-apiserver.yaml
+++ b/infrastructure/ingress-controller/api-server/ingress-apiserver.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ingress-apiserver

--- a/infrastructure/ingress-controller/manifests/custom-error-pages.yaml
+++ b/infrastructure/ingress-controller/manifests/custom-error-pages.yaml
@@ -54,7 +54,7 @@ spec:
     targetPort: 8080
     name: http
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/monitoring/manifests/alertmanager-ingress-oauth2.yaml
+++ b/infrastructure/monitoring/manifests/alertmanager-ingress-oauth2.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/monitoring/manifests/alertmanager-ingress.yaml
+++ b/infrastructure/monitoring/manifests/alertmanager-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/monitoring/manifests/grafana-ingress.yaml
+++ b/infrastructure/monitoring/manifests/grafana-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/monitoring/manifests/prometheus-ingress-oauth2.yaml
+++ b/infrastructure/monitoring/manifests/prometheus-ingress-oauth2.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/infrastructure/monitoring/manifests/prometheus-ingress.yaml
+++ b/infrastructure/monitoring/manifests/prometheus-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
# Description

This PR updates the deprecated ingress API group for the different resources deployed in the cluster, as suggested by the [popeye](https://github.com/derailed/popeye) report.

The same operation should also be performed for the ingresses created by the operator. @palexster WDYT?

# How Has This Been Tested?

The resources have been updated on the CrownLabs cluster.
