### PR TITLE
Fix a typo in the templates API

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -45,8 +45,8 @@ type TemplateStatus struct {
 
 type Environment struct {
 	Name string `json:"name,omitempty"`
-	// +kubebuilder:default="7d"
-	GuiEnabled bool                 `json:"labType,omitempty"`
+	// +kubebuilder:default=true
+	GuiEnabled bool                 `json:"guiEnabled,omitempty"`
 	Resources  EnvironmentResources `json:"resources"`
 	// +kubebuilder:validation:Enum="VirtualMachine";"Container"
 	EnvironmentType EnvironmentType `json:"environmentType"`

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -48,11 +48,11 @@ spec:
                       - VirtualMachine
                       - Container
                       type: string
+                    guiEnabled:
+                      default: true
+                      type: boolean
                     image:
                       type: string
-                    labType:
-                      default: 7d
-                      type: boolean
                     name:
                       type: string
                     persistent:


### PR DESCRIPTION
# Description
This PR fixes a typo introduced in #347, which prevented the validation of the `template` CRD.

# How Has This Been Tested?

Applying the newly generated CRD in the CrownLabs cluster