### PR TITLE
Fix check to show switch view button only when admin

### DIFF
--- a/webservice/src/components/Header.jsx
+++ b/webservice/src/components/Header.jsx
@@ -40,8 +40,10 @@ export default function Header(props) {
     name,
     logout,
     setIsLightTheme,
-    isLightTheme
+    isLightTheme,
+    isAlsoAdmin
   } = props;
+
   return (
     <div className={classes.header}>
       <AppBar position="static" color="primary">
@@ -74,11 +76,19 @@ export default function Header(props) {
               </IconButton>
             </Tooltip>
           </a>
-          <Tooltip title="Switch professor/student view">
-            <IconButton onClick={switchAdminView} color="secondary">
-              {isStudentView ? <ProfIcon /> : <HomeIcon />}
-            </IconButton>
-          </Tooltip>
+          {isAlsoAdmin && (
+            <Tooltip
+              title={
+                isStudentView
+                  ? 'Switch to professor view'
+                  : 'Switch to student view'
+              }
+            >
+              <IconButton onClick={switchAdminView} color="secondary">
+                {isStudentView ? <ProfIcon /> : <HomeIcon />}
+              </IconButton>
+            </Tooltip>
+          )}
           <Tooltip title="Toggle light/dark theme">
             <IconButton
               color="secondary"

--- a/webservice/src/components/Main.jsx
+++ b/webservice/src/components/Main.jsx
@@ -64,6 +64,7 @@ const Main = props => {
           switchAdminView={changeAdminView}
           isLightTheme={isLightTheme}
           setIsLightTheme={setIsLightTheme}
+          isAlsoAdmin={adminGroups.length > 0}
         />
         <Body
           retrieveImageList={imageList}


### PR DESCRIPTION
# Description

This PR fixes a bug inserted by an [old PR](https://github.com/netgroup-polito/CrownLabs/pull/311/files#diff-87b3e833f5d97db4731f5f31c506c92eL85) of mine. Don't know why but I removed the check to show the *switch view button* only when the user is also admin.

I also changed to tooltip text depending on the current view


# How Has This Been Tested?

It has been tested by logging with 2 different users and checking the presence of the button.