### PR TITLE
Support for Persistence

### DIFF
--- a/infrastructure/virtualization/README.md
+++ b/infrastructure/virtualization/README.md
@@ -16,3 +16,17 @@ $ kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBE
 # wait until all KubeVirt components are up
 $ kubectl -n kubevirt wait kv kubevirt --for condition=Available
 ```
+
+# Containerized data importer
+[Containerized-Data-Importer (CDI)](https://github.com/kubevirt/containerized-data-importer) is an operator which automates the creation and population of PVCs with VM images, to be attached to KubeVirt VMs. In particular, it relies on the `Datavolume` resource, which essentially describes the source the image is imported from. Please, refer to the [official documentation](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/image-from-registry.md) for more information about this process.
+
+## How to install
+In the following you can find the commands you need to execute in order to deploy CDI in a Kubernetes cluster:
+```bash
+#Export last cdi version
+export VERSION=$(curl -s https://github.com/kubevirt/containerized-data-importer/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+#Deploy the cdi operator
+kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-operator.yaml
+#Deploy cdi CR which triggers the actual installation
+kubectl create -f https://github.com/kubevirt/containerized-data-importer/releases/download/$VERSION/cdi-cr.yaml
+```

--- a/operators/README.md
+++ b/operators/README.md
@@ -55,12 +55,13 @@ helm upgrade crownlabs-instance-operator deploy/instance-operator \
 
 Based on [Kubebuilder 2.3](https://github.com/kubernetes-sigs/kubebuilder.git), the operator implements the environment creation logic of CrownLabs.
 
-Upon the creation of a _Instance_, the operator triggers the creation of the following components:
-
-- Kubevirt VirtualMachine Instance and the logic to access the noVNC instance inside the VM (Service, Ingress)
-- An instance of [Oauth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) (Deployment, Service, Ingress) to regulate access to the VM.
+Upon the creation of a *Instance*, the operator triggers the creation of the following components:
+* Kubevirt VirtualMachine Instance and the logic to access the noVNC instance inside the VM (Service, Ingress)
+* An instance of [Oauth2 Proxy](https://github.com/oauth2-proxy/oauth2-proxy) (Deployment, Service, Ingress) to regulate access to the VM.
+*  A DataVolume (only in case of prersistent VMs). It wraps a Persistent Volume Claim (PVC), and takes care of initializing it with the content of the selected VM image through an importer pod.
 
 All those resources are bound to the Instance life-cycle via the [OwnerRef property](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/)
+
 
 ### APIs/CRDs
 
@@ -68,6 +69,12 @@ The Instance Operator implements the backend logic necessary to spawn new enviro
 
 - **Template** defines the size of the execution environment (e.g.; Virtual Machine), its base image and a description. This object is created by managers and read by users, while creating new instances.
 - **Instance** defines an instance of a certain template. The manipulation of those objects triggers the reconciliation logic in the operator, which creates/destroy associated resources (e.g.; Virtual Machines).
+
+### Persistent Feature
+The Instance Operator allows you to create persistent Virtual Machines. Persistent means that the VM can be stopped and restarted, deleted and recreated without data loss. To make this possible, the content of the VM's disk is stored in a PVC.
+In order to use this feature, [the CDI operator](../infrastructure/virtualization/README.md) has to be installed.
+Granted the CDI operator has been deployed, the Instance Operator spawns a persistent VM similarly to a normal (i.e. non-persistent) one. To this end, the selection about which version to create is performed looking at the corresponding field in the `template` spec.
+N.B. The process of creating a persistent VirtualMachine can take a bit more time with the respect to a normal one (5-10 mins, depending on the size of the image). However when you recreate the VM you will not have to wait such that time.
 
 ### Build from source
 

--- a/operators/api/v1alpha2/instance_types.go
+++ b/operators/api/v1alpha2/instance_types.go
@@ -58,10 +58,6 @@ type InstanceStatus struct {
 	// be used to access it through the SSH protocol (leveraging the SSH bastion
 	// in case it is not contacted from another CrownLabs Instance).
 	IP string `json:"ip,omitempty"`
-
-	// The generation of the object which has been observed. This is used to
-	// filter out the reconciliation events referring only to status modifications.
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -28,6 +28,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
@@ -48,6 +49,8 @@ func init() {
 	_ = crownlabsv1alpha2.AddToScheme(scheme)
 
 	_ = virtv1.AddToScheme(scheme)
+
+	_ = cdiv1.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/operators/deploy/crds/crownlabs.polito.it_instances.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_instances.yaml
@@ -105,12 +105,6 @@ spec:
                   the SSH bastion in case it is not contacted from another CrownLabs
                   Instance).
                 type: string
-              observedGeneration:
-                description: The generation of the object which has been observed.
-                  This is used to filter out the reconciliation events referring only
-                  to status modifications.
-                format: int64
-                type: integer
               phase:
                 description: The current status Instance, with reference to the associated
                   environment (e.g. VM). This conveys which resource is being created,

--- a/operators/deploy/instance-operator/templates/clusterrole.yaml
+++ b/operators/deploy/instance-operator/templates/clusterrole.yaml
@@ -19,16 +19,24 @@ rules:
 
 - apiGroups: [""]
   resources: ["secrets","services","events"]
-  verbs: ["get","list","watch","create"]
+  verbs: ["get","list","watch","create","patch","update"]
 
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get","list","watch","create"]
+  verbs: ["get","list","watch","create","patch","update"]
 
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
-  verbs: ["get","list","watch","create"]
+  verbs: ["get","list","watch","create","patch","update"]
 
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachines", "virtualmachineinstances"]
-  verbs: ["get","list","watch","create"]
+  verbs: ["get","list","watch","create","patch","update"]
+
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes"]
+  verbs: ["get","list","watch","create", "patch", "update"]
+
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes/source"]
+  verbs: ["create", "patch", "update"]

--- a/operators/go.mod
+++ b/operators/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/klog/v2 v2.2.0
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	kubevirt.io/client-go v0.35.0
+	kubevirt.io/containerized-data-importer v1.25.0
 	sigs.k8s.io/controller-runtime v0.6.2
 )
 

--- a/operators/go.sum
+++ b/operators/go.sum
@@ -987,6 +987,7 @@ k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269/go.mod h1:V5BD6M4CyaN5m
 k8s.io/code-generator v0.0.0-20191121015212-c4c8f8345c7e/go.mod h1:DVmfPQgxQENqDIzVR2ddLXMH34qeszkKSdH/N+s+38s=
 k8s.io/code-generator v0.18.6/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/code-generator v0.19.0-rc.2/go.mod h1:uR3gwQvtcOjBrvwXhFF1lw5kq9BOOAfSKl/pZZ1zW3I=
+k8s.io/code-generator v0.19.0 h1:r0BxYnttP/r8uyKd4+Njg0B57kKi8wLvwEzaaVy3iZ8=
 k8s.io/code-generator v0.19.0/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
 k8s.io/component-base v0.17.0/go.mod h1:rKuRAokNMY2nn2A6LP/MiwpoaMRHpfRnrPaUJJj1Yoc=
 k8s.io/component-base v0.18.6/go.mod h1:knSVsibPR5K6EW2XOjEHik6sdU5nCvKMrzMt2D4In14=
@@ -999,6 +1000,7 @@ k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14 h1:t4L10Qfx/p7ASH3gXCdIUtPbbIuegCoUJf3TMSFekjw=
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.0.0-20190306015804-8e90cee79f82/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1014,6 +1016,7 @@ k8s.io/klog/v2 v2.2.0 h1:XRvcwJozkgZ1UQJmfMGpvRthQHOvihEhYtDfAaxMz/A=
 k8s.io/klog/v2 v2.2.0/go.mod h1:Od+F08eJP+W3HUb4pSrPpgp9DGU4GzlpG/TmITuYh/Y=
 k8s.io/kube-aggregator v0.0.0-20181204002017-122bac39d429/go.mod h1:8sbzT4QQKDEmSCIbfqjV0sd97GpUT7A4W626sBiYJmU=
 k8s.io/kube-aggregator v0.18.6/go.mod h1:MKm8inLHdeiXQJCl6UdmgMosRrqJgyxO2obTXOkey/s=
+k8s.io/kube-aggregator v0.19.0-rc.2 h1:vio1J9d+UHUA/ChBeYgBKVlvzOlG4Jztz1Qw+EIGtFg=
 k8s.io/kube-aggregator v0.19.0-rc.2/go.mod h1:6PWWQhJWKECXUitSZ8Mo6LD9gIu4sPZaPpOEU67NkmM=
 k8s.io/kube-openapi v0.0.0-20181031203759-72693cb1fadd/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20181114233023-0317810137be/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=

--- a/operators/pkg/instance-controller/logic.go
+++ b/operators/pkg/instance-controller/logic.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	v1 "kubevirt.io/client-go/api/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
@@ -17,42 +19,50 @@ import (
 // Kubernetes resources required to start a CrownLabs environment.
 func (r *InstanceReconciler) CreateVMEnvironment(instance *crownlabsv1alpha2.Instance, environment *crownlabsv1alpha2.Environment, namespace, name string, vmStart time.Time) error {
 	var user, password string
-	// this is added so that all resources created for this Instance are destroyed when the Instance is deleted
-	b := true
-	globalOwnerReference := []metav1.OwnerReference{
-		{
-			APIVersion:         instance.APIVersion,
-			Kind:               instance.Kind,
-			Name:               instance.Name,
-			UID:                instance.UID,
-			BlockOwnerDeletion: &b,
-		},
-	}
+	var vmi *v1.VirtualMachineInstance
 	ctx := context.TODO()
 	err := instance_creation.GetWebdavCredentials(ctx, r.Client, r.WebdavSecretName, instance.Namespace, &user, &password)
 	if err != nil {
 		klog.Error("unable to get Webdav Credentials")
 		klog.Error(err)
 	} else {
-		klog.Info("Webdav secrets obtained. Getting public keys. " + instance.Name)
+		klog.Info("Webdav secrets obtained. Getting public keys. " + name)
 	}
 	var publicKeys []string
 	if err = instance_creation.GetPublicKeys(ctx, r.Client, instance.Spec.Tenant, instance.Spec.Template, &publicKeys); err != nil {
 		klog.Error("unable to get public keys")
 		klog.Error(err)
 	} else {
-		klog.Info("Public keys obtained. Building cloud-init script. " + instance.Name)
+		klog.Info("Public keys obtained. Building cloud-init script. " + name)
 	}
-	secret := instance_creation.CreateCloudInitSecret(name, namespace, user, password, r.NextcloudBaseURL, publicKeys, globalOwnerReference)
-	if err = instance_creation.CreateOrUpdate(ctx, r.Client, secret); err != nil {
+
+	// persistent feature
+	if environment.Persistent {
+		if cancontinue, err1 := r.createPersistentlogic(instance, environment, name); err1 != nil {
+			return err1
+			// If no errors have happened if datavolume is not succeeded no need to go on
+		} else if !cancontinue {
+			return nil
+		}
+	}
+
+	// create secret
+	secret := instance_creation.CreateCloudInitSecret(name, namespace, user, password, r.NextcloudBaseURL, publicKeys)
+	_, err = ctrl.CreateOrUpdate(ctx, r.Client, &secret, func() error {
+		return ctrl.SetControllerReference(instance, &secret, r.Scheme)
+	})
+	if err != nil {
 		r.setInstanceStatus(ctx, "Could not create secret "+secret.Name+" in namespace "+secret.Namespace, "Warning", "SecretNotCreated", instance, "", "")
 	} else {
 		r.setInstanceStatus(ctx, "Secret "+secret.Name+" correctly created in namespace "+secret.Namespace, "Normal", "SecretCreated", instance, "", "")
 	}
 
 	// create Service to expose the vm
-	service := instance_creation.ForgeService(name, namespace, globalOwnerReference)
-	if err = instance_creation.CreateOrUpdate(ctx, r.Client, service); err != nil {
+	service := instance_creation.ForgeService(name, namespace)
+	_, err = ctrl.CreateOrUpdate(ctx, r.Client, &service, func() error {
+		return ctrl.SetControllerReference(instance, &service, r.Scheme)
+	})
+	if err != nil {
 		r.setInstanceStatus(ctx, "Could not create service "+service.Name+" in namespace "+service.Namespace, "Warning", "ServiceNotCreated", instance, "", "")
 		return err
 	}
@@ -60,59 +70,110 @@ func (r *InstanceReconciler) CreateVMEnvironment(instance *crownlabsv1alpha2.Ins
 
 	urlUUID := uuid.New().String()
 	// create Ingress to manage the service
-	ingress := instance_creation.ForgeIngress(name, namespace, &service, urlUUID, r.WebsiteBaseURL, globalOwnerReference)
-	if err = instance_creation.CreateOrUpdate(ctx, r.Client, ingress); err != nil {
+	ingress := instance_creation.ForgeIngress(name, namespace, &service, urlUUID, r.WebsiteBaseURL)
+	_, err = ctrl.CreateOrUpdate(ctx, r.Client, &ingress, func() error {
+		return ctrl.SetControllerReference(instance, &ingress, r.Scheme)
+	})
+	if err != nil {
 		r.setInstanceStatus(ctx, "Could not create ingress "+ingress.Name+" in namespace "+ingress.Namespace, "Warning", "IngressNotCreated", instance, "", "")
 		return err
 	}
 	r.setInstanceStatus(ctx, "Ingress "+ingress.Name+" correctly created in namespace "+ingress.Namespace, "Normal", "IngressCreated", instance, "", "")
 
-	if err = r.createOAUTHlogic(name, instance, namespace, globalOwnerReference, urlUUID); err != nil {
+	if err = r.createOAUTHlogic(name, instance, namespace, urlUUID); err != nil {
 		return err
 	}
 
-	// create VirtualMachineInstance
-	vmi, err := instance_creation.CreateVirtualMachineInstance(name, namespace, environment, instance.Name, secret.Name, globalOwnerReference)
+	// create vm
+	vmi = &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+	vmStatus := "VmiCreated"
+	if environment.Persistent {
+		vm := v1.VirtualMachine{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+		_, err = ctrl.CreateOrUpdate(ctx, r.Client, &vm, func() error {
+			instance_creation.UpdateVirtualMachineSpec(&vm, environment, instance.Spec.Running)
+			vm.Spec.Template.ObjectMeta.Labels = instance_creation.UpdateLabels(vm.Spec.Template.ObjectMeta.Labels, environment, name)
+			return ctrl.SetControllerReference(instance, &vm, r.Scheme)
+		})
+		if !instance.Spec.Running {
+			vmStatus = "VmiOff"
+		}
+	} else {
+		_, err = ctrl.CreateOrUpdate(ctx, r.Client, vmi, func() error {
+			if vmi.ObjectMeta.CreationTimestamp.IsZero() {
+				instance_creation.UpdateVirtualMachineInstanceSpec(vmi, environment)
+			}
+			vmi.Labels = instance_creation.UpdateLabels(vmi.Labels, environment, name)
+			return ctrl.SetControllerReference(instance, vmi, r.Scheme)
+		})
+	}
 	if err != nil {
+		r.setInstanceStatus(ctx, "Could not create vmi "+vmi.Name+" in namespace "+namespace, "Warning", "VmiNotCreated", instance, "", "")
 		return err
 	}
-	if err := instance_creation.CreateOrUpdate(ctx, r.Client, vmi); err != nil {
-		r.setInstanceStatus(ctx, "Could not create vmi "+vmi.Name+" in namespace "+vmi.Namespace, "Warning", "VmiNotCreated", instance, "", "")
-		return err
+	r.setInstanceStatus(ctx, "VirtualMachineInstance "+vmi.Name+" correctly created in namespace "+namespace, "Normal", vmStatus, instance, "", "")
+
+	if vmStatus != "VmiOff" {
+		go r.getVmiStatus(ctx, environment.GuiEnabled, &service, &ingress, instance, vmi, vmStart)
 	}
-	r.setInstanceStatus(ctx, "VirtualMachineInstance "+vmi.Name+" correctly created in namespace "+vmi.Namespace, "Normal", "VmiCreated", instance, "", "")
-	go r.getVmiStatus(ctx, environment.GuiEnabled, &service, &ingress, instance, vmi, vmStart)
+
 	return nil
 }
 
-func (r *InstanceReconciler) createOAUTHlogic(name string, instance *crownlabsv1alpha2.Instance, namespace string, ownerRef []metav1.OwnerReference, urlUUID string) error {
+func (r *InstanceReconciler) createOAUTHlogic(name string, instance *crownlabsv1alpha2.Instance, namespace, urlUUID string) error {
 	ctx := context.TODO()
 
 	// create Service for oauth2
-	oauthService := instance_creation.ForgeOauth2Service(name, namespace, ownerRef)
-	if err := instance_creation.CreateOrUpdate(ctx, r.Client, oauthService); err != nil {
+	oauthService := instance_creation.ForgeOauth2Service(name, namespace)
+	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, &oauthService, func() error {
+		return ctrl.SetControllerReference(instance, &oauthService, r.Scheme)
+	}); err != nil {
 		r.setInstanceStatus(ctx, "Could not create service "+oauthService.Name+" in namespace "+oauthService.Namespace, "Warning", "Oauth2ServiceNotCreated", instance, "", "")
 		return err
 	}
 	r.setInstanceStatus(ctx, "Service "+oauthService.Name+" correctly created in namespace "+oauthService.Namespace, "Normal", "Oauth2ServiceCreated", instance, "", "")
 
 	// create Ingress to manage the oauth2 service
-	oauthIngress := instance_creation.ForgeOauth2Ingress(name, namespace, &oauthService, urlUUID, r.WebsiteBaseURL, ownerRef)
+	oauthIngress := instance_creation.ForgeOauth2Ingress(name, namespace, &oauthService, urlUUID, r.WebsiteBaseURL)
 	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, &oauthIngress, func() error {
-		r.setInstanceStatus(ctx, "Ingress "+oauthIngress.Name+" correctly created in namespace "+oauthIngress.Namespace, "Normal", "Oauth2IngressCreated", instance, "", "")
 		return ctrl.SetControllerReference(instance, &oauthIngress, r.Scheme)
 	}); err != nil {
+		r.setInstanceStatus(ctx, "Could not create ingress "+oauthIngress.Name+" in namespace "+oauthIngress.Namespace, "Warning", "Oauth2IngressNotCreated", instance, "", "")
 		return err
 	}
-	r.setInstanceStatus(ctx, "Could not create ingress "+oauthIngress.Name+" in namespace "+oauthIngress.Namespace, "Warning", "Oauth2IngressNotCreated", instance, "", "")
+	r.setInstanceStatus(ctx, "Ingress "+oauthIngress.Name+" correctly created in namespace "+oauthIngress.Namespace, "Normal", "Oauth2IngressCreated", instance, "", "")
 
 	// create Deployment for oauth2
-	oauthDeploy := instance_creation.ForgeOauth2Deployment(name, namespace, urlUUID, r.Oauth2ProxyImage, r.OidcClientSecret, r.OidcProviderURL, ownerRef)
-	if err := instance_creation.CreateOrUpdate(ctx, r.Client, oauthDeploy); err != nil {
+	oauthDeploy := instance_creation.ForgeOauth2Deployment(name, namespace, urlUUID, r.Oauth2ProxyImage, r.OidcClientSecret, r.OidcProviderURL)
+	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, &oauthDeploy, func() error {
+		return ctrl.SetControllerReference(instance, &oauthDeploy, r.Scheme)
+	}); err != nil {
 		r.setInstanceStatus(ctx, "Could not create deployment "+oauthDeploy.Name+" in namespace "+oauthDeploy.Namespace, "Warning", "Oauth2DeployNotCreated", instance, "", "")
 		return err
 	}
 	r.setInstanceStatus(ctx, "Deployment "+oauthDeploy.Name+" correctly created in namespace "+oauthDeploy.Namespace, "Normal", "Oauth2DeployCreated", instance, "", "")
-
 	return nil
+}
+
+func (r *InstanceReconciler) createPersistentlogic(instance *crownlabsv1alpha2.Instance, environment *crownlabsv1alpha2.Environment, name string) (bool, error) {
+	ctx := context.TODO()
+	// create datavolume
+	dv := cdiv1.DataVolume{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: instance.Namespace}}
+	dvOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &dv, func() error {
+		instance_creation.UpdateDataVolumeSpec(&dv, environment)
+		return ctrl.SetControllerReference(instance, &dv, r.Scheme)
+	})
+	if err != nil {
+		klog.Error(err, "unable to create or update DataVolume ")
+		return false, err
+	}
+	klog.Infof("Data volume correctly %s", dvOpRes)
+
+	// check if datavolume is succeeded
+	if dv.Status.Phase != cdiv1.DataVolumePhase("Succeeded") {
+		r.setInstanceStatus(ctx, "PVC "+dv.Name+" importing", "Normal", "Importing", instance, "", "")
+		return false, nil
+	}
+
+	r.setInstanceStatus(ctx, "PVC "+dv.Name+" import completed", "Normal", "ImportCompleted", instance, "", "")
+	return true, nil
 }

--- a/operators/pkg/instance-controller/status_inspection.go
+++ b/operators/pkg/instance-controller/status_inspection.go
@@ -19,10 +19,9 @@ func (r *InstanceReconciler) getVmiStatus(ctx context.Context,
 	guiEnabled bool, service *v1.Service, ingress *networkingv1.Ingress,
 	instance *crownlabsv1alpha2.Instance, vmi *virtv1.VirtualMachineInstance, startTimeVM time.Time) {
 	var vmStatus virtv1.VirtualMachineInstancePhase
-
 	var ip string
-	url := ingress.GetAnnotations()["crownlabs.polito.it/probe-url"]
 
+	url := ingress.GetAnnotations()["crownlabs.polito.it/probe-url"]
 	// iterate until the vm is running
 	for {
 		err := r.Client.Get(ctx, types.NamespacedName{
@@ -35,7 +34,6 @@ func (r *InstanceReconciler) getVmiStatus(ctx context.Context,
 				if len(vmi.Status.Interfaces) > 0 {
 					ip = vmi.Status.Interfaces[0].IP
 				}
-
 				msg := "VirtualMachineInstance " + vmi.Name + " in namespace " + vmi.Namespace + " status update to " + string(vmStatus)
 				if vmStatus == virtv1.Failed {
 					r.setInstanceStatus(ctx, msg, "Warning", "Vmi"+string(vmStatus), instance, "", "")

--- a/operators/pkg/instance-controller/suite_test.go
+++ b/operators/pkg/instance-controller/suite_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -62,7 +63,6 @@ var _ = BeforeSuite(func(done Done) {
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "deploy", "crds"),
 			filepath.Join("..", "..", "tests", "crds")},
 	}
-
 	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())
@@ -72,7 +72,8 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	err = crownlabsv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
-
+	err = cdiv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 	// +kubebuilder:scaffold:scheme
 	ctrl.SetLogger(zap.New(func(o *zap.Options) {
 		o.Development = true

--- a/operators/pkg/instance-creation/cloud-init.go
+++ b/operators/pkg/instance-creation/cloud-init.go
@@ -11,6 +11,7 @@ type writeFile struct {
 	Path        string `yaml:"path"`
 	Permissions string `yaml:"permissions"`
 }
+
 type cloudInitConfig struct {
 	Network struct {
 		Version int `yaml:"version"`
@@ -54,16 +55,15 @@ func createUserdata(nextUsername, nextPassword, nextCloudBaseURL string, publicK
 
 // CreateCloudInitSecret creates and returns a Kubernetes Secret object which
 // contains the cloud-init configuration required to correctly start the VMs.
-func CreateCloudInitSecret(name, namespace, nextUsername, nextPassword, nextCloudBaseURL string, publicKeys []string, references []metav1.OwnerReference) v1.Secret {
+func CreateCloudInitSecret(name, namespace, nextUsername, nextPassword, nextCloudBaseURL string, publicKeys []string) v1.Secret {
 	secret := v1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "v1",
 			APIVersion: "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-secret",
-			Namespace:       namespace,
-			OwnerReferences: references,
+			Name:      name,
+			Namespace: namespace,
 		},
 		Data: nil,
 		StringData: createUserdata(

--- a/operators/pkg/instance-creation/cloud-init_test.go
+++ b/operators/pkg/instance-creation/cloud-init_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateUserData(t *testing.T) {
@@ -55,12 +54,7 @@ func TestCreateCloudInitSecret(t *testing.T) {
 		nextCloudBaseURL = "nextcloud.url"
 	)
 	publicKeys := []string{"key1", "key2", "key3"}
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	}}
-	secret := CreateCloudInitSecret(name, namespace, nextUsername, nextPassword, nextCloudBaseURL, publicKeys, ownerRef)
+	secret := CreateCloudInitSecret(name, namespace, nextUsername, nextPassword, nextCloudBaseURL, publicKeys)
 
 	var (
 		expectedmount       = []string{nextCloudBaseURL + "/remote.php/dav/files/" + nextUsername, "/media/MyDrive", "davfs", "_netdev,auto,user,rw,uid=1000,gid=1000", "0", "0"}
@@ -75,7 +69,7 @@ func TestCreateCloudInitSecret(t *testing.T) {
 	err := yaml.Unmarshal([]byte(secret.StringData["userdata"]), &config)
 	assert.Equal(t, err, nil, "Yaml parser should return nil error.")
 
-	assert.Equal(t, secret.ObjectMeta.Name, "name-secret", "Name of secret.ObjectMeta should be "+name+"-secret")
+	assert.Equal(t, secret.ObjectMeta.Name, "name", "Name of secret.ObjectMeta should be "+name+"-secret")
 	assert.Equal(t, secret.ObjectMeta.Namespace, namespace, "Namespace of secret.ObjectMeta should be "+namespace)
 
 	// check config
@@ -88,8 +82,4 @@ func TestCreateCloudInitSecret(t *testing.T) {
 	assert.Equal(t, config.SSHAuthorizedKeys[0], publicKeys[0], "Public key should be set to"+publicKeys[0]+" .")
 	assert.Equal(t, config.SSHAuthorizedKeys[1], publicKeys[1], "Public key should be set to"+publicKeys[1]+" .")
 	assert.Equal(t, config.SSHAuthorizedKeys[2], publicKeys[2], "Public key should be set to"+publicKeys[2]+" .")
-
-	assert.Equal(t, secret.ObjectMeta.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, secret.ObjectMeta.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, secret.ObjectMeta.OwnerReferences[0].Name, "Test1")
 }

--- a/operators/pkg/instance-creation/creation.go
+++ b/operators/pkg/instance-creation/creation.go
@@ -11,10 +11,10 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	virtv1 "kubevirt.io/client-go/api/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
@@ -25,86 +25,163 @@ var cpuHypervisorReserved float32 = 0.5
 var memoryHypervisorReserved string = "500M"
 var registryCred string = "registry-credentials"
 
-// CreateVirtualMachineInstance creates and returns a Kubevirt VirtualMachineInstance
-// object representing the definition of the VM corresponding to a given Environment.
-func CreateVirtualMachineInstance(name, namespace string, template *crownlabsv1alpha2.Environment, instanceName, secretName string, references []metav1.OwnerReference) (*virtv1.VirtualMachineInstance, error) {
-	vmMemory := template.Resources.Memory
-	template.Resources.Memory.Add(resource.MustParse(memoryHypervisorReserved))
-	vm := virtv1.VirtualMachineInstance{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "VirtualMachineInstance",
-			APIVersion: "kubevirt.io/v1alpha3",
+// UpdateVirtualMachineInstanceSpec updates the specification of a Kubevirt VirtualMachineInstance
+// object representing the definition of the VM corresponding to a given CrownLabs Environment.
+func UpdateVirtualMachineInstanceSpec(vmi *virtv1.VirtualMachineInstance, template *crownlabsv1alpha2.Environment) {
+	domain := UpdateVMdomain(template)
+	containerdisk := CreateVolumeContainerdisk(template, vmi.Name)
+	cloudinitdisk := CreateVolumeCloudinitdisk(vmi.Name)
+	vmi.Spec = virtv1.VirtualMachineInstanceSpec{
+		TerminationGracePeriodSeconds: &terminationGracePeriod,
+		Domain:                        domain,
+		Volumes: []virtv1.Volume{
+			containerdisk,
+			cloudinitdisk,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-vmi",
-			Namespace:       namespace,
-			OwnerReferences: references,
-			Labels:          map[string]string{"name": name, "template-name": template.Name, "instance-name": instanceName},
-		},
-		Spec: virtv1.VirtualMachineInstanceSpec{
-			TerminationGracePeriodSeconds: &terminationGracePeriod,
-			Domain: virtv1.DomainSpec{
-				Resources: virtv1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						"cpu":    resource.MustParse(computeCPURequests(template.Resources.CPU, template.Resources.ReservedCPUPercentage)),
-						"memory": template.Resources.Memory,
-					},
-					Limits: corev1.ResourceList{
-						"cpu":    resource.MustParse(computeCPULimits(template.Resources.CPU, cpuHypervisorReserved)),
-						"memory": template.Resources.Memory,
-					},
-				},
-				CPU: &virtv1.CPU{
-					Cores: template.Resources.CPU,
-				},
-				Memory: &virtv1.Memory{
-					Guest: &vmMemory,
-				},
-				Machine: virtv1.Machine{},
-				Devices: virtv1.Devices{
-					Disks: []virtv1.Disk{
-						{
-							Name: "containerdisk",
-							DiskDevice: virtv1.DiskDevice{
-								Disk: &virtv1.DiskTarget{
-									Bus: "virtio",
-								},
-							},
-						},
-						{
-							Name: "cloudinitdisk",
-							DiskDevice: virtv1.DiskDevice{
-								Disk: &virtv1.DiskTarget{
-									Bus: "virtio",
-								},
-							},
-						},
-					},
+	}
+}
+
+// UpdateVirtualMachineSpec updates the specification of a Kubevirt VirtualMachineInstance
+// object representing the definition of the VM corresponding to a persistent Crownlabs environment.
+func UpdateVirtualMachineSpec(vm *virtv1.VirtualMachine, template *crownlabsv1alpha2.Environment, running bool) {
+	domain := UpdateVMdomain(template)
+	containerdisk := CreateVolumeContainerdiskPVC(template, vm.Name)
+	cloudinitdisk := CreateVolumeCloudinitdisk(vm.Name)
+	vm.Spec = virtv1.VirtualMachineSpec{
+		Running: &running,
+		Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+			Spec: virtv1.VirtualMachineInstanceSpec{
+				TerminationGracePeriodSeconds: &terminationGracePeriod,
+				Domain:                        domain,
+				Volumes: []virtv1.Volume{
+					containerdisk,
+					cloudinitdisk,
 				},
 			},
-			Volumes: []virtv1.Volume{
+		},
+	}
+}
+
+// CreateVolumeContainerdiskPVC returns containerdisk volume for persistent VM
+// object pvc is linked to the VM.
+func CreateVolumeContainerdiskPVC(template *crownlabsv1alpha2.Environment, name string) virtv1.Volume {
+	volume := virtv1.Volume{
+		Name: "containerdisk",
+		VolumeSource: virtv1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: name,
+			},
+		},
+	}
+	return volume
+}
+
+// CreateVolumeContainerdisk returns containerdisk volume for non persistent VMs.
+func CreateVolumeContainerdisk(template *crownlabsv1alpha2.Environment, name string) virtv1.Volume {
+	volume := virtv1.Volume{
+		Name: "containerdisk",
+		VolumeSource: virtv1.VolumeSource{
+			ContainerDisk: &virtv1.ContainerDiskSource{
+				Image:           template.Image,
+				ImagePullSecret: registryCred,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			},
+		},
+	}
+	return volume
+}
+
+// CreateVolumeCloudinitdisk returns cloudinitdisk volume.
+// object contains the cloud-init configuration.
+func CreateVolumeCloudinitdisk(secretName string) virtv1.Volume {
+	volume := virtv1.Volume{
+		Name: "cloudinitdisk",
+		VolumeSource: virtv1.VolumeSource{
+			CloudInitNoCloud: &virtv1.CloudInitNoCloudSource{
+				UserDataSecretRef: &corev1.LocalObjectReference{Name: secretName},
+			},
+		},
+	}
+	return volume
+}
+
+// UpdateVMdomain returns the updated domain field for the all the VMs.
+// represents all the resources and the disks of which the vm is composed.
+func UpdateVMdomain(template *crownlabsv1alpha2.Environment) virtv1.DomainSpec {
+	vmMemory := template.Resources.Memory
+	template.Resources.Memory.Add(resource.MustParse(memoryHypervisorReserved))
+	Domain := virtv1.DomainSpec{
+		Resources: virtv1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse(computeCPURequests(template.Resources.CPU, template.Resources.ReservedCPUPercentage)),
+				"memory": template.Resources.Memory,
+			},
+			Limits: corev1.ResourceList{
+				"cpu":    resource.MustParse(computeCPULimits(template.Resources.CPU, cpuHypervisorReserved)),
+				"memory": template.Resources.Memory,
+			},
+		},
+		CPU: &virtv1.CPU{
+			Cores: template.Resources.CPU,
+		},
+		Memory: &virtv1.Memory{
+			Guest: &vmMemory,
+		},
+		Machine: virtv1.Machine{},
+		Devices: virtv1.Devices{
+			Disks: []virtv1.Disk{
 				{
 					Name: "containerdisk",
-					VolumeSource: virtv1.VolumeSource{
-						ContainerDisk: &virtv1.ContainerDiskSource{
-							Image:           template.Image,
-							ImagePullSecret: registryCred,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+					DiskDevice: virtv1.DiskDevice{
+						Disk: &virtv1.DiskTarget{
+							Bus: "virtio",
 						},
 					},
 				},
 				{
 					Name: "cloudinitdisk",
-					VolumeSource: virtv1.VolumeSource{
-						CloudInitNoCloud: &virtv1.CloudInitNoCloudSource{
-							UserDataSecretRef: &corev1.LocalObjectReference{Name: secretName},
+					DiskDevice: virtv1.DiskDevice{
+						Disk: &virtv1.DiskTarget{
+							Bus: "virtio",
 						},
 					},
 				},
 			},
 		},
 	}
-	return &vm, nil
+	return Domain
+}
+
+// UpdateLabels is a function that modifies the  labels map for VMs and VMIs.
+func UpdateLabels(labels map[string]string, template *crownlabsv1alpha2.Environment, name string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels["name"] = name
+	labels["crownlabs.polito.it/template"] = template.Name
+	labels["crownlabs.polito.it/managed-by"] = "instance"
+	return labels
+}
+
+// UpdateDataVolumeSpec create datavolume specification.
+// object allows the creation of the pvc and the import of the virtual machine image.
+func UpdateDataVolumeSpec(dv *cdiv1.DataVolume, template *crownlabsv1alpha2.Environment) {
+	dv.Spec = cdiv1.DataVolumeSpec{
+		Source: cdiv1.DataVolumeSource{
+			Registry: &cdiv1.DataVolumeSourceRegistry{
+				URL:       "docker://" + template.Image,
+				SecretRef: "registry-credentials-cdi",
+			},
+		},
+		PVC: &corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: template.Resources.Disk,
+				},
+			},
+		},
+	}
 }
 
 func computeCPULimits(cpu uint32, hypervisorCoefficient float32) string {

--- a/operators/pkg/instance-creation/exposition.go
+++ b/operators/pkg/instance-creation/exposition.go
@@ -15,12 +15,11 @@ import (
 
 // ForgeService creates and returns a Kubernetes Service resource providing
 // access to a CrownLabs environment.
-func ForgeService(name, namespace string, references []metav1.OwnerReference) corev1.Service {
+func ForgeService(name, namespace string) corev1.Service {
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-svc",
-			Namespace:       namespace,
-			OwnerReferences: references,
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -48,13 +47,13 @@ func ForgeService(name, namespace string, references []metav1.OwnerReference) co
 
 // ForgeIngress creates and returns a Kubernetes Ingress resource providing
 // exposing the remote desktop of a CrownLabs environment.
-func ForgeIngress(name, namespace string, svc *corev1.Service, urlUUID, websiteBaseURL string, references []metav1.OwnerReference) networkingv1.Ingress {
+func ForgeIngress(name, namespace string, svc *corev1.Service, urlUUID, websiteBaseURL string) networkingv1.Ingress {
 	pathType := networkingv1.PathTypePrefix
 	url := websiteBaseURL + "/" + urlUUID
 
 	ingress := networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "-ingress",
+			Name:      name,
 			Namespace: namespace,
 			Labels:    nil,
 			Annotations: map[string]string{
@@ -66,7 +65,6 @@ func ForgeIngress(name, namespace string, svc *corev1.Service, urlUUID, websiteB
 				"crownlabs.polito.it/probe-url":                     "https://" + url,
 				"nginx.ingress.kubernetes.io/configuration-snippet": `sub_filter '<head>' '<head> <base href="https://$host/` + urlUUID + `/index.html">';`,
 			},
-			OwnerReferences: references,
 		},
 		Spec: networkingv1.IngressSpec{
 			TLS: []networkingv1.IngressTLS{
@@ -107,7 +105,7 @@ func ForgeIngress(name, namespace string, svc *corev1.Service, urlUUID, websiteB
 // ForgeOauth2Deployment creates and returns a Kubernetes Deployment resource
 // for oauth2-proxy, which is used to enforce authentication when connecting
 // to the remote desktop of a CrownLabs environment.
-func ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, providerURL string, references []metav1.OwnerReference) appsv1.Deployment {
+func ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, providerURL string) appsv1.Deployment {
 	cookieUUID := uuid.New().String()
 	id, _ := uuid.New().MarshalBinary()
 	cookieSecret := base64.StdEncoding.EncodeToString(id)
@@ -115,10 +113,9 @@ func ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, provid
 
 	deploy := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-oauth2-deploy",
-			Namespace:       namespace,
-			OwnerReferences: references,
-			Labels:          labels,
+			Name:      name + "-oauth2",
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(1),
@@ -181,15 +178,14 @@ func ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, provid
 // ForgeOauth2Service creates and returns a Kubernetes Service resource
 // for oauth2-proxy, which is used to enforce authentication when connecting
 // to the remote desktop of a CrownLabs environment.
-func ForgeOauth2Service(name, namespace string, references []metav1.OwnerReference) corev1.Service {
+func ForgeOauth2Service(name, namespace string) corev1.Service {
 	labels := generateOauth2Labels(name)
 	service := corev1.Service{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-oauth2-svc",
-			Namespace:       namespace,
-			OwnerReferences: references,
-			Labels:          labels,
+			Name:      name + "-oauth2",
+			Namespace: namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
@@ -210,15 +206,14 @@ func ForgeOauth2Service(name, namespace string, references []metav1.OwnerReferen
 // ForgeOauth2Ingress creates and returns a Kubernetes Ingress resource
 // for oauth2-proxy, which is used to enforce authentication when connecting
 // to the remote desktop of a CrownLabs environment.
-func ForgeOauth2Ingress(name, namespace string, svc *corev1.Service, urlUUID, websiteBaseURL string, references []metav1.OwnerReference) networkingv1.Ingress {
+func ForgeOauth2Ingress(name, namespace string, svc *corev1.Service, urlUUID, websiteBaseURL string) networkingv1.Ingress {
 	pathType := networkingv1.PathTypePrefix
 	ingress := networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name + "-oauth2-ingress",
-			Namespace:       namespace,
-			OwnerReferences: references,
-			Labels:          generateOauth2Labels(name),
+			Name:      name + "-oauth2",
+			Namespace: namespace,
+			Labels:    generateOauth2Labels(name),
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/cors-allow-credentials": "true",
 				"nginx.ingress.kubernetes.io/cors-allow-headers":     "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization",

--- a/operators/pkg/instance-creation/exposition_test.go
+++ b/operators/pkg/instance-creation/exposition_test.go
@@ -15,20 +15,10 @@ func TestForgeService(t *testing.T) {
 		namespace = "namespacetest"
 	)
 
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	},
-	}
+	service := ForgeService(name, namespace)
 
-	service := ForgeService(name, namespace, ownerRef)
-
-	assert.Equal(t, service.ObjectMeta.Name, name+"-svc")
+	assert.Equal(t, service.ObjectMeta.Name, name)
 	assert.Equal(t, service.ObjectMeta.Namespace, namespace)
-	assert.Equal(t, service.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, service.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, service.OwnerReferences[0].Name, "Test1")
 	assert.Equal(t, service.Spec.Ports[0].Name, "vnc")
 	assert.Equal(t, service.Spec.Ports[0].Port, int32(6080))
 	assert.Equal(t, service.Spec.Ports[1].Name, "ssh")
@@ -60,16 +50,9 @@ func TestForgeIngress(t *testing.T) {
 		url = websiteBaseURL + "/" + urlUUID
 	)
 
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	},
-	}
+	ingress := ForgeIngress(name, namespace, &svc, urlUUID, websiteBaseURL)
 
-	ingress := ForgeIngress(name, namespace, &svc, urlUUID, websiteBaseURL, ownerRef)
-
-	assert.Equal(t, ingress.ObjectMeta.Name, name+"-ingress")
+	assert.Equal(t, ingress.ObjectMeta.Name, name)
 	assert.Equal(t, ingress.ObjectMeta.Namespace, namespace)
 	assert.Equal(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name, svc.Name)
 	assert.Equal(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Number, svc.Spec.Ports[0].TargetPort.IntVal)
@@ -80,9 +63,6 @@ func TestForgeIngress(t *testing.T) {
 	assert.Equal(t, ingress.ObjectMeta.Annotations["crownlabs.polito.it/probe-url"], "https://"+url)
 	assert.Equal(t, ingress.Spec.TLS[0].Hosts[0], websiteBaseURL)
 	assert.Equal(t, ingress.Spec.Rules[0].Host, websiteBaseURL)
-	assert.Equal(t, ingress.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, ingress.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, ingress.OwnerReferences[0].Name, "Test1")
 }
 
 func TestForgeOauth2Deployment(t *testing.T) {
@@ -94,20 +74,11 @@ func TestForgeOauth2Deployment(t *testing.T) {
 		clientSecret = "secrettest"
 		providerURL  = "urltest"
 	)
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	},
-	}
 
-	deploy := ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, providerURL, ownerRef)
+	deploy := ForgeOauth2Deployment(name, namespace, urlUUID, image, clientSecret, providerURL)
 
-	assert.Equal(t, deploy.ObjectMeta.Name, name+"-oauth2-deploy")
+	assert.Equal(t, deploy.ObjectMeta.Name, name+"-oauth2")
 	assert.Equal(t, deploy.ObjectMeta.Namespace, namespace)
-	assert.Equal(t, deploy.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, deploy.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, deploy.OwnerReferences[0].Name, "Test1")
 	assert.Equal(t, deploy.Spec.Template.Spec.Containers[0].Image, image)
 	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, "--proxy-prefix=/"+urlUUID+"/oauth2")
 	assert.Contains(t, deploy.Spec.Template.Spec.Containers[0].Args, "--cookie-path=/"+urlUUID)
@@ -122,19 +93,11 @@ func TestForgeOauth2Service(t *testing.T) {
 		name      = "usertest"
 		namespace = "namespacetest"
 	)
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	},
-	}
-	service := ForgeOauth2Service(name, namespace, ownerRef)
 
-	assert.Equal(t, service.ObjectMeta.Name, name+"-oauth2-svc")
+	service := ForgeOauth2Service(name, namespace)
+
+	assert.Equal(t, service.ObjectMeta.Name, name+"-oauth2")
 	assert.Equal(t, service.ObjectMeta.Namespace, namespace)
-	assert.Equal(t, service.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, service.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, service.OwnerReferences[0].Name, "Test1")
 	assert.Equal(t, service.Spec.Selector, generateOauth2Labels(name))
 }
 
@@ -157,20 +120,11 @@ func TestForgeOauth2Ingress(t *testing.T) {
 			},
 		}
 	)
-	ownerRef := []metav1.OwnerReference{{
-		APIVersion: "crownlabs.polito.it/v1alpha2",
-		Kind:       "Instance",
-		Name:       "Test1",
-	},
-	}
 
-	ingress := ForgeOauth2Ingress(name, namespace, &svc, urlUUID, websiteBaseURL, ownerRef)
+	ingress := ForgeOauth2Ingress(name, namespace, &svc, urlUUID, websiteBaseURL)
 
-	assert.Equal(t, ingress.ObjectMeta.Name, name+"-oauth2-ingress")
+	assert.Equal(t, ingress.ObjectMeta.Name, name+"-oauth2")
 	assert.Equal(t, ingress.ObjectMeta.Namespace, namespace)
-	assert.Equal(t, ingress.OwnerReferences[0].APIVersion, "crownlabs.polito.it/v1alpha2")
-	assert.Equal(t, ingress.OwnerReferences[0].Kind, "Instance")
-	assert.Equal(t, ingress.OwnerReferences[0].Name, "Test1")
 	assert.Equal(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name, svc.Name)
 	assert.Equal(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Number, svc.Spec.Ports[0].TargetPort.IntVal)
 	assert.Equal(t, ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Path, "/"+urlUUID+"/oauth2/.*")

--- a/operators/tests/crds/VM.yaml
+++ b/operators/tests/crds/VM.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualmachines.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: kubevirt.io
+  names:
+    categories:
+      - all
+    kind: VirtualMachine
+    listKind: VirtualMachineList
+    plural: virtualmachines
+    shortNames:
+      - vm
+      - vms
+    singular: virtualmachine
+  scope: Namespaced
+  versions:
+    - name: v1alpha3
+      served: true
+      storage: true

--- a/operators/tests/crds/datavolume.yaml
+++ b/operators/tests/crds/datavolume.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: datavolumes.cdi.kubevirt.io
+spec:
+  conversion:
+    strategy: None
+  group: cdi.kubevirt.io
+  names:
+    categories:
+    - all
+    kind: DataVolume
+    listKind: DataVolumeList
+    plural: datavolumes
+    shortNames:
+    - dv
+    - dvs
+    singular: datavolume
+  scope: Namespaced
+  versions:
+   - name: v1alpha1
+     schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            type: object
+            x-preserve-unknown-fields: true
+          status:
+            description: DataVolumeStatus contains the current status of the DataVolume
+            properties:
+              phase:
+                description: Phase is the current phase of the data volume
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+     served: true
+     storage: false
+   - name: v1beta1
+     schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            type: object
+            x-preserve-unknown-fields: true
+          status:
+            description: DataVolumeStatus contains the current status of the DataVolume
+            properties:
+              phase:
+                description: Phase is the current phase of the data volume
+                type: string
+            type: object
+        required:
+        - spec
+        type: object  
+     served: true
+     storage: true


### PR DESCRIPTION
# Description

With this PR now it is possible to create persistent VM.
The instance controller has been updated in order to react to persistent template. A datavolume is created and it allows the creation of a pvc used to import the VM images.
It has been used a virtual machine instead of a virtual machine instance because of the need to start and stop the VMI.

