### PR TITLE
Update lint action to calculate diff on master

### DIFF
--- a/.github/workflows/webservice_lint_check.yml
+++ b/.github/workflows/webservice_lint_check.yml
@@ -4,7 +4,7 @@ on:
     branches-ignore:
       - master
     tags-ignore:
-      - '**'
+      - "**"
 jobs:
   webservice_lint_check:
     runs-on: ubuntu-latest
@@ -12,7 +12,7 @@ jobs:
       - name: checkout code in action environment
         uses: actions/checkout@v2
       - name: collect data about changes in path
-        uses: dorny/paths-filter@v2.0.0
+        uses: dorny/paths-filter@v2.2.0
         id: filter
         with:
           filters: |


### PR DESCRIPTION
# Description

This PR includes a little change to the linting action. We updated the version of the action to calculate the diff, now it calculates the diff with the base (master) branch, as discusses [here](https://github.com/dorny/paths-filter/issues/15)

# How Has This Been Tested?

[This commit](https://github.com/netgroup-polito/CrownLabs/runs/806391275?check_suite_focus=true) is the first in the new remote branch and it doesn't fail and doesn't run the linting since nothing has changed in the /webservice folder