### PR TITLE
Added visual discrimination between dekstop and CLI VMs

### DIFF
--- a/webservice/package.json
+++ b/webservice/package.json
@@ -103,6 +103,14 @@
       "react/jsx-pascal-case": "error",
       "react/prop-types": "off",
       "no-nested-ternary": "off",
+      "no-console": [
+        "warn",
+        {
+          "allow": [
+            "error"
+          ]
+        }
+      ],
       "react/jsx-indent": "off",
       "react/jsx-wrap-multilines": [
         "error",

--- a/webservice/src/components/Body.jsx
+++ b/webservice/src/components/Body.jsx
@@ -5,7 +5,6 @@ import StudentView from './StudentView';
 export default function Body(props) {
   const {
     isStudentView,
-    registryName,
     retrieveImageList,
     adminGroups,
     templateLabsAdmin,
@@ -41,7 +40,6 @@ export default function Body(props) {
         />
       ) : (
         <ProfessorView
-          registryName={registryName}
           imageList={retrieveImageList}
           adminGroups={adminGroups}
           templateLabs={templateLabsAdmin}

--- a/webservice/src/components/LabTemplatesList.jsx
+++ b/webservice/src/components/LabTemplatesList.jsx
@@ -170,6 +170,13 @@ export default function LabTemplatesList(props) {
                         labName.charAt(0).toUpperCase() +
                           labName.slice(1).replace(/-/g, ' ')
                       }
+                      secondary={
+                        <>
+                          <b>ID: </b>
+                          {labName}
+                          <br />
+                        </>
+                      }
                     />
                   </>
                 </Tooltip>

--- a/webservice/src/components/LabTemplatesList.jsx
+++ b/webservice/src/components/LabTemplatesList.jsx
@@ -13,7 +13,7 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import SortByAlphaIcon from '@material-ui/icons/SortByAlpha';
 import OrderSelector from './OrderSelector';
 import TextSelector from './TextSelector';
-
+import { vmTypeSelectors } from './RunningLabList';
 /* The style for the ListItem */
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -42,11 +42,12 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: 'inherit',
     padding: 0
   },
-  titlebar: {
+  listSubHeader: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    fontSize: '30px'
+    fontSize: '30px',
+    padding: theme.spacing(0, 1)
   },
   titleActions: {
     display: 'flex',
@@ -58,6 +59,13 @@ const useStyles = makeStyles(theme => ({
   },
   deleteIcon: {
     color: theme.palette.error.main
+  },
+  templateType: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    color: theme.palette.info.main,
+    width: theme.spacing(7)
   }
 }));
 
@@ -76,10 +84,11 @@ export default function LabTemplatesList(props) {
   const labList = courseNames.reduce(
     (acc, courseName) => [
       ...acc,
-      ...labs.get(courseName).map(({ labName, description }) => ({
+      ...labs.get(courseName).map(({ labName, description, type }) => ({
         labName,
         courseName,
-        description
+        description,
+        type
       }))
     ],
     []
@@ -107,15 +116,15 @@ export default function LabTemplatesList(props) {
         <List
           className={classes.list}
           subheader={
-            <ListSubheader className={classes.titlebar}>
-              {title}
+            <ListSubheader className={classes.listSubHeader}>
+              <div>{title}</div>
               <div className={classes.titleActions}>
-                <TextSelector value={textMatch} setValue={setTextMatch} />
                 <OrderSelector
                   selectors={selectors}
                   setOrderData={setOrderData}
                   orderData={orderData}
                 />
+                <TextSelector value={textMatch} setValue={setTextMatch} />
               </div>
             </ListSubheader>
           }
@@ -140,7 +149,7 @@ export default function LabTemplatesList(props) {
                   : a.labName.localeCompare(b.labName);
               return isDirUp ? sortResult : -sortResult;
             })
-            .map(({ labName, courseName, description }, i) => (
+            .map(({ labName, courseName, description, type }, i) => (
               <ListItem
                 key={labName}
                 button
@@ -151,14 +160,18 @@ export default function LabTemplatesList(props) {
                 }}
               >
                 <Tooltip title="Select it">
-                  <ListItemText
-                    inset
-                    primary={
-                      description ||
-                      labName.charAt(0).toUpperCase() +
-                        labName.slice(1).replace(/-/g, ' ')
-                    }
-                  />
+                  <>
+                    <div className={classes.templateType}>
+                      {vmTypeSelectors.find(sel => sel.value === type).icon}
+                    </div>
+                    <ListItemText
+                      primary={
+                        description ||
+                        labName.charAt(0).toUpperCase() +
+                          labName.slice(1).replace(/-/g, ' ')
+                      }
+                    />
+                  </>
                 </Tooltip>
                 {selectedIndex === i && deleteLabTemplate ? (
                   <Tooltip title="Delete template">

--- a/webservice/src/components/Main.jsx
+++ b/webservice/src/components/Main.jsx
@@ -18,13 +18,12 @@ darkThemeConfig.palette.type = 'dark';
 const lightTheme = createMuiTheme(lightThemeConfig);
 const darkTheme = createMuiTheme(darkThemeConfig);
 
-const Themer = props => {
+const Main = props => {
   const {
     logout,
     name,
     isStudentView,
     adminGroups,
-    registryName,
     imageList,
     templateLabsAdmin,
     instanceLabsAdmin,
@@ -42,13 +41,17 @@ const Themer = props => {
 
   const [isLightTheme, setIsLightTheme] = useState(() => {
     const prevIsLightTheme = JSON.parse(localStorage.getItem('isLightTheme'));
-    if (prevIsLightTheme === null) return false;
+    if (prevIsLightTheme === null) {
+      const prefersDarkMode = window.matchMedia('(prefers-color-scheme: dark)')
+        .matches;
+      return !prefersDarkMode;
+    }
     return prevIsLightTheme;
   });
+
   useEffect(() => {
     localStorage.setItem('isLightTheme', JSON.stringify(isLightTheme));
   }, [isLightTheme]);
-
   return (
     <ThemeProvider theme={isLightTheme ? lightTheme : darkTheme}>
       <CssBaseline />
@@ -63,7 +66,6 @@ const Themer = props => {
           setIsLightTheme={setIsLightTheme}
         />
         <Body
-          registryName={registryName}
           retrieveImageList={imageList}
           adminGroups={adminGroups}
           templateLabsAdmin={templateLabsAdmin}
@@ -85,4 +87,4 @@ const Themer = props => {
   );
 };
 
-export default Themer;
+export default Main;

--- a/webservice/src/components/NewTemplateForm.jsx
+++ b/webservice/src/components/NewTemplateForm.jsx
@@ -87,14 +87,12 @@ export default function TemplateForm(props) {
     namespace,
     errorcode,
     adminGroups,
-    labId,
     image,
     imageList,
     description,
     type,
     version,
     setVersion,
-    setLabid,
     setImage,
     setNamespace,
     setType,
@@ -110,9 +108,7 @@ export default function TemplateForm(props) {
   const handleChangeType = event => {
     setType(event.target.value);
   };
-  const handleChangeLabid = event => {
-    setLabid(event.target.value);
-  };
+
   const handleChangeNamespace = event => {
     setNamespace(event.target.value);
   };
@@ -133,7 +129,7 @@ export default function TemplateForm(props) {
       autoComplete="off"
     >
       <TextField
-        style={{ margin: 10, width: '40%' }}
+        style={{ margin: 10, width: '84%' }}
         name="courseCode"
         select
         label="Course Code"
@@ -148,19 +144,6 @@ export default function TemplateForm(props) {
           </MenuItem>
         ))}
       </TextField>
-      <TextField
-        required
-        type="number"
-        placeholder="insert lab id"
-        style={{ margin: 10, width: '40%' }}
-        id="outlined-basic-image"
-        label="Lab ID"
-        name="labId"
-        variant="outlined"
-        value={labId || ''}
-        onChange={handleChangeLabid}
-        helperText={errorcode === 2 ? 'Insert a valid labID!' : ' '}
-      />
       <TextField
         required
         select
@@ -189,7 +172,7 @@ export default function TemplateForm(props) {
         style={{ margin: 10, width: '40%' }}
         id="outlined-basic"
         label="Image Version"
-        name="image"
+        name="version"
         disabled={!image || imageList.get(image).length === 1}
         value={version || ''}
         onChange={handleChangeVersion}
@@ -225,14 +208,13 @@ export default function TemplateForm(props) {
         required
         select
         InputLabelProps={{ shrink: true }}
-        placeholder="insert image Version"
         style={{
           margin: 10,
           width: '20%'
         }}
         id="outlined-basic"
         label="VM type"
-        name="image"
+        name="type"
         value={type || ''}
         onChange={handleChangeType}
         variant="outlined"

--- a/webservice/src/components/NewTemplateForm.jsx
+++ b/webservice/src/components/NewTemplateForm.jsx
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import React from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Slider from '@material-ui/core/Slider';
+import { vmTypes } from '../services/ApiManager';
 
 const iOSBoxShadow =
   '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.13),0 0 0 1px rgba(0,0,0,0.02)';
@@ -86,18 +87,28 @@ export default function TemplateForm(props) {
     namespace,
     errorcode,
     adminGroups,
-    labid,
+    labId,
     image,
     imageList,
+    description,
+    type,
     version,
     setVersion,
     setLabid,
     setImage,
-    setNamespace
+    setNamespace,
+    setType,
+    setDescription
   } = props;
 
   const handleChangeVersion = event => {
     setVersion(event.target.value);
+  };
+  const handleChangeDescription = event => {
+    setDescription(event.target.value);
+  };
+  const handleChangeType = event => {
+    setType(event.target.value);
   };
   const handleChangeLabid = event => {
     setLabid(event.target.value);
@@ -144,9 +155,9 @@ export default function TemplateForm(props) {
         style={{ margin: 10, width: '40%' }}
         id="outlined-basic-image"
         label="Lab ID"
-        name="labid"
+        name="labId"
         variant="outlined"
-        value={labid || ''}
+        value={labId || ''}
         onChange={handleChangeLabid}
         helperText={errorcode === 2 ? 'Insert a valid labID!' : ' '}
       />
@@ -192,6 +203,46 @@ export default function TemplateForm(props) {
               </MenuItem>
             ))
           : []}
+      </TextField>
+      <TextField
+        required
+        type="text"
+        InputLabelProps={{ shrink: true }}
+        placeholder=""
+        style={{
+          margin: 10,
+          width: '60%'
+        }}
+        id="outlined-basic"
+        label="VM description"
+        name="description"
+        value={description || ''}
+        onChange={handleChangeDescription}
+        variant="outlined"
+        helperText={errorcode === 4 ? 'Select a valid Version!' : ' '}
+      />
+      <TextField
+        required
+        select
+        InputLabelProps={{ shrink: true }}
+        placeholder="insert image Version"
+        style={{
+          margin: 10,
+          width: '20%'
+        }}
+        id="outlined-basic"
+        label="VM type"
+        name="image"
+        value={type || ''}
+        onChange={handleChangeType}
+        variant="outlined"
+        helperText={errorcode === 4 ? 'Select a valid Version!' : ' '}
+      >
+        {Object.values(vmTypes).map(vmType => (
+          <MenuItem key={vmType} value={vmType}>
+            {vmType}
+          </MenuItem>
+        ))}
       </TextField>
 
       <Typography

--- a/webservice/src/components/OrderSelector.jsx
+++ b/webservice/src/components/OrderSelector.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
 import IconButton from '@material-ui/core/IconButton';
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
+import Selector from './Selector';
 
 const useStyles = makeStyles(() => ({
+  orderSelector: { display: 'flex' },
   flipOrderBtn: {
-    transition: '0.5s ease-out',
-    marginRight: 10
+    transition: '0.5s ease-out'
   },
   rotate0: {
     transform: 'rotateZ(0deg)'
@@ -21,42 +19,14 @@ const useStyles = makeStyles(() => ({
 
 export default function OrderSelector(props) {
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] = React.useState(null);
   const { selectors, orderData, setOrderData } = props;
   const { order, isDirUp } = orderData;
-  const handleClick = event => {
-    setAnchorEl(event.currentTarget);
+  const setOrder = newOrder => {
+    setOrderData({ ...orderData, order: newOrder });
   };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
   return (
-    <div>
-      {selectors.length > 1 && (
-        <IconButton color="secondary" onClick={handleClick}>
-          {selectors.find(sel => sel.value === order).icon}
-        </IconButton>
-      )}
-      <Menu
-        anchorEl={anchorEl}
-        keepMounted
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-      >
-        {selectors.map(({ text, icon, value }) => (
-          <MenuItem
-            onClick={() => {
-              setOrderData({ ...orderData, order: value });
-              setAnchorEl(null);
-            }}
-            key={text}
-          >
-            <ListItemIcon>{icon}</ListItemIcon>
-            {text}
-          </MenuItem>
-        ))}
-      </Menu>
+    <div className={classes.orderSelector}>
+      <Selector selectors={selectors} value={order} setValue={setOrder} />
       <IconButton
         color="secondary"
         onClick={() => setOrderData({ ...orderData, isDirUp: !isDirUp })}

--- a/webservice/src/components/ProfessorView.jsx
+++ b/webservice/src/components/ProfessorView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Slide from '@material-ui/core/Slide';
 import Button from '@material-ui/core/Button';
@@ -12,6 +12,7 @@ import TemplateForm from './NewTemplateForm';
 import { labPapersStyle } from './StudentView';
 import LabInstancesList from './LabInstancesList';
 import LabTemplatesList from './LabTemplatesList';
+import { vmTypes } from '../services/ApiManager';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -34,22 +35,24 @@ export default function ProfessorView(props) {
     adminGroups
   } = props;
 
-  const [open, setOpen] = React.useState(false);
-  const [image, setImage] = React.useState(null);
-  const [version, setVersion] = React.useState(null);
-  const [labid, setLabid] = React.useState(null);
-  const [namespace, setNamespace] = React.useState(null);
-  const [errorcode, setErrorcode] = React.useState(0);
+  const [open, setOpen] = useState(false);
+  const [image, setImage] = useState(null);
+  const [version, setVersion] = useState(null);
+  const [labId, setLabid] = useState(null);
+  const [namespace, setNamespace] = useState(null);
+  const [errorcode, setErrorcode] = useState(0);
+  const [description, setDescription] = useState(null);
+  const [type, setType] = useState(null);
 
   const handleClickOpen = () => {
     setOpen(true);
   };
-  const handleClose = () => {
+  const handleSubmit = () => {
     if (!adminGroups.includes(namespace)) {
       setErrorcode(1);
       return;
     }
-    if (labid === null || !labid.length) {
+    if (labId === null || !labId.length) {
       setErrorcode(2);
       return;
     }
@@ -64,11 +67,12 @@ export default function ProfessorView(props) {
 
     createNewTemplate(
       namespace,
-      labid,
-      `namespace: ${namespace} laboratory number: ${labid}`,
+      labId,
+      description,
       Number(document.getElementsByName('cpu')[0].value),
       Number(document.getElementsByName('memory')[0].value),
-      `${registryName}/${image}:${version}`
+      `${registryName}/${image}:${version}`,
+      type || vmTypes.GUI
     );
 
     setErrorcode(0);
@@ -76,6 +80,8 @@ export default function ProfessorView(props) {
     if (image !== null) setVersion([]);
     setImage(null);
     setLabid(null);
+    setDescription(null);
+    setType(null);
     setOpen(false);
   };
 
@@ -85,6 +91,8 @@ export default function ProfessorView(props) {
     if (image !== null) setVersion([]);
     setImage(null);
     setLabid(null);
+    setDescription(null);
+    setType(null);
     setOpen(false);
   };
   return (
@@ -128,7 +136,7 @@ export default function ProfessorView(props) {
               </DialogTitle>
               <DialogContent>
                 <TemplateForm
-                  labid={labid}
+                  labId={labId}
                   image={image}
                   version={version}
                   namespace={namespace}
@@ -136,9 +144,13 @@ export default function ProfessorView(props) {
                   setImage={setImage}
                   setVersion={setVersion}
                   setNamespace={setNamespace}
+                  setDescription={setDescription}
+                  setType={setType}
                   imageList={imageList}
                   adminGroups={adminGroups}
                   errorcode={errorcode}
+                  description={description}
+                  type={type}
                 />
               </DialogContent>
               <DialogActions>
@@ -154,8 +166,17 @@ export default function ProfessorView(props) {
                   variant="contained"
                   color="primary"
                   startIcon={<AddCircleIcon />}
-                  onClick={handleClose}
+                  onClick={handleSubmit}
                   type="submit"
+                  disabled={
+                    !description ||
+                    description === '' ||
+                    !type ||
+                    !labId ||
+                    !image ||
+                    !version ||
+                    !namespace
+                  }
                 >
                   Create
                 </Button>

--- a/webservice/src/components/ProfessorView.jsx
+++ b/webservice/src/components/ProfessorView.jsx
@@ -29,7 +29,6 @@ export default function ProfessorView(props) {
     connect,
     stop,
     showStatus,
-    registryName,
     imageList,
     createNewTemplate,
     adminGroups
@@ -65,7 +64,8 @@ export default function ProfessorView(props) {
       description,
       Number(document.getElementsByName('cpu')[0].value),
       Number(document.getElementsByName('memory')[0].value),
-      `${registryName}/${image}:${version}`,
+      image,
+      version,
       type || vmTypes.GUI
     );
 

--- a/webservice/src/components/ProfessorView.jsx
+++ b/webservice/src/components/ProfessorView.jsx
@@ -38,7 +38,6 @@ export default function ProfessorView(props) {
   const [open, setOpen] = useState(false);
   const [image, setImage] = useState(null);
   const [version, setVersion] = useState(null);
-  const [labId, setLabid] = useState(null);
   const [namespace, setNamespace] = useState(null);
   const [errorcode, setErrorcode] = useState(0);
   const [description, setDescription] = useState(null);
@@ -52,10 +51,6 @@ export default function ProfessorView(props) {
       setErrorcode(1);
       return;
     }
-    if (labId === null || !labId.length) {
-      setErrorcode(2);
-      return;
-    }
     if (!imageList.has(image)) {
       setErrorcode(3);
       return;
@@ -67,7 +62,6 @@ export default function ProfessorView(props) {
 
     createNewTemplate(
       namespace,
-      labId,
       description,
       Number(document.getElementsByName('cpu')[0].value),
       Number(document.getElementsByName('memory')[0].value),
@@ -77,9 +71,8 @@ export default function ProfessorView(props) {
 
     setErrorcode(0);
     setNamespace(null);
-    if (image !== null) setVersion([]);
+    setVersion(null);
     setImage(null);
-    setLabid(null);
     setDescription(null);
     setType(null);
     setOpen(false);
@@ -88,9 +81,8 @@ export default function ProfessorView(props) {
   const handleAbort = () => {
     setErrorcode(0);
     setNamespace(null);
-    if (image !== null) setVersion([]);
+    setVersion(null);
     setImage(null);
-    setLabid(null);
     setDescription(null);
     setType(null);
     setOpen(false);
@@ -136,11 +128,9 @@ export default function ProfessorView(props) {
               </DialogTitle>
               <DialogContent>
                 <TemplateForm
-                  labId={labId}
                   image={image}
                   version={version}
                   namespace={namespace}
-                  setLabid={setLabid}
                   setImage={setImage}
                   setVersion={setVersion}
                   setNamespace={setNamespace}
@@ -172,7 +162,6 @@ export default function ProfessorView(props) {
                     !description ||
                     description === '' ||
                     !type ||
-                    !labId ||
                     !image ||
                     !version ||
                     !namespace

--- a/webservice/src/components/RunningLabList.jsx
+++ b/webservice/src/components/RunningLabList.jsx
@@ -111,7 +111,7 @@ export const vmTypeSelectors = [
   { text: 'CLI only', icon: <TerminalIcon />, value: vmTypes.CLI }
 ];
 
-const getLabCodeFromName = name => name.slice(name.length - 4);
+const getLabCodeFromName = name => /-([0-9]{1,4})$/.exec(name)[1];
 
 const RunningLabList = props => {
   const { labList, stop, connect, title, isStudentView } = props;
@@ -189,7 +189,7 @@ const RunningLabList = props => {
             return true;
           })
           .sort((a, b) => {
-            let sortResult;
+            let sortResult = 1;
             const { order, isDirUp } = orderData;
             if (order === 'time')
               sortResult = utc(b.creationTime).diff(a.creationTime, 's');
@@ -267,7 +267,9 @@ const RunningLabList = props => {
                         )}
                         <>
                           <b>Created: </b>
-                          {utc(creationTime).format('DD/MM/YY HH:MM')}
+                          {utc(creationTime)
+                            .local()
+                            .format('DD/MM/YY HH:mm:ss')}
                           <br />
                         </>
                         <>

--- a/webservice/src/components/Selector.jsx
+++ b/webservice/src/components/Selector.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import IconButton from '@material-ui/core/IconButton';
+
+export default function Selector(props) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const { selectors, value, setValue } = props;
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      {selectors.length > 1 && (
+        <IconButton color="secondary" onClick={handleClick}>
+          {selectors.find(sel => sel.value === value).icon}
+        </IconButton>
+      )}
+      <Menu
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        {selectors.map(({ text, icon, value: newValue }) => (
+          <MenuItem
+            onClick={() => {
+              setValue(newValue);
+              setAnchorEl(null);
+            }}
+            key={text}
+          >
+            <ListItemIcon>{icon}</ListItemIcon>
+            {text}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/webservice/src/components/UserLogic.jsx
+++ b/webservice/src/components/UserLogic.jsx
@@ -168,13 +168,13 @@ export default class UserLogic extends React.Component {
   /**
    * Function to start and create a CRD template
    */
-  createCRDtemplate(namespace, description, cpu, memory, image, type) {
-    const { templateLabsAdmin } = this.state;
+  createCRDtemplate(namespace, description, cpu, memory, image, version, type) {
+    const { templateLabsAdmin, registryName } = this.state;
     const currentLabNums = templateLabsAdmin
       .get(namespace)
       .map(({ labNum }) => Number(labNum));
-    let newLabNum = 1;
     // create a new unique labNum based on the current ones
+    let newLabNum = 1;
     while (currentLabNums.includes(newLabNum)) newLabNum += 1;
     this.apiManager
       .createCRDtemplate(
@@ -183,7 +183,7 @@ export default class UserLogic extends React.Component {
         description,
         cpu,
         memory,
-        image,
+        `${registryName}/${image}:${version}`,
         type
       )
       .then(() => {
@@ -536,7 +536,6 @@ export default class UserLogic extends React.Component {
       name,
       isStudentView,
       adminGroups,
-      registryName,
       imageList,
       templateLabsAdmin,
       instanceLabsAdmin,
@@ -547,7 +546,6 @@ export default class UserLogic extends React.Component {
       <Main
         name={name}
         logout={logout}
-        registryName={registryName}
         imageList={imageList}
         adminGroups={adminGroups}
         templateLabsAdmin={templateLabsAdmin}

--- a/webservice/src/components/UserLogic.jsx
+++ b/webservice/src/components/UserLogic.jsx
@@ -175,7 +175,6 @@ export default class UserLogic extends React.Component {
     image,
     type
   ) {
-    const { templateLabs, templateLabsAdmin } = this.state;
     this.apiManager
       .createCRDtemplate(
         namespace,
@@ -186,17 +185,13 @@ export default class UserLogic extends React.Component {
         image,
         type
       )
-      .then(response => {
-        Toastr.success(`Successfully create template \`${description}\``);
-        const newMap = templateLabs;
-        newMap.set(response.body.metadata.name, { status: 0, url: null });
+      .then(() => {
+        Toastr.success(`Successfully created template \`${description}\``);
       })
       .catch(error => {
         this.handleErrors(error);
       })
       .finally(() => {
-        templateLabs.clear();
-        templateLabsAdmin.clear();
         this.retrieveCRDtemplates();
       });
   }
@@ -464,28 +459,39 @@ export default class UserLogic extends React.Component {
     let msg = '';
     // next eslint-disable is because the k8s_library uses the dash in their implementation
     // eslint-disable-next-line no-underscore-dangle
-    switch (error.response._fetchResponse.status) {
-      case 401:
-        msg += 'Forbidden, something in the ticket renewal failed';
-        this.logoutInterval();
-        break;
-      case 403:
-        msg +=
-          'It seems you do not have the right permissions to perform this operation';
-        break;
-      case 404:
-        msg += 'Resource not found, probably you have already destroyed it';
-        break;
-      case 409:
-        msg += 'The resource is already present';
-        break;
-      default:
-        msg += `An error occurred(${
-          // next eslint-disable is because the k8s_library uses the dash in their implementation
-          // eslint-disable-next-line no-underscore-dangle
-          error && error.response._fetchResponse.status
-        }), please login again`;
-        this.logoutInterval();
+    if (error.response && error._fetchResponse)
+      // eslint-disable-next-line no-underscore-dangle
+      switch (error.response._fetchResponse.status) {
+        case 401:
+          msg += 'Forbidden, something in the ticket renewal failed';
+          this.logoutInterval();
+          break;
+        case 403:
+          msg +=
+            'It seems you do not have the right permissions to perform this operation';
+          break;
+        case 404:
+          msg += 'Resource not found, probably you have already destroyed it';
+          break;
+        case 409:
+          msg += 'The resource is already present';
+          break;
+        default:
+          msg += `An error occurred(${
+            // next eslint-disable is because the k8s_library uses the dash in their implementation
+            // eslint-disable-next-line no-underscore-dangle
+            error && error.response._fetchResponse.status
+          }), please login again`;
+          this.logoutInterval();
+      }
+    else {
+      console.error(error);
+      msg += `An error occurred(${
+        // next eslint-disable is because the k8s_library uses the dash in their implementation
+        // eslint-disable-next-line no-underscore-dangle
+        error
+      }), please login again`;
+      this.logoutInterval();
     }
     Toastr.error(msg);
   }

--- a/webservice/src/components/UserLogic.jsx
+++ b/webservice/src/components/UserLogic.jsx
@@ -101,19 +101,21 @@ export default class UserLogic extends React.Component {
           if (x) {
             newMap.set(
               x.course,
-              x.labs.map(({ name, description, type }) => ({
+              x.labs.map(({ name, description, type, labNum }) => ({
                 labName: name,
                 description,
-                type
+                type,
+                labNum
               }))
             );
             if (adminGroups.includes(x.course))
               newMapAdmin.set(
                 x.course,
-                x.labs.map(({ name, description, type }) => ({
+                x.labs.map(({ name, description, type, labNum }) => ({
                   labName: name,
                   description,
-                  type
+                  type,
+                  labNum
                 }))
               );
             x.labs.forEach(({ name, description, type }) => {
@@ -166,19 +168,18 @@ export default class UserLogic extends React.Component {
   /**
    * Function to start and create a CRD template
    */
-  createCRDtemplate(
-    namespace,
-    labNumber,
-    description,
-    cpu,
-    memory,
-    image,
-    type
-  ) {
+  createCRDtemplate(namespace, description, cpu, memory, image, type) {
+    const { templateLabsAdmin } = this.state;
+    const currentLabNums = templateLabsAdmin
+      .get(namespace)
+      .map(({ labNum }) => Number(labNum));
+    let newLabNum = 1;
+    // create a new unique labNum based on the current ones
+    while (currentLabNums.includes(newLabNum)) newLabNum += 1;
     this.apiManager
       .createCRDtemplate(
         namespace,
-        labNumber,
+        newLabNum,
         description,
         cpu,
         memory,

--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -67,7 +67,8 @@ export default class ApiManager {
         nodesResponse.body.items.map(x => ({
           name: x.metadata.name,
           description: x.spec.description,
-          type: x.spec.vmType
+          type: x.spec.vmType,
+          labNum: x.spec.labNum
         }))
       )
       .catch(error => {

--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -209,8 +209,8 @@ export default class ApiManager {
                 },
                 memory: { guest: `${memory}G` },
                 resources: {
-                  limits: { cpu: `${cpu + 1}`, memory: `${memory + 1}G` },
-                  requests: { cpu: `${cpu}`, memory: `${memory}G` }
+                  limits: { cpu: `${cpu + 0.5}`, memory: `${memory + 0.5}G` },
+                  requests: { cpu: `${cpu * 0.5}`, memory: `${memory}G` }
                 }
               },
               volumes: [

--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -258,21 +258,4 @@ export default class ApiManager {
       }
     );
   }
-
-  /**
-   * @@@@ UNUSED (since watcher has been patched and works)
-   * Function to get a specific lab instance status
-   *
-   * @param name the name of the lab instance
-   * @returns the promise handling the request
-   */
-  getCRDstatus(name) {
-    return this.apiCRD.getNamespacedCustomObjectStatus(
-      this.instanceGroup,
-      this.version,
-      this.instanceNamespace,
-      this.instancePlural,
-      name
-    );
-  }
 }


### PR DESCRIPTION
# Description

This PR includes:
- added visual discrimination between VM type in the lists
- added possibility to create new template with custom description and type
- removed `labId` field from the newTemplateForm and made it self-generated, it was a bit confusing
- added template name to GUI, to make it more reachable with kubectl
- change parameters when creating new templates to make it same as python scripts
- fix visualization of creation date and labcode in instance view

This PR will remain in draft till the operator can create CLI only VMs, just to be sure that everything will work correctly

# How Has This Been Tested?

This has been tested by checking that all the required GUI functionalities work

- view templates and instances running
- start an instance
- connect to an instance
- stop an instance
- create a template
- delete a template