### PR TITLE
VM provisioning: improve the setup-crownlabs-vm script

### DIFF
--- a/provisioning/virtual-machines/README-VM-create.md
+++ b/provisioning/virtual-machines/README-VM-create.md
@@ -11,7 +11,6 @@ All the functionalities can be triggered executing the `setup-crownlabs-vms.sh` 
 - **curl**: used to download the guest operating system installer (e.g., the ISO image of the guest operating system).
 - **ssh**: required by ansible to interact with the VMs and configure the additional software required in the guest environment (e.g., additional applications).
 - **sshpass**: required by ansible to (silently) authenticate with the VM when establishing the SSH connection (to configure additional software packages).
-- **ssh-keygen**: used to remove any existing SSH associations and prevent the "Host key verification failed" message.
 - **virt-sparsify**: used to export the resulting VM images into the format required by CrownLabs, compacting the resulting disk image in order to save space (and decrease the boot time).
 - **docker**: used to export the resulting VM images into the format required by CrownLabs
 
@@ -70,7 +69,7 @@ The tools that are required by CrownLabs to work and are automatically installed
 3. Once the installation terminates and the OS completes the reboot, issue `./setup-crownlabs-vm.sh <vm-name> configure <ansible-playbook.yml>`, where the _playbook_ contains the instructions to configure and install the additional software packages you need to run in the VM.
 The script connects to the VM via SSH and runs the specified ansible playbook.
 For more detailed instructions about creating and customizing Ansible playbook, look at the [dedicated subsection](#ansible).
-  
+
 4. Log-in the VM and complete the remaining manual tasks as explained in the [README](ansible/xubuntu-post/files/README) file (copied to the Desktop).
 
 5. Shutdown the VM and issue `./setup-crownlabs-vm.sh <vm-name> export [ova|crownlabs]` to export the VM to an `.ova` file or make it available for the *CrownLabs*.

--- a/provisioning/virtual-machines/setup-crownlabs-vm.sh
+++ b/provisioning/virtual-machines/setup-crownlabs-vm.sh
@@ -98,7 +98,6 @@ check_available "docker"
 check_docker_privileges
 check_available "ssh"
 check_available "sshpass"
-check_available "ssh-keygen"
 check_available "virt-sparsify"
 echo
 
@@ -319,9 +318,6 @@ then
         { echo "VBoxManage command failed. Abort"; exit ${EXIT_FAILURE}; }
 fi
 
-# Remove the SSH association if already present
-ssh-keygen -f "$HOME/.ssh/known_hosts" -R "$SSHREM" > /dev/null 2> /dev/null
-
 # Create the inventory file
 INVENTORY_FILE="${BASEDIR}/${VMNAME}-inventory.yml"
 cat <<EOF > "${INVENTORY_FILE}"
@@ -334,7 +330,7 @@ all:
       ansible_user: $USERNAME
       ansible_ssh_pass: $PASSWORD
       ansible_become_pass: $PASSWORD
-      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
+      ansible_ssh_extra_args: '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
       ansible_python_interpreter: auto
 EOF
 


### PR DESCRIPTION
# Description

This PR improves the setup-crownlabs-vm script. Specifically, it:
* removes the dependency on ssh-keygen
* improves the error handling during the download of the iso files, verifying the correctness of the corresponding checksum value to prevent broken images.

# How Has This Been Tested?

Manually testing the script operations in different conditions
