### PR TITLE
Rename api to crownlabs.polito.it

### DIFF
--- a/operators/labInstance-operator/Makefile
+++ b/operators/labInstance-operator/Makefile
@@ -11,10 +11,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: test
+all: generate fmt vet manifests
 
 # Run tests
-test: generate fmt vet manifests
+test: all
 	go test ./... -coverprofile cover.out
 
 # Build manager binary
@@ -39,7 +39,7 @@ deploy: manifests
 	kubectl kustomize config/default | kubectl apply -f -
 
 # Generate manifests e.g. CRD, RBAC etc.
-manifests: controller-gen
+manifests: controller-gen lab-template
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./api/v1" output:crd:artifacts:config=config/crd/bases
 
 lab-template: controller-gen

--- a/operators/labInstance-operator/PROJECT
+++ b/operators/labInstance-operator/PROJECT
@@ -1,4 +1,4 @@
-domain: crown.team.com
+domain: crownlabs.polito.it
 repo: github.com/netgroup-polito/CrownLabs/labInstance-operator
 resources:
 - group: instance

--- a/operators/labInstance-operator/api/v1/groupversion_info.go
+++ b/operators/labInstance-operator/api/v1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 // Package v1 contains API Schema definitions for the instance v1 API group
 // +kubebuilder:object:generate=true
