### PR TITLE
Labinstance operator: refactor cloud-init userdata generation.

### DIFF
--- a/operators/labInstance-operator/go.mod
+++ b/operators/labInstance-operator/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
+	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 	k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
@@ -21,4 +22,3 @@ require (
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1
 	sigs.k8s.io/controller-runtime v0.4.0
 )
-

--- a/operators/labInstance-operator/pkg/instanceCreation/creation.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	virtv1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/kubeVirt/api/v1"
 	templatev1alpha1 "github.com/netgroup-polito/CrownLabs/operators/labInstance-operator/labTemplate/api/v1alpha1"
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +36,50 @@ func CreateVirtualMachineInstance(name string, namespace string, template templa
 	return vm
 }
 
+type writeFile struct {
+	Content     string `yaml:"content"`
+	Path        string `yaml:"path"`
+	Permissions string `yaml:"permissions"`
+}
+type cloudInitConfig struct {
+	Network struct {
+		Version int         `yaml:"version"`
+		ID0     interface{} `yaml:"id0"`
+		Dhcp4   bool        `yaml:"dhcp4"`
+	} `yaml:"network"`
+	Mounts     [][]string  `yaml:"mounts"`
+	WriteFiles []writeFile `yaml:"write_files"`
+}
+
+func createUserdata(nextUsername string, nextPassword string, nextCloudBaseUrl string) map[string]string {
+	var Userdata cloudInitConfig
+
+	Userdata.Network.Version = 2
+	Userdata.Network.Dhcp4 = true
+	Userdata.Mounts = [][]string{{
+		nextCloudBaseUrl + "/remote.php/dav/files/" + nextUsername,
+		"/media/MyDrive",
+		"davfs",
+		"_netdev,auto,user,rw,uid=1000,gid=1000",
+		"0",
+		"0"},
+	// New mounts should be added here as []string
+	}
+	Userdata.WriteFiles = []writeFile{{
+		Content:     "/media/MyDrive " + nextUsername + " " + nextPassword,
+		Path:        "/etc/davfs2/secrets",
+		Permissions: "0600",
+	},
+	// New mounts should be added here as []string
+	}
+
+	out, _ := yaml.Marshal(Userdata)
+
+	headerComment := "#cloud-init\n"
+
+	return map[string]string{"userdata": headerComment + string(out)}
+}
+
 func CreateSecret(name string, namespace string, nextUsername string, nextPassword string, nextCloudBaseUrl string) corev1.Secret {
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -42,20 +87,10 @@ func CreateSecret(name string, namespace string, nextUsername string, nextPasswo
 			Namespace: namespace,
 		},
 		Data: nil,
-		StringData: map[string]string{"userdata": `
-#cloud-config
-network:
-  version: 2
-  id0:
-    dhcp4: true
-mounts:
-  - [ "` + nextCloudBaseUrl + `/remote.php/dav/files/` + nextUsername + `", "/media/MyDrive", "davfs", "_netdev,auto,user,rw,uid=1000,gid=1000","0","0" ]
-write_files:
-  - content: |
-      /media/MyDrive ` + nextUsername + " " + nextPassword + `
-    path: /etc/davfs2/secrets
-    permissions: '0600'
-`},
+		StringData: createUserdata(
+			nextUsername,
+			nextPassword,
+			nextCloudBaseUrl),
 		Type: corev1.SecretTypeOpaque,
 	}
 

--- a/operators/labInstance-operator/pkg/instanceCreation/creation.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation.go
@@ -68,14 +68,13 @@ func createUserdata(nextUsername string, nextPassword string, nextCloudBaseUrl s
 	Userdata.WriteFiles = []writeFile{{
 		Content:     "/media/MyDrive " + nextUsername + " " + nextPassword,
 		Path:        "/etc/davfs2/secrets",
-		Permissions: "0600",
-	},
-	// New mounts should be added here as []string
+		Permissions: "0600"},
+	// New write_files should be added here as []writeFile
 	}
 
 	out, _ := yaml.Marshal(Userdata)
 
