### PR TITLE
Fix the code testing and linting pipelines

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Check linting
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -15,6 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Check linting
@@ -33,6 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Check linting
@@ -50,6 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup nodeJS
@@ -74,6 +80,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Check the validity of the links in the documentation
@@ -90,6 +98,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Run shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
@@ -44,6 +46,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Setup Go
@@ -106,6 +110,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           persist-credentials: false
 
       - name: Load the example configuration


### PR DESCRIPTION
# Description

This PR fixes a bug introduced in #351. Specifically, since the pipeline was changed to run on the `pull_request_target` event, the checkout action started getting the master branch instead of the last commit of the PR.

Additionally, it also changes the linting pipeline to use pull_request_target (as it requires the PAT) and applies the same modifications.
