### PR TITLE
Github Actions: fix "suffix" bug in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,16 +33,15 @@ jobs:
               echo "::set-output name=ref::${{ github.sha }}"
             }
 
-          # The suffix to append to the repository name
-          [[ "${{ github.ref }}" == "refs/heads/master" ]] && \
+          # The suffix to append to the repository name if not triggered by a push to master
+          [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]] && \
             echo "::set-output name=repo-suffix::" || \
             echo "::set-output name=repo-suffix::-dev"
 
-          # Do not push the resulting images to DockerHub if the pull request is from a fork
-          [[ "${{ github.event_name }}" != "pull_request" || \
-             "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]] && \
-            echo "::set-output name=repo-push::true" || \
-            echo "::set-output name=repo-push::false"
+          # Do not push the resulting images to DockerHub if triggered by a pull request
+          [[ "${{ github.event_name }}" == "pull_request" ]] && \
+            echo "::set-output name=repo-push::false" || \
+            echo "::set-output name=repo-push::true"
 
 
   frontend:


### PR DESCRIPTION
# Description

This PR fixes a bug in the `build.yml` github action, which prevented the image suffix from being correctly configured when triggered by a repository dispatch. Additionally, it disables the push of the images to dockerhub when not necessary to avoid polluting the repository.