### PR TITLE
Fix vm generation to avoid 10000 vmID

### DIFF
--- a/webservice/src/services/ApiManager.js
+++ b/webservice/src/services/ApiManager.js
@@ -11,6 +11,13 @@ export const VM_STATUS = {
   ERROR: -1
 };
 
+function getRandomInt(min, max) {
+  const ceiledMin = Math.ceil(min);
+  const flooredMax = Math.floor(max);
+  // min is included, max is excluded
+  return Math.floor(Math.random() * (flooredMax - ceiledMin)) + ceiledMin;
+}
+
 /**
  * Class to manage all the interaction with the cluster
  *
@@ -114,9 +121,9 @@ export default class ApiManager {
         apiVersion: `${this.instanceGroup}/${this.version}`,
         kind: 'LabInstance',
         metadata: {
-          name: `${labTemplateName}-${this.studentID}-${
-            Math.floor(Math.random() * 10000) + 1
-          }`,
+          name: `${labTemplateName}-${this.studentID}-${Math.floor(
+            getRandomInt(1000, 10000)
+          )}`,
           namespace: this.instanceNamespace
         },
         spec: {


### PR DESCRIPTION
# Description

This PR includes a fix for the generation of the VMid. In case the id is 10000 the dashboard will crash since [this](https://github.com/netgroup-polito/CrownLabs/blob/a2b3c249ce7f1e5e1b3267fc61425f4e30a0c4cf/webservice/src/components/RunningLabList.jsx#L86) regex looks for 4 digits at maximum. Now the client will create VMs with an ID between 1000 and 9999

# How Has This Been Tested?

This has been tested by checking the normal creation of VMs
