### PR TITLE
Tenant operator: add rbac to access own tenant resource

### DIFF
--- a/operators/deploy/tenant-operator/k8s-cluster-role.yaml
+++ b/operators/deploy/tenant-operator/k8s-cluster-role.yaml
@@ -12,7 +12,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "delete", "deletecollection"]
 
   - apiGroups: ["rbac.authorization.k8s.io"]
-    resources: ["rolebindings", "clusterrolebindings"]
+    resources: ["rolebindings", "clusterroles", "clusterrolebindings"]
     verbs: ["get", "list", "watch", "create", "update", "delete", "deletecollection"]
 
   - apiGroups: ["networking.k8s.io"]

--- a/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
+++ b/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
@@ -83,7 +83,7 @@ spec:
         resources:
           limits:
             memory: 250Mi
-            cpu: 100m
+            cpu: 250m
           requests:
             memory: 100Mi
             cpu: 100m

--- a/operators/pkg/tenant-controller/workspace_controller.go
+++ b/operators/pkg/tenant-controller/workspace_controller.go
@@ -128,12 +128,11 @@ func (r *WorkspaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		retrigErr = err
 	}
 
-	if retrigErr != nil {
+	if retrigErr == nil {
 		klog.Infof("Workspace %s reconciled successfully", ws.Name)
 	} else {
 		klog.Errorf("Workspace %s failed to reconcile", ws.Name)
 	}
-	klog.Info(randomRange(60, 120))
 	return ctrl.Result{RequeueAfter: (time.Minute * time.Duration(randomRange(60, 120)))}, retrigErr
 }
 


### PR DESCRIPTION
# Description

This PR adds the creation of the cluster role and cluster role binding to the tenant operator to allow each user to access its own tenant resource,

# How Has This Been Tested?

- Adding some tests to the tenant operator