-	headerComment := "#cloud-init\n"
+	headerComment := "#cloud-config\n"
 
 	return map[string]string{"userdata": headerComment + string(out)}
 }

--- a/operators/labInstance-operator/pkg/instanceCreation/creation_test.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation_test.go
@@ -1,10 +1,13 @@
 package instanceCreation
 
 import (
+	"strings"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 var ns1 = v1.Namespace{
@@ -40,4 +43,38 @@ func TestWhitelist(t *testing.T) {
 	c2 := CheckLabels(ns2, labels)
 	assert.Equal(t, c1, true, "The two label set should be identical and return true.")
 	assert.Equal(t, c2, false, "The two labels set should be different and return false.")
+}
+
+func TestCreateUserData(t *testing.T) {
+	var (
+		nextUsername     = "usertest"
+		nextPassword     = "passtest"
+		nextCloudBaseUrl = "nextcloud.url"
+	)
+
+	rawConfig := createUserdata(nextUsername, nextPassword, nextCloudBaseUrl)
+
+	var config cloudInitConfig
+
+	err := yaml.Unmarshal([]byte(rawConfig["userdata"]), &config)
+
+	assert.Equal(t, err, nil, "Yaml parser should return nil error.")
+
+	// check if header comment is present
+	hc := strings.HasPrefix(rawConfig["userdata"], "#cloud-init\n")
+
+	var (
+		expectedmount       = []string{nextCloudBaseUrl + "/remote.php/dav/files/" + nextUsername, "/media/MyDrive", "davfs", "_netdev,auto,user,rw,uid=1000,gid=1000", "0", "0"}
+		expectedcontent     = "/media/MyDrive " + nextUsername + " " + nextPassword
+		expectedpath        = "/etc/davfs2/secrets"
+		expectedpermissions = "0600"
+	)
+
+	assert.Equal(t, hc, true, "Cloud-init head comment should be present.")
+	assert.Equal(t, config.Network.Version, 2, "Network version should be set to 2.")
+	assert.Equal(t, config.Network.Dhcp4, true, "DHCPv4 should be set to true.")
+	assert.Equal(t, config.Mounts[0], expectedmount, "Nextcloud mount should be set to "+strings.Join(expectedmount, ", ")+".")
+	assert.Equal(t, config.WriteFiles[0].Content, expectedcontent, "Nextcloud secret should be se to "+expectedcontent+" .")
+	assert.Equal(t, config.WriteFiles[0].Path, expectedpath, "Nextcloud secret path should be set to "+expectedpath+".")
+	assert.Equal(t, config.WriteFiles[0].Permissions, expectedpermissions, "Nextcloud secret permissions should be set to "+expectedpermissions+" .")
 }

--- a/operators/labInstance-operator/pkg/instanceCreation/creation_test.go
+++ b/operators/labInstance-operator/pkg/instanceCreation/creation_test.go
@@ -61,7 +61,7 @@ func TestCreateUserData(t *testing.T) {
 	assert.Equal(t, err, nil, "Yaml parser should return nil error.")
 
 	// check if header comment is present
-	hc := strings.HasPrefix(rawConfig["userdata"], "#cloud-init\n")
+	hc := strings.HasPrefix(rawConfig["userdata"], "#cloud-config\n")
 
 	var (
 		expectedmount       = []string{nextCloudBaseUrl + "/remote.php/dav/files/" + nextUsername, "/media/MyDrive", "davfs", "_netdev,auto,user,rw,uid=1000,gid=1000", "0", "0"}


### PR DESCRIPTION
# Description
This PR refactors the creation of the user-data configuration for cloud-init, to its own method `createUserdata`. A standard yaml parser has been used as well as some new types needed to parse the configuration.
It also bring the unit test that checks that the string generated is a valid yaml and that the parameters corresponds with the expected output.

# How Has This Been Tested?

Unit test
