### PR TITLE
Labinstance operator: add support for CLI VMs

### DIFF
--- a/operators/labInstance-operator/Dockerfile
+++ b/operators/labInstance-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 COPY . /go/src/github.com/netgroup-polito/CrownLabs/operators/labInstance-operator
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/netgroup-polito/CrownLabs/operators/labInstance-opera
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o controller .
 RUN cp controller /usr/bin/controller
 
-FROM broady/cacerts
+FROM busybox
 COPY --from=builder /usr/bin/controller /usr/bin/controller
 USER 20000:20000
 ENTRYPOINT [ "/usr/bin/controller" ]

--- a/operators/labInstance-operator/go.sum
+++ b/operators/labInstance-operator/go.sum
@@ -381,6 +381,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783 h1:V6ndwCPoao1
 k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae1SZB3E17UpV59AWc271W/Ph25N+bjPyR63X6tPY=
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655 h1:CS1tBQz3HOXiseWZu6ZicKX361CZLT97UFnnPx0aqBw=
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90 h1:mLmhKUm1X+pXu0zXMEzNsOF5E2kKFGe5o6BZBIIqA6A=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53q3Uz5OSfgsv4uxpScmmyYOOlk=

--- a/operators/labInstance-operator/pkg/instanceCreation/creation.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation.go
@@ -81,7 +81,7 @@ func CreateService(name string, namespace string) corev1.Service {
 					Name:       "ssh",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       22,
-					TargetPort: intstr.IntOrString{IntVal: 6081},
+					TargetPort: intstr.IntOrString{IntVal: 22},
 				},
 			},
 			Selector:  map[string]string{"name": name},


### PR DESCRIPTION
# Description

This PR modifies the labinstance operator to add the support for CLI only VMs (i.e. detect when they are running).

### Additional modifications
* Changed the base docker image to `busybox`, for easier debugging
* Uniformed the name of the resources created by the operator (i.e. equal to the labinstance name)

# How Has This Been Tested?

Deploying the operator and verifying the correct functioning (both with GUI and CLI VMs).