### PR TITLE
Uniforming ordering controls in GUI lists

### DIFF
--- a/webservice/src/components/RunningLabList.jsx
+++ b/webservice/src/components/RunningLabList.jsx
@@ -104,7 +104,7 @@ const adminSelectors = [
   }
 ];
 
-const ALL_VM_TYPES = '';
+export const ALL_VM_TYPES = '';
 export const vmTypeSelectors = [
   { text: 'All', icon: <AllIcon />, value: ALL_VM_TYPES },
   { text: 'GUI enabled', icon: <DesktopIcon />, value: vmTypes.GUI },
@@ -132,7 +132,10 @@ const RunningLabList = props => {
   });
 
   useEffect(() => {
-    localStorage.setItem(`orderData-${title}`, JSON.stringify(orderData));
+    localStorage.setItem(
+      `orderData-${title}-${isStudentView}`,
+      JSON.stringify(orderData)
+    );
   }, [orderData]);
 
   useEffect(() => {
@@ -151,17 +154,17 @@ const RunningLabList = props => {
           <ListSubheader className={classes.listSubHeader}>
             <div>{title}</div>
             <div className={classes.titleActions}>
-              <Selector
-                selectors={vmTypeSelectors}
-                value={vmType}
-                setValue={setVmType}
-              />
               <OrderSelector
                 selectors={isStudentView ? studentSelectors : adminSelectors}
                 setOrderData={setOrderData}
                 orderData={orderData}
               />
               <TextSelector value={textMatch} setValue={setTextMatch} />
+              <Selector
+                selectors={vmTypeSelectors}
+                value={vmType}
+                setValue={setVmType}
+              />
             </div>
           </ListSubheader>
         }
@@ -232,6 +235,7 @@ const RunningLabList = props => {
                   key={labName}
                   button
                   selected={selectedIndex === i}
+                  disableRipple
                   onClick={() => {
                     setSelectedIndex(i);
                   }}

--- a/webservice/src/components/StudentView.jsx
+++ b/webservice/src/components/StudentView.jsx
@@ -19,7 +19,7 @@ export default function StudentView(props) {
   const { templateLabs, start, instanceLabs, connect, stop } = props;
   return (
     <div className={classes.labPapers}>
-      <LabTemplatesList labs={templateLabs} start={start} />
+      <LabTemplatesList labs={templateLabs} start={start} isStudentView />
       <LabInstancesList
         runningLabs={instanceLabs}
         connect={connect}


### PR DESCRIPTION
# Description

This PR includes:
- little fix in UX: the list Vm instances didn't actually remember the user's last choice due to a misalignment in the local storage key name
- added filtering based on VM type in template list, can be useful for uses who have access to multiple templates

*Note: this changes will make the transformation into a single list component (which will be duplicated through props) much easier*

# How Has This Been Tested?

This PR has been tested by checking that the order remains when reloading the page. It has been also checked that the changing of the order in the student view does not affect the one in the prof view
