### PR TITLE
Fix the rebase pipeline

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -14,9 +14,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Automatic rebase
-        uses: cirrus-actions/rebase@1.3
+        uses: giorio94/rebase@1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN }}
 

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -16,7 +16,14 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
           reaction-token: ${{ secrets.CI_TOKEN }}
           issue-type: pull-request
-          permission: write
-          commands: |
-            merge
-            rebase
+          config: >
+            [
+              {
+                "command": "merge",
+                "permission": "write"
+              },
+              {
+                "command": "rebase",
+                "permission": "none"
+              }
+            ]


### PR DESCRIPTION
# Description

This PR fixes the rebase pipeline:
* Uses a forked version of the action, which supports repository dispatches
* Extends the permissions to trigger the action to everyone, in order to avoid problems with forks

# How Has This Been Tested?

Tested on a personal repository. It seemed to work correctly
