### PR TITLE
VM provisioning: fix bug

### DIFF
--- a/provisioning/virtual-machines/setup-crownlabs-vm.sh
+++ b/provisioning/virtual-machines/setup-crownlabs-vm.sh
@@ -541,10 +541,11 @@ then
 fi
 
 # Check for the readability of the executable containing the Linux kernel (required by virt-sparsify)
-if [[ ! -r "/boot/vmlinuz-$(uname -r)" ]]
+KERNEL_IMAGE=$(find /boot -maxdepth 1 -iname 'vmlinuz-*' | tail -n 1)
+if [[ ! -r "${KERNEL_IMAGE}" ]]
 then
     echo "Unfortunately it seems you strumbled into this Ubuntu \"bug\" [https://bugs.launchpad.net/ubuntu/+source/linux/+bug/759725]"
-    echo "Please run 'sudo dpkg-statoverride --add --update root root 0644 /boot/vmlinuz-$(uname -r)' and then rerun this script."
+    echo "Please run 'sudo dpkg-statoverride --add --update root root 0644 ${KERNEL_IMAGE} and then rerun this script."
     exit ${EXIT_FAILURE}
 fi
 


### PR DESCRIPTION
# Description

This PR fixes a bug in the `setup-crownlabs-vm` script. Specifically, a check was not triggered correctly in case the host kernel had been updated and no reboot had been triggered yet. In turn, this caused a failure in reporting another bug and the corresponding solution.