### PR TITLE
webservice_lint_check - do not run on tag push

### DIFF
--- a/.github/workflows/webservice_lint_check.yml
+++ b/.github/workflows/webservice_lint_check.yml
@@ -1,5 +1,10 @@
 name: Check linting in webservice
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - '**'
 jobs:
   webservice_lint_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

This PR prevents the link checking to be triggered when a new tag is pushed, otherwise the filtering action fails since no differences are present. Additionally, it also avoids this action to be triggered when landing to master, being it of no use.

# How Has This Been Tested?

AFAIK, this cannot be tested in advance for tag pushes. Yet, the lint checking correctly ran when pushing this commit.