### PR TITLE
VM Provisioning: explicit Docker MTU for k8s

### DIFF
--- a/provisioning/virtual-machines/ansible/roles/kubernetes/files/daemon.json
+++ b/provisioning/virtual-machines/ansible/roles/kubernetes/files/daemon.json
@@ -4,5 +4,6 @@
     "log-opts": {
       "max-size": "100m"
     },
+    "mtu": 1440,
     "storage-driver": "overlay2"
 }


### PR DESCRIPTION
# Description

This PR explicitly sets the Docker MTU in the k8s role. This is necessary since the MTU in CrownLabs is lower than 1500 and Docker does not detect it automatically. The MTU is explicitly not configured for the Docker lab, in order to show how to solve this problem during the lab itself.
