### PR TITLE
Fix errors in the GitHub pipelines

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,3 @@
-automerge:
-  - '**'
-  - '.*'
-  - '.*/**'
-
 sig-api:
   - operators/**/*
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,22 +1,8 @@
-name: Automerge
+name: Merge the current PR
 on:
-  pull_request_target:
+  repository_dispatch:
     types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  status: {}
+      - merge-command
 
 jobs:
   automerge:
@@ -28,9 +14,8 @@ jobs:
         uses: pascalgn/automerge-action@v0.12.0
         env:
           GITHUB_TOKEN: "${{ secrets.CI_TOKEN }}"
-          MERGE_LABELS: "automerge,!hold"
-          MERGE_REMOVE_LABELS: "automerge"
+          MERGE_LABELS: "!hold"
           MERGE_METHOD: "merge"
-          MERGE_RETRY_SLEEP: "10000"  # 10 seconds
-          UPDATE_LABELS: "automerge,!hold"
+          MERGE_RETRY_SLEEP: "30000"  # 30 seconds
+          UPDATE_LABELS: "!hold"
           UPDATE_METHOD: "rebase"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,17 +23,18 @@ jobs:
         id: configure
         run: |
           # The ref of the commit to checkout (do not use the merge commit if pull request)
-          [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && \
+          [[ "${{ github.event_name }}" == "pull_request" ]] && \
             echo "::set-output name=ref::${{ github.event.pull_request.head.sha }}" || \
             echo "::set-output name=ref::${{ github.sha }}"
 
           # The suffix to append to the repository name
-          [[ "${{ github.ref }}" == 'refs/heads/master' ]] && \
+          [[ "${{ github.ref }}" == "refs/heads/master" ]] && \
             echo "::set-output name=repo-suffix::" || \
             echo "::set-output name=repo-suffix::-dev"
 
-          # Whether to push the resulting image to DockerHub
-          [[ "${{ github.event.repository.full_name }}" == 'netgroup-polito/CrownLabs' ]] && \
+          # Do not push the resulting images to DockerHub if the pull request is from a fork
+          [[ "${{ github.event_name }}" != "pull_request" || \
+             "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] && \
             echo "::set-output name=repo-push::true" || \
             echo "::set-output name=repo-push::false"
 
@@ -63,7 +64,7 @@ jobs:
       - name: Set the Docker repository name
         id: repo-name
         run: |
-          echo "::set-output name=repo-name::website${{ needs.configure.outputs.repo-suffix }}"
+          echo "::set-output name=repo-name::frontend${{ needs.configure.outputs.repo-suffix }}"
 
       - name: Build and Push the Frontend image
         uses: docker/build-push-action@v2
@@ -122,7 +123,8 @@ jobs:
       - frontend
       - laboratory-operator
     if: |
-      github.event.repository.full_name == 'netgroup-polito/CrownLabs' &&
+      github.event_name == 'push' &&
+      github.event.repository.full_name == github.repository &&
       github.ref == 'refs/heads/master'
 
     steps:
@@ -142,4 +144,4 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
           repository: netgroup-polito/CrownOps
           event-type: preprod-event
-          client_payload: '{"tag": "${{ needs.configure.outputs.ref }}"}'
+          client-payload: '{"tag": "${{ needs.configure.outputs.ref }}"}'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,16 +1,13 @@
 name: Rebase
 on:
-  issue_comment:
+  repository_dispatch:
     types:
-      - created
+      - rebase-command
 
 jobs:
   rebase:
     name: Rebase
     runs-on: ubuntu-latest
-    if: |
-      github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/rebase')
 
     steps:
       - name: Checkout
@@ -31,19 +28,10 @@ jobs:
             echo ::set-output name=reaction::confused
         if: always()
 
-      - name: Report status as comment
+      - name: Report status as reaction
         uses: peter-evans/create-or-update-comment@v1
         with:
           token: ${{ secrets.CI_TOKEN }}
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            Rebase status: ${{ job.status }}!
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
           reactions: '${{ steps.rebase_reaction.outputs.reaction }}'
         if: always()
-
-  always_job:
-    name: Always run job
-    runs-on: ubuntu-latest
-    steps:
-      - name: Always run
-        run: echo "This job is used to prevent the workflow to fail when all other jobs are skipped."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,4 +85,5 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
           repository: netgroup-polito/CrownOps
           event-type: release-event
-          client_payload: '{"version": "${{ steps.version.outputs.version }}"}'
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -1,0 +1,22 @@
+name: Dispatch Slash Commands
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  dispatch:
+    name: Dispatch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch Slash Commands
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          reaction-token: ${{ secrets.CI_TOKEN }}
+          issue-type: pull-request
+          permission: write
+          commands: |
+            merge
+            rebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,4 +22,6 @@ When creating PRs and issues follow the repo's guidelines. Use meaningful messag
 
 ## PR merging guidelines
 
-An important note on our PR management. We use a bot to perform merges into master so there is no need to do it yourself. Once a PR with the *automerge* label (added by default to every PR) has 2 approving reviews and all check are successful, it will be automatically merged into master. In case this behavior is not desired, just remove the *automerge* label or override it with the *hold* label. If your PR is behind master and it fails to merge, **don't** use the GitHub button to merge the current master in your PR. Instead, perform a rebase on your local machine or add a `/rebase` line to your PR description or in a follow-up comment, this will force the bot to do the rebase for you (if no conflicts are present).
+Before a PR can be merged to the master branch, two approving reviews and all successful checks are required. Then, once a PR is ready to be merged, this action can be performed by any contributor with write access to the repository, either manually or issuing a `/merge` comment to the PR itself.
+
+If your PR is behind master and it fails to merge, **don't** use the GitHub button to merge the current master in your PR. Instead, perform a rebase on your local machine or issue a `/rebase` comment to the PR itself. This will force the bot to do the rebase for you (if no conflicts are present).


### PR DESCRIPTION
# Description

This PR fixes a couple of issues introduced by #315.

Additionally:
* It introduces the slash command dispatcher (that will be also used to trigger the event required to deploy the testing environment upon an `/ok-to-deploy` comment)
* It disables the automerge functionality, as it used to have some strange behaviors and it breaks in case of forks. Now, contributors with write access to the repo can still trigger an automerge by issuing a '/merge' comment
