### PR TITLE
Fix leftover references to the v1 API

### DIFF
--- a/operators/labInstance-operator/api/v1alpha1/groupversion_info.go
+++ b/operators/labInstance-operator/api/v1alpha1/groupversion_info.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the instance v1 API group
+// Package v1alpha1 contains API Schema definitions for the instance v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=crownlabs.polito.it
 package v1alpha1

--- a/operators/labInstance-operator/controllers/labinstance_controller.go
+++ b/operators/labInstance-operator/controllers/labinstance_controller.go
@@ -18,16 +18,17 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/pkg/instanceCreation"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/pkg/instanceCreation"
+
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	instancev1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/api/v1alpha1"
+	instancev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/api/v1alpha1"
 	virtv1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/kubeVirt/api/v1"
-	templatev1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
+	templatev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ func (r *LabInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	log := r.Log.WithValues("labinstance", req.NamespacedName)
 
 	// get labInstance
-	var labInstance instancev1.LabInstance
+	var labInstance instancev1alpha1.LabInstance
 	if err := r.Get(ctx, req.NamespacedName, &labInstance); err != nil {
 		// reconcile was triggered by a delete request
 		log.Info("LabInstance " + req.Name + " deleted")
@@ -100,7 +101,7 @@ func (r *LabInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 		Namespace: labInstance.Spec.LabTemplateNamespace,
 		Name:      labInstance.Spec.LabTemplateName,
 	}
-	var labTemplate templatev1.LabTemplate
+	var labTemplate templatev1alpha1.LabTemplate
 	if err := r.Get(ctx, templateName, &labTemplate); err != nil {
 		// no LabTemplate related exists
 		log.Info("LabTemplate " + templateName.Name + " doesn't exist. Deleting LabInstance " + labInstance.Name)
@@ -223,13 +224,13 @@ func (r *LabInstanceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 
 func (r *LabInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&instancev1.LabInstance{}).
+		For(&instancev1alpha1.LabInstance{}).
 		Complete(r)
 }
 
 func setLabInstanceStatus(r *LabInstanceReconciler, ctx context.Context, log logr.Logger,
 	msg string, eventType string, eventReason string,
-	labInstance *instancev1.LabInstance, ip, url string) {
+	labInstance *instancev1alpha1.LabInstance, ip, url string) {
 
 	log.Info(msg)
 	r.EventsRecorder.Event(labInstance, eventType, eventReason, msg)
@@ -246,7 +247,7 @@ func setLabInstanceStatus(r *LabInstanceReconciler, ctx context.Context, log log
 
 func getVmiStatus(r *LabInstanceReconciler, ctx context.Context, log logr.Logger,
 	name string, service v1.Service, ingress v1beta1.Ingress,
-	labInstance *instancev1.LabInstance, vmi virtv1.VirtualMachineInstance, startTimeVM time.Time) {
+	labInstance *instancev1alpha1.LabInstance, vmi virtv1.VirtualMachineInstance, startTimeVM time.Time) {
 
 	var vmStatus virtv1.VirtualMachineInstancePhase
 	// iterate until the vm is running

--- a/operators/labInstance-operator/labTemplate/api/v1alpha1/groupversion_info.go
+++ b/operators/labInstance-operator/labTemplate/api/v1alpha1/groupversion_info.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1 contains API Schema definitions for the template v1 API group
+// Package v1alpha1 contains API Schema definitions for the template v1alpha1 API group
 // +kubebuilder:object:generate=true
 // +groupName=crownlabs.polito.it
 package v1alpha1
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "crownlabs.polito.it", Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: "crownlabs.polito.it", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/operators/labInstance-operator/main.go
+++ b/operators/labInstance-operator/main.go
@@ -25,9 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	instancev1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/api/v1alpha1"
+	instancev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/api/v1alpha1"
 	"github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/controllers"
-	templatev1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
+	templatev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -44,9 +44,9 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	_ = instancev1.AddToScheme(scheme)
+	_ = instancev1alpha1.AddToScheme(scheme)
 
-	_ = templatev1.AddToScheme(scheme)
+	_ = templatev1alpha1.AddToScheme(scheme)
 
 	_ = virtv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme

--- a/operators/labInstance-operator/pkg/instanceCreation/creation.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	virtv1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/kubeVirt/api/v1"
-	templatev1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
+	templatev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateVirtualMachineInstance(name string, namespace string, template templatev1.LabTemplate, instanceName string, secretName string) virtv1.VirtualMachineInstance {
+func CreateVirtualMachineInstance(name string, namespace string, template templatev1alpha1.LabTemplate, instanceName string, secretName string) virtv1.VirtualMachineInstance {
 	vm := template.Spec.Vm
 	vm.Name = name + "-vmi"
 	vm.Namespace = namespace

--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -23,7 +23,7 @@ export default class ApiManager {
     this.apiCRD = this.kc.makeApiClient(CustomObjectsApi);
     this.templateGroup = 'crownlabs.polito.it';
     this.instanceGroup = 'crownlabs.polito.it';
-    this.version = 'v1';
+    this.version = 'v1alpha1';
     this.templatePlural = 'labtemplates';
     this.instancePlural = 'labinstances';
     this.studentID = studentID;


### PR DESCRIPTION
# Description

This PR fixes some references which remained to the v1 API, instead of the v1alpha1 version as changed in #306 

# How Has This Been Tested?

Locally executing the frontend and the operator and verifying the correct functioning