### PR TITLE
GitHub Actions: Create release (and changelog) upon tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release a new CrownLabs version
 on:
   push:
     tags:
-      - '**'
+      - 'v*'
 
 jobs:
   release:
@@ -15,9 +15,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get the CrownLabs version
+      - name: Get the CrownLabs version to be released
         id: version
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+
+      - name: Get the latest CrownLabs release
+        uses: pozetroninc/github-action-get-latest-release@v0.5.0
+        id: last-release
+        with:
+          repository: ${{ github.repository }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -49,6 +55,29 @@ jobs:
           push: true
           file: ./operators/labInstance-operator/Dockerfile
           context: ./operators/labInstance-operator/
+
+      - name: Generate the CHANGELOG
+        uses: RiskLedger/generate-changelog@v1.2
+        id: changelog
+        with:
+          from: ${{ steps.last-release.outputs.release }}
+          to: ${{ steps.version.outputs.version }}
+        env:
+          GITHUB_AUTH: ${{ secrets.CI_TOKEN }}
+
+      - name: Save the CHANGELOG as a file
+        run: |
+          echo "${{ steps.changelog.outputs.changelog }}" > ./CHANGELOG.md
+          sed -i "1s/.*/## Changes since ${{ steps.last-release.outputs.release }}/" ./CHANGELOG.md
+
+      - name: Create the release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          release_name: Release ${{ steps.version.outputs.version }}
+          body_path: ./CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
 
       - name: Notify Event to CrownOps
         uses: peter-evans/repository-dispatch@v1

--- a/lerna.json
+++ b/lerna.json
@@ -1,0 +1,8 @@
+{
+  "changelog": {
+    "repo": "netgroup-polito/CrownLabs",
+    "ignoreCommitters": [
+      "kingmakerbot"
+    ]
+  }
+}


### PR DESCRIPTION
# Description

This PR updates the release pipeline in order to create an actual GitHub release upon the push of a tag. The CHANGELOG is automatically generated based on the list of PRs that have been merged since the last release (and their labels) using [lerna-changelog](https://github.com/lerna/lerna-changelog).

**NOTE:** before going on with this PR, it is necessary to agree on the labeling style, in order to distinguish between different types of PRs. A solution may be to adopt (a subset of) the ones used by kubernetes:
```
kind/api-change
kind/bug
kind/cleanup
kind/deprecation
kind/design
kind/documentation
kind/feature
kind/flake
``` 

As an example, the CHANGELOG for the current release would be (different PRs may not be correctly labeled and do not show up):

## Changes since v0.7.0

#### :rocket: Enhancement
* [#312](https://github.com/netgroup-polito/CrownLabs/pull/312) Added visual discrimination between dekstop and CLI VMs ([@GabriFila](https://github.com/GabriFila))

#### :bug: Bug Fix
* [#317](https://github.com/netgroup-polito/CrownLabs/pull/317) Uniforming ordering controls in GUI lists ([@GabriFila](https://github.com/GabriFila))
* [#314](https://github.com/netgroup-polito/CrownLabs/pull/314) Fix check to show switch view button only when admin ([@GabriFila](https://github.com/GabriFila))

#### Committers: 3
- Gabriele Filaferro ([@GabriFila](https://github.com/GabriFila))
- Marco Iorio ([@giorio94](https://github.com/giorio94))
- Mattia Lavacca ([@mlavacca](https://github.com/mlavacca))