### PR TITLE
Improve the CrownLabs Ansible role for VM provisioning

### DIFF
--- a/provisioning/virtual-machines/ansible/roles/crownlabs/handlers/main.yml
+++ b/provisioning/virtual-machines/ansible/roles/crownlabs/handlers/main.yml
@@ -1,2 +1,7 @@
 - name: Run update-grub
   command: update-grub
+
+- name: Restart the timesyncd service
+  systemd:
+    name: systemd-timesyncd
+    state: restarted

--- a/provisioning/virtual-machines/ansible/roles/crownlabs/tasks/main.yml
+++ b/provisioning/virtual-machines/ansible/roles/crownlabs/tasks/main.yml
@@ -1,6 +1,14 @@
 ---
 # tasks file for crownlabs
 
+# The default time server is blocked by the firewall
+- name: Configure timesyncd
+  replace:
+    path: /etc/systemd/timesyncd.conf
+    regexp: '^(^#NTP=)$'
+    replace: 'NTP=time.polito.it'
+  notify: Restart the timesyncd service
+
 # Cloud Init Configuration
 - name: Install cloud-init
   apt:
@@ -102,6 +110,18 @@
     enabled: yes
     daemon_reload: yes
   when: desktop_environment_detected
+
+- name: Allow to start graphical applications as root
+  lineinfile:
+    path: "/home/{{ ansible_user }}/.bashrc"
+    line: export XAUTHORITY=~/.Xauthority
+    state: present
+
+- name: Prevent the appearance of an authorization popup due to vnc and polkit
+  replace:
+    path: /usr/share/polkit-1/actions/org.freedesktop.color.policy
+    regexp: '<allow_any>auth_admin<\/allow_any>'
+    replace: '<allow_any>yes</allow_any>'
 
 
 # NoVNC Configuration

--- a/provisioning/virtual-machines/ansible/roles/crownlabs/templates/vncserver.service
+++ b/provisioning/virtual-machines/ansible/roles/crownlabs/templates/vncserver.service
@@ -6,6 +6,7 @@ After=syslog.target network-online.target
 Type=forking
 User={{ ansible_user }}
 Group={{ ansible_user }}
+PAMName=login
 WorkingDirectory=/home/{{ ansible_user }}
 ExecStartPre=/bin/sh -c '/usr/bin/vncserver -kill %i > /dev/null 2>&1 || :'
 ExecStart=/usr/bin/vncserver %i -SecurityTypes None -localhost


### PR DESCRIPTION
# Description

Minor changes to the CrownLabs Ansible role to improve the VM creation:
* Use the correct time server
* Enable polkit (authorization manager) also in the VNC session
* Allow to run graphical applications as root if needed