### PR TITLE
Improve action to lint check linting in webservice

### DIFF
--- a/.github/workflows/webservice_lint_check.yml
+++ b/.github/workflows/webservice_lint_check.yml
@@ -6,13 +6,23 @@ jobs:
     steps:
       - name: checkout code in action environment
         uses: actions/checkout@v2
+      - name: collect data about changes in path
+        uses: dorny/paths-filter@v2.0.0
+        id: filter
+        with:
+          filters: |
+            webservice:
+              - 'webservice/**/*'
       - name: setup nodeJS in action environment
+        if: steps.filter.outputs.webservice == 'true'
         uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: install only prettier package to reduce execution time
+      - name: install necessary packages for lint checking
+        if: steps.filter.outputs.webservice == 'true'
         working-directory: ./webservice
         run: npm run lint-setup
       - name: run npm script to check linting
+        if: steps.filter.outputs.webservice == 'true'
         working-directory: ./webservice
         run: npm run lint-check


### PR DESCRIPTION
# Description

This PR improves the action to check the linting of the /webservice folder only when there are changes in the /webservice folder

# How Has This Been Tested?

It has been tested by checking the actions history
[This](https://github.com/netgroup-polito/CrownLabs/runs/776420651?check_suite_focus=true) ran
[This](https://github.com/netgroup-polito/CrownLabs/runs/776427193?check_suite_focus=true) did not run 