### PR TITLE
Fix and improve workspace controller

### DIFF
--- a/operators/api/v1alpha1/common_types.go
+++ b/operators/api/v1alpha1/common_types.go
@@ -7,14 +7,12 @@ type NameCreated struct {
 }
 
 // SubscriptionStatus is an enum for the status of a subscription to a service
-// +kubebuilder:validation:Enum=Ok;Pending;Failed
+// +kubebuilder:validation:Enum=Ok;Failed
 type SubscriptionStatus string
 
 const (
 	// SubscrOk -> the subscription was successful
 	SubscrOk SubscriptionStatus = "Ok"
-	// SubscrPending -> the subscription is in process
-	SubscrPending SubscriptionStatus = "Pending"
 	// SubscrFailed -> the subscription has failed
 	SubscrFailed SubscriptionStatus = "Failed"
 )

--- a/operators/build/tenant-operator/Dockerfile
+++ b/operators/build/tenant-operator/Dockerfile
@@ -1,3 +1,6 @@
+FROM alpine as certs
+RUN apk update && apk add ca-certificates
+
 # Build the manager binary
 FROM golang:1.15 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
@@ -8,6 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o controller ./cmd/tenant-op
 RUN cp controller /usr/bin/controller
 
 FROM busybox
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /usr/bin/controller /usr/bin/controller
 USER 20000:20000
 ENTRYPOINT [ "/usr/bin/controller" ]

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -117,7 +117,6 @@ spec:
                   description: SubscriptionStatus is an enum for the status of a subscription to a service
                   enum:
                   - Ok
-                  - Pending
                   - Failed
                   type: string
                 type: object

--- a/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
@@ -59,7 +59,6 @@ spec:
                   description: SubscriptionStatus is an enum for the status of a subscription to a service
                   enum:
                   - Ok
-                  - Pending
                   - Failed
                   type: string
                 type: object

--- a/operators/deploy/tenant-operator/k8s-manifest-example.env
+++ b/operators/deploy/tenant-operator/k8s-manifest-example.env
@@ -1,9 +1,12 @@
+# k8s deployment related
+NAMESPACE_TENANT_OPERATOR="crownlabs-tenant-operator"
+
 # Docker image related
 IMAGE_TAG=v1
 IMAGE_SUFFIX=""
 
 # keycloak related
-KEYCLOAK_URL="auth.crownlabs.polito.it/auth"
+KEYCLOAK_URL="https://auth.crownlabs.polito.it/"
 KEYCLOAK_LOGIN_REALM="master"
 KEYCLOAK_TARGET_REALM="testing"
 KEYCLOAK_TARGET_CLIENT="k8s"

--- a/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
+++ b/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
@@ -1,8 +1,15 @@
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${NAMESPACE_TENANT_OPERATOR}
+
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: tenant-operator-config
+  namespace: ${NAMESPACE_TENANT_OPERATOR}
 data:
   keycloakURL: ${KEYCLOAK_URL}
   keycloakLoginRealm: ${KEYCLOAK_LOGIN_REALM}
@@ -14,6 +21,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: tenant-operator-secret
+  namespace: ${NAMESPACE_TENANT_OPERATOR}
 type: Opaque
 stringData:
   keycloakTenantOperatorUser: ${KEYCLOAK_TENANT_OPERATOR_USER}
@@ -24,12 +32,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tenant-operator
+  namespace: ${NAMESPACE_TENANT_OPERATOR}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: crowlabs-tenant-operator
+  name: crownlabs-tenant-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -37,6 +46,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: tenant-operator
+    namespace: ${NAMESPACE_TENANT_OPERATOR}
 
 ---
 apiVersion: apps/v1
@@ -47,6 +57,7 @@ metadata:
   labels:
     run: tenant-operator
   name: tenant-operator
+  namespace: ${NAMESPACE_TENANT_OPERATOR}
 spec:
   replicas: 1
   selector:
@@ -101,6 +112,11 @@ spec:
             configMapKeyRef:
               name: tenant-operator-config
               key: keycloakURL
+        - name: KEYCLOAK_LOGIN_REALM
+          valueFrom:
+            configMapKeyRef:
+              name: tenant-operator-config
+              key: keycloakLoginRealm
         - name: KEYCLOAK_TARGET_REALM
           valueFrom:
             configMapKeyRef:

--- a/operators/pkg/tenant-controller/keycloak_utils.go
+++ b/operators/pkg/tenant-controller/keycloak_utils.go
@@ -2,6 +2,7 @@ package tenant_controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	gocloak "github.com/Nerzal/gocloak/v7"
@@ -41,13 +42,15 @@ func createKcRole(ctx context.Context, kcA *KcActor, newRoleName string) error {
 		}
 		klog.Infof("Role created %s", createdRoleName)
 		return nil
+	} else if err != nil {
+		klog.Error("Error when getting user role", err)
+		return err
 	} else if *role.Name == newRoleName {
 		klog.Infof("Role already existed %s", newRoleName)
 		return nil
-	} else {
-		klog.Error("Error when getting user role", err)
-		return err
 	}
+	klog.Errorf("Error when getting role %s", newRoleName)
+	return errors.New("Something went wrong when getting a role")
 }
 
 func deleteKcRoles(ctx context.Context, kcA *KcActor, rolesToDelete []string) error {


### PR DESCRIPTION
# Description

This PR includes:
- fix to deployment files for the workspace CRD controller
- logic flow fix in function to create a role in keycloak
- adapted the workspace controller to use a `fail-fast:false` strategy, in order to have a cleaner code and to avoid executing some actions if other independent ones have failed.

_Side note:_ please tell me what you think about the use of a dedicated struct for the retriggering of the reconcile, I believe it is an elegant solution. If it is ok, il later PRs I would move it to another file, since it will be used also by the tenant-controller.

# How Has This Been Tested?

This has been tested by temporarily adding an error in the code and check the correct retrigger of the reconcile function. Also, since the injected error consisted in providing a non-existing name for the target realm for the creation of keycloak roles, this procedure allowed to spot a bug in the logic of  `createKcRole` in the `keycloak_utils.go` file. The bug made the operator crash.