### PR TITLE
SSH access: workspace managers key injection, update laboperator rbac

### DIFF
--- a/operators/deploy/bastion-operator/k8s-cluster-role.yaml
+++ b/operators/deploy/bastion-operator/k8s-cluster-role.yaml
@@ -5,4 +5,4 @@ metadata:
 rules:
 - apiGroups: ["crownlabs.polito.it"]
   resources: ["tenants"]
-  verbs: ["list","watch"]
+  verbs: ["get","watch"]

--- a/operators/deploy/laboratory-operator/k8s-cluster-role.yaml
+++ b/operators/deploy/laboratory-operator/k8s-cluster-role.yaml
@@ -11,6 +11,10 @@ rules:
   resources: ["labtemplates", "templates"]
   verbs: ["get","list","watch"]
 
+- apiGroups: ["crownlabs.polito.it"]
+  resources: ["tenants"]
+  verbs: ["get","list"]
+
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get","list","watch"]

--- a/operators/pkg/bastion-controller/bastion_controller.go
+++ b/operators/pkg/bastion-controller/bastion_controller.go
@@ -39,7 +39,7 @@ type BastionReconciler struct {
 	AuthorizedKeysPath string
 }
 
-// +kubebuilder:rbac:groups=crownlabs.polito.it,resources=tenants,verbs=list
+// +kubebuilder:rbac:groups=crownlabs.polito.it,resources=tenants,verbs=get;watch
 
 func (r *BastionReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()

--- a/operators/pkg/instance-controller/logic.go
+++ b/operators/pkg/instance-controller/logic.go
@@ -30,14 +30,14 @@ func (r *LabInstanceReconciler) CreateVMEnvironment(labInstance *crownlabsv1alph
 		klog.Error("unable to get Webdav Credentials")
 		klog.Error(err)
 	} else {
-		klog.Info("Webdav secrets obtained. Getting public keys." + labInstance.Name)
+		klog.Info("Webdav secrets obtained. Getting public keys. " + labInstance.Name)
 	}
 	var publicKeys []string
-	if err := instance_creation.GetPublicKeys(r.Client, ctx, labInstance.Spec.Tenant.Name, labInstance.Spec.Tenant.Namespace, &publicKeys); err != nil {
+	if err := instance_creation.GetPublicKeys(r.Client, ctx, labInstance.Spec.Tenant, labInstance.Spec.Template, &publicKeys); err != nil {
 		klog.Error("unable to get public keys")
 		klog.Error(err)
 	} else {
-		klog.Info("Public keys obtained. Building cloud-init script." + labInstance.Name)
+		klog.Info("Public keys obtained. Building cloud-init script. " + labInstance.Name)
 	}
 	secret := instance_creation.CreateCloudInitSecret(name, namespace, user, password, r.NextcloudBaseUrl, publicKeys, globalOwnerReference)
 	if err := instance_creation.CreateOrUpdate(r.Client, ctx, secret); err != nil {

--- a/operators/pkg/instance-creation/ssh.go
+++ b/operators/pkg/instance-creation/ssh.go
@@ -4,22 +4,48 @@ import (
 	"context"
 
 	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetPublicKeys(c client.Client, ctx context.Context, name string, namespace string, publicKeys *[]string) error {
+func GetPublicKeys(c client.Client, ctx context.Context, Tenant crownlabsv1alpha2.GenericRef, Template crownlabsv1alpha2.GenericRef, publicKeys *[]string) error {
 	tenant := crownlabsv1alpha1.Tenant{}
-	nsdName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	if err := c.Get(ctx, nsdName, &tenant); err == nil {
-
-		*publicKeys = append(*publicKeys, tenant.Spec.PublicKeys...)
-
-		return nil
-	} else {
+	if err := c.Get(ctx, types.NamespacedName{
+		Namespace: Tenant.Namespace,
+		Name:      Tenant.Name,
+	}, &tenant); err != nil {
 		return err
 	}
+
+	*publicKeys = append(*publicKeys, tenant.Spec.PublicKeys...)
+
+	template := crownlabsv1alpha2.Template{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Namespace: Template.Namespace,
+		Name:      Template.Name,
+	}, &template); err != nil {
+		return err
+	}
+
+	label := map[string]string{crownlabsv1alpha1.WorkspaceLabelPrefix + template.Spec.WorkspaceRef.Name: "manager"}
+
+	var managers crownlabsv1alpha1.TenantList
+	if err := c.List(context.Background(), &managers, client.MatchingLabels(label)); apierrors.IsNotFound(err) {
+		// if there are no managers in this worspace there's nothing to do
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	for _, manager := range managers.Items {
+		// avoid duplicates
+		if manager.Name != tenant.Name {
+			*publicKeys = append(*publicKeys, manager.Spec.PublicKeys...)
+		}
+	}
+
+	return nil
+
 }


### PR DESCRIPTION
# Description

This PR updates the permission of Laboperator so that it is possible to retrieve the related tenant and workspace managers.
In addition it brings the feature of retrieving also the workspace managers keys in order to inject them in the VM.

It also fixes the RBAC of bastion-operator, since the `list` action is not performed anymore, the permission to `get` is granted instead.

# How Has This Been Tested?

At the moment no tests have been performed, apart from a successful build and run of the operator.