-// +groupName=instance.crown.team.com
+// +groupName=instance.crownlabs.polito.it
 package v1
 
 import (
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "instance.crown.team.com", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "instance.crownlabs.polito.it", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/operators/labInstance-operator/config/crd/bases/instance.crownlabs.polito.it_labinstances.yaml
+++ b/operators/labInstance-operator/config/crd/bases/instance.crownlabs.polito.it_labinstances.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
-  name: labinstances.instance.crown.team.com
+  name: labinstances.instance.crownlabs.polito.it
 spec:
-  group: instance.crown.team.com
+  group: instance.crownlabs.polito.it
   names:
     kind: LabInstance
     listKind: LabInstanceList

--- a/operators/labInstance-operator/config/crd/kustomization.yaml
+++ b/operators/labInstance-operator/config/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/instance.crown.team.com_labinstances.yaml
+- bases/instance.crownlabs.polito.it_labinstances.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/operators/labInstance-operator/config/crd/patches/cainjection_in_labinstances.yaml
+++ b/operators/labInstance-operator/config/crd/patches/cainjection_in_labinstances.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: labinstances.instance.crown.team.com
+  name: labinstances.instance.crownlabs.polito.it

--- a/operators/labInstance-operator/config/crd/patches/webhook_in_labinstances.yaml
+++ b/operators/labInstance-operator/config/crd/patches/webhook_in_labinstances.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: labinstances.instance.crown.team.com
+  name: labinstances.instance.crownlabs.polito.it
 spec:
   conversion:
     strategy: Webhook

--- a/operators/labInstance-operator/config/rbac/labinstance_editor_role.yaml
+++ b/operators/labInstance-operator/config/rbac/labinstance_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: labinstance-editor-role
 rules:
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances/status
   verbs:

--- a/operators/labInstance-operator/config/rbac/labinstance_viewer_role.yaml
+++ b/operators/labInstance-operator/config/rbac/labinstance_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: labinstance-viewer-role
 rules:
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances/status
   verbs:

--- a/operators/labInstance-operator/config/rbac/role.yaml
+++ b/operators/labInstance-operator/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - instance.crown.team.com
+  - instance.crownlabs.polito.it
   resources:
   - labinstances/status
   verbs:

--- a/operators/labInstance-operator/config/samples/instance_v1_labinstance.yaml
+++ b/operators/labInstance-operator/config/samples/instance_v1_labinstance.yaml
@@ -1,4 +1,4 @@
-apiVersion: instance.crown.team.com/v1
+apiVersion: instance.crownlabs.polito.it/v1
 kind: LabInstance
 metadata:
   name: cloud-computing-lab3-987654

--- a/operators/labInstance-operator/controllers/labinstance_controller.go
+++ b/operators/labInstance-operator/controllers/labinstance_controller.go
@@ -53,8 +53,8 @@ type LabInstanceReconciler struct {
 	OidcProviderUrl    string
 }
 
-// +kubebuilder:rbac:groups=instance.crown.team.com,resources=labinstances,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=instance.crown.team.com,resources=labinstances/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=instance.crownlabs.polito.it,resources=labinstances,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=instance.crownlabs.polito.it,resources=labinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events/status,verbs=get
 

--- a/operators/labInstance-operator/k8s/operator/clusterroles.yaml
+++ b/operators/labInstance-operator/k8s/operator/clusterroles.yaml
@@ -4,7 +4,7 @@ metadata:
   name: labtemplate-consumer-operator
 rules:
   - apiGroups:
-      - template.crown.team.com
+      - template.crownlabs.polito.it
     resources:
       - labtemplates
     verbs:
@@ -18,7 +18,7 @@ metadata:
   name: labinstance-consumer-operator
 rules:
   - apiGroups:
-      - instance.crown.team.com
+      - instance.crownlabs.polito.it
     resources:
       - labinstances
     verbs:

--- a/operators/labInstance-operator/k8s/tenant/admin/LabTemplate.yaml
+++ b/operators/labInstance-operator/k8s/tenant/admin/LabTemplate.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: template.crown.team.com/v1
+apiVersion: template.crownlabs.polito.it/v1
 kind: LabTemplate
 metadata:
   name: cloud-computing-lab3

--- a/operators/labInstance-operator/k8s/tenant/example/LabInstance.yaml
+++ b/operators/labInstance-operator/k8s/tenant/example/LabInstance.yaml
@@ -1,5 +1,5 @@
  
-apiVersion: instance.crown.team.com/v1
+apiVersion: instance.crownlabs.polito.it/v1
 kind: LabInstance
 metadata:
   name: cloud-computing-lab3-123456

--- a/operators/labInstance-operator/labTemplate/api/v1/groupversion_info.go
+++ b/operators/labInstance-operator/labTemplate/api/v1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 // Package v1 contains API Schema definitions for the template v1 API group
 // +kubebuilder:object:generate=true
-// +groupName=template.crown.team.com
+// +groupName=template.crownlabs.polito.it
 package v1
 
 import (
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "template.crown.team.com", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "template.crownlabs.polito.it", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/operators/labInstance-operator/labTemplate/api/v1/labtemplate_types.go
+++ b/operators/labInstance-operator/labTemplate/api/v1/labtemplate_types.go
@@ -21,13 +21,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type VmType string
+
+const (
+	TypeGUI VmType = "GUI"
+	TypeCLI VmType = "CLI"
+)
+
 // LabTemplateSpec defines the desired state of LabTemplate
 type LabTemplateSpec struct {
 	CourseName  string                        `json:"courseName,omitempty"`
 	LabName     string                        `json:"labName,omitempty"`
 	LabNum      resource.Quantity             `json:"labNum,omitempty"`
 	Description string                        `json:"description,omitempty"`
-	Vm          virtv1.VirtualMachineInstance `json:"vm,omitempty"`
+	Vm          virtv1.VirtualMachineInstance `json:"vm"`
+	// +kubebuilder:validation:Enum="GUI";"CLI"
+	VmType `json:"vmType,omitempty"`
 }
 
 // LabTemplateStatus defines the observed state of LabTemplate

--- a/operators/labInstance-operator/labTemplate/crd/bases/template.crownlabs.polito.it_labtemplates.yaml
+++ b/operators/labInstance-operator/labTemplate/crd/bases/template.crownlabs.polito.it_labtemplates.yaml
@@ -2289,6 +2289,13 @@ spec:
               required:
               - spec
               type: object
+            vmType:
+              enum:
+              - GUI
+              - CLI
+              type: string
+          required:
+          - vm
           type: object
         status:
           description: LabTemplateStatus defines the observed state of LabTemplate

--- a/operators/labInstance-operator/labTemplate/crd/bases/template.crownlabs.polito.it_labtemplates.yaml
+++ b/operators/labInstance-operator/labTemplate/crd/bases/template.crownlabs.polito.it_labtemplates.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
-  name: labtemplates.template.crown.team.com
+  name: labtemplates.template.crownlabs.polito.it
 spec:
-  group: template.crown.team.com
+  group: template.crownlabs.polito.it
   names:
     kind: LabTemplate
     listKind: LabTemplateList

--- a/operators/labInstance-operator/labTemplate/crd/kustomization.yaml
+++ b/operators/labInstance-operator/labTemplate/crd/kustomization.yaml
@@ -2,7 +2,7 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/template.crown.team.com_labtemplates.yaml
+- bases/template.crownlabs.polito.it_labtemplates.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/operators/labInstance-operator/labTemplate/crd/patches/cainjection_in_labtemplates.yaml
+++ b/operators/labInstance-operator/labTemplate/crd/patches/cainjection_in_labtemplates.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: labtemplates.template.crown.team.com
+  name: labtemplates.template.crownlabs.polito.it

--- a/operators/labInstance-operator/labTemplate/crd/patches/webhook_in_labtemplates.yaml
+++ b/operators/labInstance-operator/labTemplate/crd/patches/webhook_in_labtemplates.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: labtemplates.template.crown.team.com
+  name: labtemplates.template.crownlabs.polito.it
 spec:
   conversion:
     strategy: Webhook

--- a/operators/labInstance-operator/labTemplate/samples/template_v1_labtemplate.yaml
+++ b/operators/labInstance-operator/labTemplate/samples/template_v1_labtemplate.yaml
@@ -52,3 +52,4 @@ spec:
         - name: pvcdisk
           persistentVolumeClaim:
             claimName: xxx
+  vmType: "GUI"

--- a/operators/labInstance-operator/labTemplate/samples/template_v1_labtemplate.yaml
+++ b/operators/labInstance-operator/labTemplate/samples/template_v1_labtemplate.yaml
@@ -1,4 +1,4 @@
-apiVersion: template.crown.team.com/v1
+apiVersion: template.crownlabs.polito.it/v1
 kind: LabTemplate
 metadata:
   name: cloud-computing-lab3

--- a/provisioning/courses/templates/labtemplate.yaml.tmpl
+++ b/provisioning/courses/templates/labtemplate.yaml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: template.crown.team.com/v1
+apiVersion: template.crownlabs.polito.it/v1
 kind: LabTemplate
 metadata:
   name: {{ course_code }}-lab{{ lab_number }}

--- a/provisioning/courses/templates/resourcequota.yaml.tmpl
+++ b/provisioning/courses/templates/resourcequota.yaml.tmpl
@@ -9,4 +9,4 @@ spec:
     limits.memory: 30Gi
     requests.cpu: "20"
     requests.memory: 30Gi
-    count/labinstances.instance.crown.team.com: "5"
+    count/labinstances.instance.crownlabs.polito.it: "5"

--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -21,8 +21,8 @@ export default class ApiManager {
 
     this.kc = new Config(window.APISERVER_URL, token, type);
     this.apiCRD = this.kc.makeApiClient(CustomObjectsApi);
-    this.templateGroup = 'template.crown.team.com';
-    this.instanceGroup = 'instance.crown.team.com';
+    this.templateGroup = 'template.crownlabs.polito.it';
+    this.instanceGroup = 'instance.crownlabs.polito.it';
     this.version = 'v1';
     this.templatePlural = 'labtemplates';
     this.instancePlural = 'labinstances';


### PR DESCRIPTION
# Description
This PR contains
- modify the family of `LabInstance` and `LabTemplate` CRD from `crown.team.com` to `crownlabs.polito.it`.
- add the vm type (GUI or CLI) to the `LabTemplate`.
