### PR TITLE
First deployable version of tenant controller

### DIFF
--- a/operators/api/v1alpha1/common_types.go
+++ b/operators/api/v1alpha1/common_types.go
@@ -22,3 +22,6 @@ type GenericRef struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace,omitempty"`
 }
+
+// WorkspaceLabelPrefix is the prefix of a label assigned to a tenant indicating it is subscribed to a workspace
+const WorkspaceLabelPrefix = "crownlabs.polito.it/workspace-"

--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -69,10 +69,11 @@ type TenantStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	PersonalNamespace NameCreated `json:"personalNamespace,omitempty"`
-	SandboxNamespace  NameCreated `json:"sandboxNamespace,omitempty"`
-
-	Subscriptions map[string]SubscriptionStatus `json:"subscription,omitempty"`
+	PersonalNamespace NameCreated                   `json:"personalNamespace,omitempty"`
+	SandboxNamespace  NameCreated                   `json:"sandboxNamespace,omitempty"`
+	FailingWorkspaces []string                      `json:"failingWorkspaces,omitempty"`
+	Subscriptions     map[string]SubscriptionStatus `json:"subscriptions,omitempty"`
+	Ready             bool                          `json:"ready,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -81,6 +82,7 @@ type TenantStatus struct {
 // +kubebuilder:printcolumn:name="First Name",type=string,JSONPath=`.spec.firstName`
 // +kubebuilder:printcolumn:name="Last Name",type=string,JSONPath=`.spec.lastName`
 // +kubebuilder:printcolumn:name="Email",type=string,JSONPath=`.spec.email`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 
 // Tenant is the Schema for the tenants API
 type Tenant struct {

--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -24,12 +24,12 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // WorkspaceUserRole is an enum for the role of a user in a workspace
-// +kubebuilder:validation:Enum=admin;user
+// +kubebuilder:validation:Enum=manager;user
 type WorkspaceUserRole string
 
 const (
-	// Admin allows to interact with all VMs of a workspace
-	Admin WorkspaceUserRole = "admin"
+	// Manager allows to interact with all VMs of a workspace
+	Manager WorkspaceUserRole = "manager"
 	// User allows to interact with owned vms
 	User WorkspaceUserRole = "user"
 )

--- a/operators/api/v1alpha1/workspace_types.go
+++ b/operators/api/v1alpha1/workspace_types.go
@@ -39,12 +39,15 @@ type WorkspaceStatus struct {
 	Namespace NameCreated `json:"namespace,omitempty"`
 
 	Subscriptions map[string]SubscriptionStatus `json:"subscription,omitempty"`
+
+	Ready bool `json:"ready,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope="Cluster"
 // +kubebuilder:printcolumn:name="Pretty Name",type=string,JSONPath=`.spec.prettyName`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 
 // Workspace is the Schema for the workspaces API
 type Workspace struct {

--- a/operators/api/v1alpha1/zz_generated.deepcopy.go
+++ b/operators/api/v1alpha1/zz_generated.deepcopy.go
@@ -438,6 +438,11 @@ func (in *TenantStatus) DeepCopyInto(out *TenantStatus) {
 	*out = *in
 	out.PersonalNamespace = in.PersonalNamespace
 	out.SandboxNamespace = in.SandboxNamespace
+	if in.FailingWorkspaces != nil {
+		in, out := &in.FailingWorkspaces, &out.FailingWorkspaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Subscriptions != nil {
 		in, out := &in.Subscriptions, &out.Subscriptions
 		*out = make(map[string]SubscriptionStatus, len(*in))

--- a/operators/crd-examples/tenant.yml
+++ b/operators/crd-examples/tenant.yml
@@ -9,6 +9,10 @@ spec:
   workspaces:
     - workspaceRef:
         name: landc
+      role: user
+      groupNumber: 12
+    - workspaceRef:
+        name: swnet
       role: admin
       groupNumber: 12
   publicKeys:

--- a/operators/crd-examples/tenant.yml
+++ b/operators/crd-examples/tenant.yml
@@ -13,7 +13,7 @@ spec:
       groupNumber: 12
     - workspaceRef:
         name: swnet
-      role: admin
+      role: manager
       groupNumber: 12
   publicKeys:
     - key1

--- a/operators/crd-examples/workspace.yml
+++ b/operators/crd-examples/workspace.yml
@@ -1,6 +1,6 @@
 apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
-  name: swnet
+  name: landc
 spec:
   prettyName: Software Networking

--- a/operators/crd-examples/workspace.yml
+++ b/operators/crd-examples/workspace.yml
@@ -1,6 +1,6 @@
 apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
-  name: landc
+  name: swnet
 spec:
   prettyName: Software Networking

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .spec.email
       name: Email
       type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -93,6 +96,10 @@ spec:
           status:
             description: TenantStatus defines the observed state of Tenant
             properties:
+              failingWorkspaces:
+                items:
+                  type: string
+                type: array
               personalNamespace:
                 description: NameCreated contains info about the status of a resource
                 properties:
@@ -103,6 +110,8 @@ spec:
                 required:
                 - created
                 type: object
+              ready:
+                type: boolean
               sandboxNamespace:
                 description: NameCreated contains info about the status of a resource
                 properties:
@@ -113,7 +122,7 @@ spec:
                 required:
                 - created
                 type: object
-              subscription:
+              subscriptions:
                 additionalProperties:
                   description: SubscriptionStatus is an enum for the status of a subscription to a service
                   enum:

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -70,7 +70,7 @@ spec:
                     role:
                       description: WorkspaceUserRole is an enum for the role of a user in a workspace
                       enum:
-                      - admin
+                      - manager
                       - user
                       type: string
                     workspaceRef:

--- a/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.prettyName
       name: Pretty Name
       type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -54,6 +57,8 @@ spec:
                 required:
                 - created
                 type: object
+              ready:
+                type: boolean
               subscription:
                 additionalProperties:
                   description: SubscriptionStatus is an enum for the status of a subscription to a service

--- a/operators/deploy/tenant-operator/k8s-cluster-role.yaml
+++ b/operators/deploy/tenant-operator/k8s-cluster-role.yaml
@@ -8,5 +8,156 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    resources: ["namespaces", "resourcequotas"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings", "clusterrolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+
+    apiVersion: rbac.authorization.k8s.io/v1
+
+---
+kind: ClusterRole
+metadata:
+  name: crownlabs-view-instances
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - instances
+      - instances/status
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-manage-instances
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - instances
+      - instances/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-view-templates
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-manage-templates
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - templates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-view-tenants
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - tenants
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-manage-tenants
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - tenants
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-view-workspaces
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - workspaces
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-manage-workspaces
+rules:
+  - apiGroups:
+      - crownlabs.polito.it
+    resources:
+      - workspaces
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -198,11 +198,7 @@ func genUserRoles(workspaces []crownlabsv1alpha1.UserWorkspaceData) []string {
 	userRoles := make([]string, len(workspaces))
 	// convert workspaces to actual keyloak role
 	for i, ws := range workspaces {
-		if ws.Role == crownlabsv1alpha1.User {
-			userRoles[i] = fmt.Sprintf("workspace-%s:user", ws.WorkspaceRef.Name)
-		} else if ws.Role == crownlabsv1alpha1.Admin {
-			userRoles[i] = fmt.Sprintf("workspace-%s:admin", ws.WorkspaceRef.Name)
-		}
+		userRoles[i] = fmt.Sprintf("workspace-%s:%s", ws.WorkspaceRef.Name, ws.Role)
 	}
 	return userRoles
 }

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -143,7 +143,7 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			klog.Error(err)
 			retrigErr = err
 			tn.Status.Subscriptions["keycloak"] = crownlabsv1alpha1.SubscrFailed
-		} else if err = r.KcA.updateUserRoles(ctx, genUserRoles(tenantExistingWorkspaces), *userID); err != nil {
+		} else if err = r.KcA.updateUserRoles(ctx, genUserRoles(tenantExistingWorkspaces), *userID, "workspace-"); err != nil {
 			klog.Errorf("Error when updating user roles of user %s", tn.Name)
 			klog.Error(err)
 			retrigErr = err

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -50,7 +50,11 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	var tn crownlabsv1alpha1.Tenant
 	var userID *string
-	if err := r.Get(ctx, req.NamespacedName, &tn); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &tn); client.IgnoreNotFound(err) != nil {
+		klog.Errorf("Error getting tenant %s on deletion", req.Name)
+		klog.Error(err)
+		return ctrl.Result{}, err
+	} else if err != nil {
 		// reconcile was triggered by a delete request
 		if userID, _, err = r.KcA.getUserInfo(ctx, req.Name); err != nil {
 			klog.Errorf("Error when checking if user %s existed for deletion", req.Name)

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -23,10 +23,14 @@ import (
 
 	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
+
+	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -89,10 +93,17 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		klog.Infof("Namespace %s for tenant %s %s", nsName, req.Name, nsOpRes)
 		tn.Status.PersonalNamespace.Created = true
 		tn.Status.PersonalNamespace.Name = nsName
+		if err := createOrUpdateTnClusterResources(ctx, r, tn.Name, nsName); err != nil {
+			klog.Errorf("Error creating k8s resources for tenant %s", tn.Name)
+			klog.Error(err)
+			retrigErr = err
+		} else {
+			klog.Infof("Cluster resources for tenant %s have been correctly handled", tn.Name)
+		}
 	}
 
-	tnWorkspaceLabels := make(map[string]string)
 	// check validity of workspaces in tenant
+	tnWorkspaceLabels := make(map[string]string)
 	tenantExistingWorkspaces := []crownlabsv1alpha1.UserWorkspaceData{}
 	tn.Status.FailingWorkspaces = []string{}
 	for _, tnWs := range tn.Spec.Workspaces {
@@ -162,6 +173,7 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		klog.Error("Unable to update resource before exiting reconciler", err)
 		retrigErr = err
 	}
+	klog.Infof("Tenant %s reconciled", tn.Name)
 	return ctrl.Result{}, retrigErr
 }
 
@@ -178,6 +190,7 @@ func updateTnNamespace(ns *v1.Namespace, tnName string) {
 	}
 	ns.Labels["crownlabs.polito.it/type"] = "tenant"
 	ns.Labels["crownlabs.polito.it/name"] = tnName
+	ns.Labels["crownlabs.polito.it/operator-selector"] = "production"
 }
 
 // genUserRoles maps the workspaces of a tenant to the need roles in keycloak
@@ -201,4 +214,90 @@ func cleanWorkspaceLabels(labels *map[string]string) {
 			delete(*labels, k)
 		}
 	}
+}
+
+func createOrUpdateTnClusterResources(ctx context.Context, r *TenantReconciler, tnName, nsName string) error {
+	// handle resource quota
+	rq := v1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-resource-quota", Namespace: nsName},
+	}
+	rqOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &rq, func() error {
+		updateTnResQuota(&rq)
+		return nil
+	})
+	if err != nil {
+		klog.Errorf("Unable to create or update resource quota for tenant %s", tnName)
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("Resource quota for tenant %s %s", tnName, rqOpRes)
+
+	// handle roleBinding
+	rb := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-manage-instances", Namespace: nsName}}
+	rbOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &rb, func() error {
+		updateTnRb(&rb, tnName)
+		return nil
+	})
+	if err != nil {
+		klog.Errorf("Unable to create or update role binding for tenant %s", tnName)
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("Role binding for tenant %s %s", tnName, rbOpRes)
+
+	netPolDeny := netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-deny-ingress-traffic", Namespace: nsName}}
+	npDOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &netPolDeny, func() error {
+		updateTnNetPolDeny(&netPolDeny)
+		return nil
+	})
+	if err != nil {
+		klog.Errorf("Unable to create or update deny network policy for tenant %s", tnName)
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("Deny network policy for tenant %s %s", tnName, npDOpRes)
+
+	netPolAllow := netv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-allow-trusted-ingress-traffic", Namespace: nsName}}
+	npAOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &netPolAllow, func() error {
+		updateTnNetPolAllow(&netPolAllow)
+		return nil
+	})
+	if err != nil {
+		klog.Errorf("Unable to create or update allow network policy for tenant %s", tnName)
+		klog.Error(err)
+		return err
+	}
+	klog.Infof("Allow network policy for tenant %s %s", tnName, npAOpRes)
+	return nil
+}
+
+// updateTnResQuota updates the tenant resource quota
+func updateTnResQuota(rq *v1.ResourceQuota) {
+
+	resourceList := make(v1.ResourceList)
+
+	resourceList["limits.cpu"] = *resource.NewQuantity(10, resource.DecimalSI)
+	resourceList["limits.memory"] = *resource.NewQuantity(25*1024*1024*1024, resource.BinarySI)
+	resourceList["requests.cpu"] = *resource.NewQuantity(10, resource.DecimalSI)
+	resourceList["requests.memory"] = *resource.NewQuantity(25*1024*1024*1024, resource.BinarySI)
+	resourceList["count/instances.crownlabs.polito.it"] = *resource.NewQuantity(5, resource.DecimalSI)
+
+	rq.Spec.Hard = resourceList
+}
+
+func updateTnRb(rb *rbacv1.RoleBinding, tnName string) {
+	rb.RoleRef = rbacv1.RoleRef{Kind: "ClusterRole", Name: "crownlabs-manage-instances", APIGroup: "rbac.authorization.k8s.io"}
+	rb.Subjects = []rbacv1.Subject{{Kind: "User", Name: tnName, APIGroup: "rbac.authorization.k8s.io"}}
+}
+
+func updateTnNetPolDeny(np *netv1.NetworkPolicy) {
+	np.Spec.PodSelector.MatchLabels = make(map[string]string)
+	np.Spec.Ingress = []netv1.NetworkPolicyIngressRule{{From: []netv1.NetworkPolicyPeer{{PodSelector: &metav1.LabelSelector{}}}}}
+}
+
+func updateTnNetPolAllow(np *netv1.NetworkPolicy) {
+	np.Spec.PodSelector.MatchLabels = make(map[string]string)
+	np.Spec.Ingress = []netv1.NetworkPolicyIngressRule{{From: []netv1.NetworkPolicyPeer{{NamespaceSelector: &metav1.LabelSelector{
+		MatchLabels: map[string]string{"crownlabs.polito.it/allow-instance-access": "true"},
+	}}}}}
 }

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -31,6 +31,10 @@ import (
 var _ = Describe("Tenant controller", func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	var (
+		wsName       = "ws1"
+		wsNamespace  = ""
+		wsPrettyName = "workspace 1"
+
 		tnName          = "mariorossi"
 		tnFirstName     = "mario"
 		tnLastName      = "rossi"
@@ -61,6 +65,8 @@ var _ = Describe("Tenant controller", func() {
 		mKcClient = nil
 		mKcClient = mocks.NewMockGoCloak(mockCtrl)
 		kcA.Client = mKcClient
+
+		setupMocksForWorkspaceCreation(mKcClient, kcAccessToken, kcTargetRealm, kcTargetClientID, wsName)
 
 		// the user did not exist
 		mKcClient.EXPECT().GetUsers(
@@ -132,9 +138,25 @@ var _ = Describe("Tenant controller", func() {
 	})
 
 	It("Should create the related resources when creating a tenant", func() {
+		ctx := context.Background()
+
+		By("By creating a workspace")
+		ws := &crownlabsv1alpha1.Workspace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "crownlabs.polito.it/v1alpha1",
+				Kind:       "Workspace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      wsName,
+				Namespace: wsNamespace,
+			},
+			Spec: crownlabsv1alpha1.WorkspaceSpec{
+				PrettyName: wsPrettyName,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ws)).Should(Succeed())
 
 		By("By creating a tenant")
-		ctx := context.Background()
 		tn := &crownlabsv1alpha1.Tenant{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "crownlabs.polito.it/v1alpha1",

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -31,12 +31,12 @@ import (
 var _ = Describe("Tenant controller", func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	var (
-		wsName       = "ws1"
-		wsNamespace  = ""
-		wsPrettyName = "workspace 1"
-		wsLabelKey   = "crownlabs.polito.it/workspace-ws1"
-		wsUserRole   = "workspace-ws1:user"
-		wsAdminRole  = "workspace-ws1:admin"
+		wsName        = "ws1"
+		wsNamespace   = ""
+		wsPrettyName  = "workspace 1"
+		wsLabelKey    = "crownlabs.polito.it/workspace-ws1"
+		wsUserRole    = "workspace-ws1:user"
+		wsManagerRole = "workspace-ws1:manager"
 
 		tnName          = "mariorossi"
 		tnFirstName     = "mario"
@@ -152,7 +152,7 @@ var _ = Describe("Tenant controller", func() {
 			gomock.Eq(kcAccessToken),
 			gomock.Eq(kcTargetRealm),
 			gomock.Eq(kcTargetClientID),
-			gomock.Eq(wsAdminRole),
+			gomock.Eq(wsManagerRole),
 		).Return(nil).MinTimes(1).MaxTimes(2)
 
 	})

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Tenant controller", func() {
 		testUserRole    = gocloak.Role{ID: &testUserRoleID, Name: &userRoleName}
 		beforeUserRoles = []*gocloak.Role{}
 		rolesToDelete   = []gocloak.Role{}
-		rolesToAdd      = []gocloak.Role{{ID: &testUserRoleID, Name: &userRoleName}}
+		rolesToSet      = []gocloak.Role{{ID: &testUserRoleID, Name: &userRoleName}}
 	)
 
 	const (
@@ -138,7 +138,7 @@ var _ = Describe("Tenant controller", func() {
 			gomock.Eq(kcTargetRealm),
 			gomock.Eq(kcTargetClientID),
 			gomock.Eq(userID),
-			gomock.AssignableToTypeOf(rolesToAdd),
+			gomock.AssignableToTypeOf(rolesToSet),
 		).Return(nil).AnyTimes()
 
 		mKcClient.EXPECT().DeleteClientRole(gomock.AssignableToTypeOf(context.Background()),

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Tenant controller", func() {
 		mKcClient = mocks.NewMockGoCloak(mockCtrl)
 		kcA.Client = mKcClient
 
-		setupMocksForWorkspaceCreation(mKcClient, kcAccessToken, kcTargetRealm, kcTargetClientID, wsName)
+		setupMocksForWorkspaceCreationExistingRoles(mKcClient, kcAccessToken, kcTargetRealm, kcTargetClientID, wsName, wsPrettyName)
 
 		// the user did not exist
 		mKcClient.EXPECT().GetUsers(

--- a/operators/pkg/tenant-controller/workspace_controller.go
+++ b/operators/pkg/tenant-controller/workspace_controller.go
@@ -45,7 +45,11 @@ func (r *WorkspaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	var ws crownlabsv1alpha1.Workspace
 
-	if err := r.Get(ctx, req.NamespacedName, &ws); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &ws); client.IgnoreNotFound(err) != nil {
+		klog.Errorf("Error getting workspace %s on deletion", req.Name)
+		klog.Error(err)
+		return ctrl.Result{}, err
+	} else if err != nil {
 		// reconcile was triggered by a delete request
 		klog.Infof("Workspace %s deleted", req.Name)
 		rolesToDelete := genWorkspaceRolesData(req.Name, ws.Spec.PrettyName)

--- a/operators/pkg/tenant-controller/workspace_controller_test.go
+++ b/operators/pkg/tenant-controller/workspace_controller_test.go
@@ -50,25 +50,7 @@ var _ = Describe("Workspace controller", func() {
 			mKcClient = nil
 			mKcClient = mocks.NewMockGoCloak(mockCtrl)
 			kcA.Client = mKcClient
-			userKcRole := fmt.Sprintf("workspace-%s:user", wsName)
-			adminKcRole := fmt.Sprintf("workspace-%s:admin", wsName)
-
-			mKcClient.EXPECT().GetClientRole(
-				gomock.AssignableToTypeOf(context.Background()),
-				gomock.Eq(kcAccessToken),
-				gomock.Eq(kcTargetRealm),
-				gomock.Eq(kcTargetClientID),
-				gomock.Eq(userKcRole),
-			).Return(&gocloak.Role{Name: &userKcRole}, nil).MinTimes(1).MaxTimes(2)
-
-			mKcClient.EXPECT().GetClientRole(
-				gomock.AssignableToTypeOf(context.Background()),
-				gomock.Eq(kcAccessToken),
-				gomock.Eq(kcTargetRealm),
-				gomock.Eq(kcTargetClientID),
-				gomock.Eq(adminKcRole),
-			).Return(&gocloak.Role{Name: &adminKcRole}, nil).MinTimes(1).MaxTimes(2)
-
+			setupMocksForWorkspaceCreation(mKcClient, kcAccessToken, kcA.TargetRealm, kcTargetClientID, wsName)
 		})
 
 	It("Should create the related resources when creating a workspace", func() {
@@ -141,3 +123,23 @@ var _ = Describe("Workspace controller", func() {
 	})
 
 })
+
+func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessToken string, kcTargetRealm string, kcTargetClientID string, wsName string) {
+	userKcRole := fmt.Sprintf("workspace-%s:user", wsName)
+	adminKcRole := fmt.Sprintf("workspace-%s:admin", wsName)
+	mockKcCLient.EXPECT().GetClientRole(
+		gomock.AssignableToTypeOf(context.Background()),
+		gomock.Eq(kcAccessToken),
+		gomock.Eq(kcTargetRealm),
+		gomock.Eq(kcTargetClientID),
+		gomock.Eq(userKcRole),
+	).Return(&gocloak.Role{Name: &userKcRole}, nil).MinTimes(1).MaxTimes(2)
+
+	mockKcCLient.EXPECT().GetClientRole(
+		gomock.AssignableToTypeOf(context.Background()),
+		gomock.Eq(kcAccessToken),
+		gomock.Eq(kcTargetRealm),
+		gomock.Eq(kcTargetClientID),
+		gomock.Eq(adminKcRole),
+	).Return(&gocloak.Role{Name: &adminKcRole}, nil).MinTimes(1).MaxTimes(2)
+}

--- a/operators/pkg/tenant-controller/workspace_controller_test.go
+++ b/operators/pkg/tenant-controller/workspace_controller_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Workspace controller", func() {
 
 func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessToken string, kcTargetRealm string, kcTargetClientID string, wsName string) {
 	userKcRole := fmt.Sprintf("workspace-%s:user", wsName)
-	adminKcRole := fmt.Sprintf("workspace-%s:admin", wsName)
+	managerKcRole := fmt.Sprintf("workspace-%s:manager", wsName)
 	mockKcCLient.EXPECT().GetClientRole(
 		gomock.AssignableToTypeOf(context.Background()),
 		gomock.Eq(kcAccessToken),
@@ -140,6 +140,6 @@ func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessTok
 		gomock.Eq(kcAccessToken),
 		gomock.Eq(kcTargetRealm),
 		gomock.Eq(kcTargetClientID),
-		gomock.Eq(adminKcRole),
-	).Return(&gocloak.Role{Name: &adminKcRole}, nil).MinTimes(1).MaxTimes(2)
+		gomock.Eq(managerKcRole),
+	).Return(&gocloak.Role{Name: &managerKcRole}, nil).MinTimes(1).MaxTimes(2)
 }

--- a/operators/pkg/tenant-controller/workspace_controller_test.go
+++ b/operators/pkg/tenant-controller/workspace_controller_test.go
@@ -32,13 +32,13 @@ var _ = Describe("Workspace controller", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		wsNamespace  = ""
-		wsPrettyName = "Workspace for testing"
-		nsNamespace  = ""
-		timeout      = time.Second * 10
-		interval     = time.Millisecond * 250
+		nsNamespace = ""
+		timeout     = time.Second * 10
+		interval    = time.Millisecond * 250
 	)
 	var (
+		wsNamespace  = ""
+		wsPrettyName = "Workspace for testing"
 		// make workspace name time-sensitive to make test more independent since using external resources like a real keycloak instance
 		wsName = fmt.Sprintf("test-%d", time.Now().Unix())
 		nsName = fmt.Sprintf("workspace-%s", wsName)
@@ -50,7 +50,7 @@ var _ = Describe("Workspace controller", func() {
 			mKcClient = nil
 			mKcClient = mocks.NewMockGoCloak(mockCtrl)
 			kcA.Client = mKcClient
-			setupMocksForWorkspaceCreation(mKcClient, kcAccessToken, kcA.TargetRealm, kcTargetClientID, wsName)
+			setupMocksForWorkspaceCreationExistingRoles(mKcClient, kcAccessToken, kcA.TargetRealm, kcTargetClientID, wsName, wsPrettyName)
 		})
 
 	It("Should create the related resources when creating a workspace", func() {
@@ -124,7 +124,7 @@ var _ = Describe("Workspace controller", func() {
 
 })
 
-func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessToken string, kcTargetRealm string, kcTargetClientID string, wsName string) {
+func setupMocksForWorkspaceCreationExistingRoles(mockKcCLient *mocks.MockGoCloak, kcAccessToken string, kcTargetRealm string, kcTargetClientID string, wsName string, wsPrettyName string) {
 	userKcRole := fmt.Sprintf("workspace-%s:user", wsName)
 	managerKcRole := fmt.Sprintf("workspace-%s:manager", wsName)
 	mockKcCLient.EXPECT().GetClientRole(
@@ -133,7 +133,7 @@ func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessTok
 		gomock.Eq(kcTargetRealm),
 		gomock.Eq(kcTargetClientID),
 		gomock.Eq(userKcRole),
-	).Return(&gocloak.Role{Name: &userKcRole}, nil).MinTimes(1).MaxTimes(2)
+	).Return(&gocloak.Role{Name: &userKcRole, Description: &wsPrettyName}, nil).MinTimes(1).MaxTimes(2)
 
 	mockKcCLient.EXPECT().GetClientRole(
 		gomock.AssignableToTypeOf(context.Background()),
@@ -141,5 +141,21 @@ func setupMocksForWorkspaceCreation(mockKcCLient *mocks.MockGoCloak, kcAccessTok
 		gomock.Eq(kcTargetRealm),
 		gomock.Eq(kcTargetClientID),
 		gomock.Eq(managerKcRole),
-	).Return(&gocloak.Role{Name: &managerKcRole}, nil).MinTimes(1).MaxTimes(2)
+	).Return(&gocloak.Role{Name: &managerKcRole, Description: &wsPrettyName}, nil).MinTimes(1).MaxTimes(2)
+
+	mockKcCLient.EXPECT().UpdateRole(
+		gomock.AssignableToTypeOf(context.Background()),
+		gomock.Eq(kcAccessToken),
+		gomock.Eq(kcTargetRealm),
+		gomock.Eq(kcTargetClientID),
+		gomock.AssignableToTypeOf(gocloak.Role{Name: &userKcRole, Description: &wsPrettyName}),
+	).Return(nil).MinTimes(1).MaxTimes(2)
+
+	mockKcCLient.EXPECT().UpdateRole(
+		gomock.AssignableToTypeOf(context.Background()),
+		gomock.Eq(kcAccessToken),
+		gomock.Eq(kcTargetRealm),
+		gomock.Eq(kcTargetClientID),
+		gomock.AssignableToTypeOf(gocloak.Role{Name: &managerKcRole, Description: &wsPrettyName}),
+	).Return(nil).MinTimes(1).MaxTimes(2)
 }


### PR DESCRIPTION
# Description

This PR includes:
- management of inconsistent workspaces, by adding the field `inconsistenWorkspaces` to the status of the tenant
- allows for the automatic unsubscription of a tenant from a workspace when the latter gets deleted
- adds automatic generation of the needed Kubernetes resources to allow the correct consumption of templates and instances
- renames the `admin` concept to `powerUser`
- adds a description equal to the pretty name of a workspace for better visualization in keycloak

# How Has This Been Tested?

At the current state, this PR doesn't add the proper testing, just the minimum for the test to run properly