### PR TITLE
lab-operator: fix bugs in the k8s manifest

### DIFF
--- a/operators/deploy/laboratory-operator/k8s-manifest.yaml.tmpl
+++ b/operators/deploy/laboratory-operator/k8s-manifest.yaml.tmpl
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ${NAMESPACE_LABOPERATOR}
+  labels:
+    access-vm: allowed
 
 ---
 kind: ConfigMap
@@ -74,7 +76,7 @@ spec:
           privileged: false
         resources:
           limits:
-            memory: 100Mi
+            memory: 250Mi
             cpu: 100m
           requests:
             memory: 100Mi


### PR DESCRIPTION
# Description

This PR fixes a couple of problems related to the k8s manifest of the lab-operator:
* Adds a missing label to allow contacting the VMs from the operator
* Increases the memory limits, to prevent the operator from being   OOMkilled when started and many VMs are already present
* ~~Removes the readOnly protection, which caused the pod to crash due to  the logger trying to write files upon error~~ (keeping for now, as required by the kubescore checks)