### PR TITLE
Update the oauth2-proxy version

### DIFF
--- a/infrastructure/monitoring/manifests/monitoring-oauth2-proxy-deployment.yaml
+++ b/infrastructure/monitoring/manifests/monitoring-oauth2-proxy-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: monitoring-oauth2-proxy
-        image: crownlabs/oauth2_proxy:v5.1.0-crown
+        image: crownlabs/oauth2-proxy:v6.0.0-crown
         imagePullPolicy: Always
         ports:
         - containerPort: 4180
@@ -28,8 +28,9 @@ spec:
         - --reverse-proxy=true
         # Cookie configurations
         - --cookie-secret=<cookie-secret>
-        - --cookie-expire=1h
-        - --cookie-refresh=45m
+        - --cookie-expire=3h
+        # Omitting, since it does not work with the keycloak provider and conflicts with --sesion-cookie-minimal
+        # - --cookie-refresh=2h
         # Use Keycloak as provider
         - --provider=keycloak
         # Client configuration in Keycloak (ID and Secret)
@@ -42,6 +43,7 @@ spec:
         # Restrictions
         - --keycloak-group=/monitoring
         - --email-domain=*
+        - --session-cookie-minimal=true
         resources:
           requests:
             cpu: "10m"

--- a/operators/labInstance-operator/pkg/creation.go
+++ b/operators/labInstance-operator/pkg/creation.go
@@ -188,14 +188,13 @@ func CreateOauth2Deployment(name string, namespace string, urlUUID string, clien
 					Containers: []corev1.Container{
 						{
 							Name:  name,
-							Image: "crownlabs/oauth2_proxy:v5.1.0-crown",
+							Image: "crownlabs/oauth2-proxy:v6.0.0-crown",
 							Args: []string{
 								"--http-address=0.0.0.0:4180",
 								"--reverse-proxy=true",
 								"--skip-provider-button=true",
 								"--cookie-secret=" + cookieSecret,
 								"--cookie-expire=24h",
-								"--cookie-refresh=23h",
 								"--cookie-name=_oauth2_cookie_" + string([]rune(cookieUUID)[:6]),
 								"--provider=keycloak",
 								"--client-id=k8s",
@@ -206,6 +205,7 @@ func CreateOauth2Deployment(name string, namespace string, urlUUID string, clien
 								"--proxy-prefix=/" + urlUUID + "/oauth2",
 								"--cookie-path=/" + urlUUID,
 								"--email-domain=*",
+								"--session-cookie-minimal=true",
 							},
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
# Description

This PR updates the oauth2-proxy version in order to benefit from the latest features introduced to reduce the size of the generated cookies (i.e. compression and session-cookie-minimal to strip unused tokens). The docker image is still a custom build since the official version has not been released yet. 

Fixes #220, since cookies are now ~200 bytes and do not longer need to be split.

# How Has This Been Tested?

Updating the oauth2-proxy deployment and checking it continued to work correctly.
