### PR TITLE
Infrastructure: update versions

### DIFF
--- a/infrastructure/certificate-provisioning/README.md
+++ b/infrastructure/certificate-provisioning/README.md
@@ -49,7 +49,7 @@ In the following, both types of challenges are configured and made available. In
 
 1. Install the `CustomResourceDefinitions` and `cert-manager` itself:
     ```sh
-    $ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.yaml
+    $ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
     ```
 2. Create the `ServiceMonitor` resource, to make Prometheus aware of the metrics exposed by `cert-manager` (Grafana dashboard with ID 11001):
     ```sh

--- a/infrastructure/external-dns-synchronization/external-dns.yaml
+++ b/infrastructure/external-dns-synchronization/external-dns.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.2
+        image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
         args:
         - --domain-filter=crownlabs.polito.it
         - --exclude-domains=internal.crownlabs.polito.it
@@ -109,7 +109,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.2
+        image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.7.3
         args:
         - --domain-filter=internal.crownlabs.polito.it
         - --provider=rfc2136

--- a/infrastructure/ingress-controller/manifests/ingress-controller-external.yaml
+++ b/infrastructure/ingress-controller/manifests/ingress-controller-external.yaml
@@ -250,7 +250,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: nginx-ingress-controller
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0
+        image: eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller:v0.34.1@sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
         args:
         - /nginx-ingress-controller
         - --configmap=$(POD_NAMESPACE)/nginx-configuration

--- a/infrastructure/ingress-controller/manifests/ingress-controller-internal.yaml
+++ b/infrastructure/ingress-controller/manifests/ingress-controller-internal.yaml
@@ -219,7 +219,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: nginx-ingress-controller
-        image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0
+        image: eu.gcr.io/k8s-artifacts-prod/ingress-nginx/controller:v0.34.1@sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
         args:
         - /nginx-ingress-controller
         - --configmap=$(POD_NAMESPACE)/nginx-configuration

--- a/infrastructure/load-balancing/README.md
+++ b/infrastructure/load-balancing/README.md
@@ -5,7 +5,7 @@ MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, us
 Run the following command to install MetalLB:
 
 ```bash
-$ kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.3/manifests/metallb.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.9.3/manifests/metallb.yaml
 ```
 
 After this command, MetalLB remains in pending state waiting for a ConfigMap (see next step).


### PR DESCRIPTION
# Description

This PR updates the manifest of different infrastructural components to the latest version:

* cert-manager: bump to v0.16.1
* external-dns: bump to v0.7.3
* metallb: bump to v0.9.3
* nginx-ingress-controller: bump to v0.34.1

# How Has This Been Tested?

Applying the changes to the CrownLabs cluster and verifying the correct operation
