### PR TITLE
Labinstance operator: remove hardcoded website URL

### DIFF
--- a/operators/labInstance-operator/controllers/labinstance_controller.go
+++ b/operators/labInstance-operator/controllers/labinstance_controller.go
@@ -185,7 +185,7 @@ func (r *LabInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	}
 
 	// create Ingress to manage the oauth2 service
-	oauthIngress := pkg.CreateOauth2Ingress(name, namespace, oauthService, urlUUID)
+	oauthIngress := pkg.CreateOauth2Ingress(name, namespace, oauthService, urlUUID, r.WebsiteBaseUrl)
 	oauthIngress.SetOwnerReferences(labiOwnerRef)
 	if err := pkg.CreateOrUpdate(r.Client, ctx, log, oauthIngress); err != nil {
 		setLabInstanceStatus(r, ctx, log, "Could not create ingress "+oauthIngress.Name+" in namespace "+oauthIngress.Namespace, "Warning", "Oauth2IngressNotCreated", &labInstance, "", "")

--- a/operators/labInstance-operator/pkg/creation.go
+++ b/operators/labInstance-operator/pkg/creation.go
@@ -258,7 +258,7 @@ func CreateOauth2Service(name string, namespace string) corev1.Service {
 	return service
 }
 
-func CreateOauth2Ingress(name string, namespace string, svc corev1.Service, urlUUID string) v1beta1.Ingress {
+func CreateOauth2Ingress(name string, namespace string, svc corev1.Service, urlUUID string, websiteBaseUrl string) v1beta1.Ingress {
 
 	ingress := v1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{},
@@ -276,13 +276,13 @@ func CreateOauth2Ingress(name string, namespace string, svc corev1.Service, urlU
 		Spec: v1beta1.IngressSpec{
 			TLS: []v1beta1.IngressTLS{
 				{
-					Hosts:      []string{"crownlabs.polito.it"},
+					Hosts:      []string{websiteBaseUrl},
 					SecretName: "crownlabs-labinstances-secret",
 				},
 			},
 			Rules: []v1beta1.IngressRule{
 				{
-					Host: "crownlabs.polito.it",
+					Host: websiteBaseUrl,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{


### PR DESCRIPTION
# Description

This PR removes the hardcoded value from CreateIngress  and parametrizes the hostname of the ingress resource generated to expose the oauth2 page. This is necessary to make the preproduction version of the operator work correctly;