### PR TITLE
Removed useless css and uncoupled css and jss

### DIFF
--- a/webservice/src/App.css
+++ b/webservice/src/App.css
@@ -1,73 +1,16 @@
-body {
-  margin: 0;
+html {
   height: 100%;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  width: 100%;
+}
+
+body {
+  height: 100%;
+  width: 100%;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-#main {
-  width: 100%;
-  height: 100%;
-}
-
-html {
-  height: 100%;
-  margin: 0;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
-}
-
-.headerstyle {
-  background-color: transparent;
-  border: none;
-  width: 100%;
-}
-
-.cover {
-  left: 0;
-  right: 0;
-  bottom: 0;
-  top: 0;
-  position: absolute;
-  overflow-y: auto;
-}
-
-.footerstyle {
-  height: 70px;
-  background-color: #032364;
-  font-size: 1.2rem;
-}
-
-.textareastyle {
-  color: white;
-  border-color: #2e2e2e;
-  background-color: #2e2e2e;
-  width: 100%;
-  height: 150px;
-  resize: none;
-  border-radius: 10px;
-  font-size: 15px;
-}
-
-.nav_new {
-  max-width: 1920px;
-  flex: 1;
-}
-
-.navText {
-  font-family: 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
-}
-
-.rotating {
-  animation: rotate 1.5s ease-in-out infinite;
-}
-
+/*definition for rotate animation (used by hourglass icon)*/
 @keyframes rotate {
   from {
     transform: rotateZ(0deg);

--- a/webservice/src/components/LabInstancesList.jsx
+++ b/webservice/src/components/LabInstancesList.jsx
@@ -38,6 +38,9 @@ const useStyles = makeStyles(theme => ({
     position: 'fixed',
     bottom: '0%',
     left: '10%'
+  },
+  rotating: {
+    animation: 'rotate 1.5s ease-in-out infinite'
   }
 }));
 
@@ -108,7 +111,10 @@ export default function LabInstancesList(props) {
             {status === 0 ? (
               <Tooltip title="Loading VM">
                 <IconButton style={{ color: 'orange' }}>
-                  <HourglassEmptyIcon className="rotating" fontSize="large" />
+                  <HourglassEmptyIcon
+                    className={classes.rotating}
+                    fontSize="large"
+                  />
                 </IconButton>
               </Tooltip>
             ) : null}


### PR DESCRIPTION
# Description

This PR removes useless CSS. Even though the target of the refactoring was to completely remove these files I believe it is better to have a dedicated CSS file for those little things that require a lot of effort to implement with js instead of a few lines with CSS. In the remain definitions for the `<html>` tag and `<body>` tag and the rotating animation description. Another thing that could be added if needed is the CSS for the `*` tag.

#226 

# How Has This Been Tested?

This has been tested by comparing the UI before and after the change and checking if there were some inconsistencies