### PR TITLE
Course provisioning: support the VM type field

### DIFF
--- a/provisioning/courses/csv-examples/laboratories.csv
+++ b/provisioning/courses/csv-examples/laboratories.csv
@@ -1,3 +1,3 @@
-Course (code),Lab number,Image,Cpu,Memory,Description
-swnet,1,registry.internal.crownlabs.polito.it/repo/image1:v1.1,2,4.5,The first laboratory
-swnet,2,registry.internal.crownlabs.polito.it/repo/image2:v0.1,5,8,The second laboratory
+Course (code),Lab number,Image,Cpu,Memory,Needs GUI,Description
+swnet,1,registry.internal.crownlabs.polito.it/repo/image1:v1.1,2,4.5,True,The first laboratory
+swnet,2,registry.internal.crownlabs.polito.it/repo/image2:v0.1,5,8,False,The second laboratory

--- a/provisioning/courses/setup-courses.py
+++ b/provisioning/courses/setup-courses.py
@@ -399,6 +399,7 @@ class Laboratory:
         self.memory = record['Memory']
         self.description = record['Description']
         self.namespace = Course.get_namespace_name(self.course_code)
+        self.vm_type = 'GUI' if record.get('Needs GUI', True) else 'CLI'
 
         sys.stdout.write("Processing laboratory {} - course {}\n"
                          .format(self.number, self.course_code))
@@ -410,7 +411,7 @@ class Laboratory:
 
         k8s_templates["labtemplate"].apply_template(
             namespace_name=self.namespace, course_code=self.course_code, lab_number=self.number,
-            description=self.description, image=self.image,
+            description=self.description, image=self.image, vm_type=self.vm_type,
             cpu=self.cpu, memory=self.memory)
 
 

--- a/provisioning/courses/templates/labtemplate.yaml.tmpl
+++ b/provisioning/courses/templates/labtemplate.yaml.tmpl
@@ -32,10 +32,10 @@ spec:
           guest: "{{ memory }}G"
         resources:
           limits:
-            cpu: "{{ cpu + 1 }}"
+            cpu: "{{ cpu + 0.5 }}"
             memory: "{{ memory + 0.5 }}G"
           requests:
-            cpu: "{{ cpu + 0.5 }}"
+            cpu: "{{ cpu * 0.5 }}"
             memory: "{{ memory }}G"
       terminationGracePeriodSeconds: 30
       volumes:
@@ -47,3 +47,4 @@ spec:
           secretRef:
             name: {{ course_code }}-lab{{ lab_name }}
         name: cloudinitdisk
+  vmType: {{ vm_type }}

--- a/provisioning/virtual-machines/ansible/roles/gather-desktop-environment-facts/tasks/main.yml
+++ b/provisioning/virtual-machines/ansible/roles/gather-desktop-environment-facts/tasks/main.yml
@@ -2,14 +2,16 @@
 # tasks file for gather-desktop-environment-facts
 
 - name: Check whether a Desktop Environment is installed
-  shell: command -v startx || true
+  shell: command -v startx
   register: startx_presence_check
   changed_when: False
+  failed_when: False
 
 - name: Check whether XFCE is installed
-  shell: command -v startxfce4 || true
+  shell: command -v startxfce4
   register: xfce_presence_check
   changed_when: False
+  failed_when: False
 
 - name: Set facts
   set_fact:


### PR DESCRIPTION
# Description

This PR introduces the support to configure the "VM type" (i.e. GUI or CLI) of a laboratory using the course provisioning script. For backward compatibility, if the `Needs GUI` column is not specified in the csv file, the script creates a GUI-based laboratory.

Additionally, this PR introduces the following improvements:
* Applies [this comment](https://github.com/netgroup-polito/CrownLabs/pull/309#discussion_r492821534) to the Ansible playbooks (the PR got merged by the bot too early);
* Reduces the amount of CPU reserved to each laboratory created using the course provisioning script, in order to leverage over-commitment and support a greater number of concurrent users.

# How Has This Been Tested?

Manually testing that the modifications work correctly
