### PR TITLE
Course provisioning: add kubectl check and update documentation

### DIFF
--- a/provisioning/courses/README.md
+++ b/provisioning/courses/README.md
@@ -30,6 +30,8 @@ To install those dependencies you can run the following command:
  pip3 install -r requirements.txt
 ````
 
+Additionally, this script requires `kubectl` to be available, and configured with the correct `kubeconfig` (bound to the `cluster-admin` role) to interact with the Kubernetes cluster hosting CrownLabs.
+
 ## Usage
 
 ```

--- a/provisioning/courses/csv-examples/laboratories.csv
+++ b/provisioning/courses/csv-examples/laboratories.csv
@@ -1,3 +1,3 @@
 Course (code),Lab number,Image,Cpu,Memory,Description
-swnet,1,your.registry.com/repo/image1:v1.1,2,4.5,The first laboratory
-swnet,2,your.registry.com/repo/image2:v0.1,5,8,The second laboratory
+swnet,1,registry.internal.crownlabs.polito.it/repo/image1:v1.1,2,4.5,The first laboratory
+swnet,2,registry.internal.crownlabs.polito.it/repo/image2:v0.1,5,8,The second laboratory


### PR DESCRIPTION
# Description

This PR adds a check to the course-provisioning script, to prevent it from being executed in case `kubectl` is not available or configured correctly. It also updates the documentation to specify this requirement.
