### PR TITLE
Add /hold command to PRs

### DIFF
--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -23,6 +23,8 @@ jobs:
             Currently, I understand the following commands:
             * `/rebase`:            Rebase this PR onto the master branch
             * `/merge`:             Merge this PR into the master branch
+            * `/hold`:              Adds hold label to prevent merging with /merge
+            * `/unhold`:            Removes the hold label to allow merging with /merge
             * `/deploy-staging`:    Deploy a staging environment to test this PR
             * `/undeploy-staging`:  Manually undeploy the staging environment
 

--- a/.github/workflows/hold.yml
+++ b/.github/workflows/hold.yml
@@ -1,0 +1,47 @@
+name: Manage the hold label
+on:
+  repository_dispatch:
+    types:
+      - hold-command
+      - unhold-command
+
+jobs:
+  hold:
+    name: Add hold label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'hold-command'
+
+    steps:
+      - name: Add the hold label to avoid merging
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: "${{ secrets.CI_TOKEN }}"
+          number: ${{ github.event.client_payload.github.payload.issue.number }}
+          labels: hold
+
+      - name: Report status as reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray
+
+  unhold:
+    name: Remove the hold label
+    runs-on: ubuntu-latest
+    if: github.event.action == 'unhold-command'
+
+    steps:
+      - name: Remove the hold label to allow merging
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: "${{ secrets.CI_TOKEN }}"
+          number: ${{ github.event.client_payload.github.payload.issue.number }}
+          labels: hold
+
+      - name: Report status as reaction
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -33,5 +33,13 @@ jobs:
               {
                 "command": "undeploy-staging",
                 "permission": "write"
+              },
+              {
+                "command": "hold",
+                "permission": "none"
+              },
+              {
+                "command": "unhold",
+                "permission": "none"
               }
             ]


### PR DESCRIPTION
# Description

This PR adds the `/hold` command to let contributors who do not have "write" privileges in the repo to hold PRs for merging.

# How Has This Been Tested?

This change has been tested on another repo, with this [PR](https://github.com/giorio94/demo-github-actions)