### PR TITLE
crownlabs-image-list: fix bug 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -54,12 +54,14 @@ further defined and clarified by project maintainers.
 
 ## Enforcement
 
+<!-- markdown-link-check-disable -->
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at crownlabs.polito@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
+<!-- markdown-link-check-enable -->
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/operators/crownlabs-image-list/update-crownlabs-image-list.py
+++ b/operators/crownlabs-image-list/update-crownlabs-image-list.py
@@ -75,7 +75,7 @@ class ImageListUpdater:
 
         logger.debug(f"Executing '{action.__name__}': next scheduled in {interval} seconds")
 
-        # Schedule the next executen
+        # Schedule the next execution
         self.scheduler.enter(
             delay=interval, priority=1, action=self._run_periodically,
             argument=(interval, action), kwargs=kwargs)
@@ -96,17 +96,20 @@ class ImageListUpdater:
 
         for image in images:
 
-            # Remove the "latest" tags
+            # Get the available tags
+            versions = image.get("tags") or []
+
+            # Remove the "latest" tag
             try:
-                image.get("tags", []).remove("latest")
+                versions.remove("latest")
             except ValueError:
                 pass
 
             # Are there still any tags?
-            if image.get("tags", []):
+            if versions:
                 converted_images.append({
                     "name": image.get("name"),
-                    "versions": image.get("tags"),
+                    "versions": versions,
                 })
 
         return converted_images

--- a/operators/crownlabs-image-list/update-crownlabs-image-list.yaml
+++ b/operators/crownlabs-image-list/update-crownlabs-image-list.yaml
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: update-crownlabs-image-list
       containers:
       - name: update-crownlabs-image-list
-        image: crownlabs/update-crownlabs-image-list:v0.1-crown
+        image: crownlabs/update-crownlabs-image-list:v0.1.1-crown
         imagePullPolicy: Always
         args:
         - --advertised-registry-name=registry.internal.crownlabs.polito.it


### PR DESCRIPTION
# Description

This PR fixes a bug in the crownlabs-image-list script, which caused a crash in case all the tags of an image had been deleted.