### PR TITLE
Add finalizers to tenant operator and other improvements

### DIFF
--- a/operators/api/v1alpha1/common_types.go
+++ b/operators/api/v1alpha1/common_types.go
@@ -25,3 +25,6 @@ type GenericRef struct {
 
 // WorkspaceLabelPrefix is the prefix of a label assigned to a tenant indicating it is subscribed to a workspace
 const WorkspaceLabelPrefix = "crownlabs.polito.it/workspace-"
+
+// TnOperatorFinalizerName is the name of the finalizer corresponding to the tenant operator
+const TnOperatorFinalizerName = "crownlabs.polito.it/tenant-operator"

--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -53,14 +53,14 @@ type TenantSpec struct {
 	// +kubebuilder:validation:Pattern="^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 	Email string `json:"email"`
 
-	// list of workspaces the user is in
+	// list of workspaces the user is subscribed to
 	Workspaces []UserWorkspaceData `json:"workspaces,omitempty"`
 
-	// public keys of user
+	// public keys of tenant
 	PublicKeys []string `json:"publicKeys,omitempty"`
 
 	// should the resource create the sandbox namespace for k8s practice environment
-	// +kubebuilder:validation:Default=false
+	// +kubebuilder:default=false
 	CreateSandbox bool `json:"createSandbox,omitempty"`
 }
 
@@ -69,11 +69,15 @@ type TenantStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	PersonalNamespace NameCreated                   `json:"personalNamespace,omitempty"`
-	SandboxNamespace  NameCreated                   `json:"sandboxNamespace,omitempty"`
-	FailingWorkspaces []string                      `json:"failingWorkspaces,omitempty"`
-	Subscriptions     map[string]SubscriptionStatus `json:"subscriptions,omitempty"`
-	Ready             bool                          `json:"ready,omitempty"`
+	PersonalNamespace NameCreated `json:"personalNamespace"`
+	SandboxNamespace  NameCreated `json:"sandboxNamespace"`
+
+	// list of workspace that are throwing errors during subscription
+	FailingWorkspaces []string `json:"failingWorkspaces"`
+
+	// list of subscriptions to non-k8s services (keycloak, nextcloud, ..)
+	Subscriptions map[string]SubscriptionStatus `json:"subscriptions"`
+	Ready         bool                          `json:"ready"`
 }
 
 // +kubebuilder:object:root=true

--- a/operators/api/v1alpha1/workspace_types.go
+++ b/operators/api/v1alpha1/workspace_types.go
@@ -38,6 +38,7 @@ type WorkspaceStatus struct {
 
 	Namespace NameCreated `json:"namespace,omitempty"`
 
+	// list of subscriptions to non-k8s services (keycloak, nextcloud, ..)
 	Subscriptions map[string]SubscriptionStatus `json:"subscription,omitempty"`
 
 	Ready bool `json:"ready,omitempty"`

--- a/operators/crd-examples/tenant.yml
+++ b/operators/crd-examples/tenant.yml
@@ -8,11 +8,11 @@ spec:
   email: mario.rossi@email.com
   workspaces:
     - workspaceRef:
-        name: landc
+        name: tea
       role: user
       groupNumber: 12
     - workspaceRef:
-        name: swnet
+        name: coffee
       role: manager
       groupNumber: 12
   publicKeys:

--- a/operators/crd-examples/workspace.yml
+++ b/operators/crd-examples/workspace.yml
@@ -1,6 +1,14 @@
 apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
-  name: swnet
+  name: tea
 spec:
-  prettyName: Software Networking
+  prettyName: A cup of tea from hte queen
+
+---
+apiVersion: crownlabs.polito.it/v1alpha1
+kind: Workspace
+metadata:
+  name: coffee
+spec:
+  prettyName: Just coffee

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -49,6 +49,7 @@ spec:
             description: TenantSpec defines the desired state of Tenant
             properties:
               createSandbox:
+                default: false
                 description: should the resource create the sandbox namespace for k8s practice environment
                 type: boolean
               email:
@@ -59,12 +60,12 @@ spec:
               lastName:
                 type: string
               publicKeys:
-                description: public keys of user
+                description: public keys of tenant
                 items:
                   type: string
                 type: array
               workspaces:
-                description: list of workspaces the user is in
+                description: list of workspaces the user is subscribed to
                 items:
                   description: UserWorkspaceData contains the info of the workspaces related to a user
                   properties:
@@ -100,6 +101,7 @@ spec:
             description: TenantStatus defines the observed state of Tenant
             properties:
               failingWorkspaces:
+                description: list of workspace that are throwing errors during subscription
                 items:
                   type: string
                 type: array
@@ -132,7 +134,14 @@ spec:
                   - Ok
                   - Failed
                   type: string
+                description: list of subscriptions to non-k8s services (keycloak, nextcloud, ..)
                 type: object
+            required:
+            - failingWorkspaces
+            - personalNamespace
+            - ready
+            - sandboxNamespace
+            - subscriptions
             type: object
         type: object
     served: true

--- a/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
@@ -69,6 +69,7 @@ spec:
                   - Ok
                   - Failed
                   type: string
+                description: list of subscriptions to non-k8s services (keycloak, nextcloud, ..)
                 type: object
             type: object
         type: object

--- a/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
+++ b/operators/deploy/tenant-operator/k8s-manifest.yaml.tmpl
@@ -83,7 +83,7 @@ spec:
         resources:
           limits:
             memory: 250Mi
-            cpu: 250m
+            cpu: 1000m
           requests:
             memory: 100Mi
             cpu: 100m

--- a/operators/pkg/tenant-controller/common_utils.go
+++ b/operators/pkg/tenant-controller/common_utils.go
@@ -1,0 +1,17 @@
+package tenant_controller
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+func randomRange(min, max int) (*int, error) {
+	bg := big.NewInt(int64(max - min))
+
+	n, err := rand.Int(rand.Reader, bg)
+	if err != nil {
+		return nil, err
+	}
+	ret := int(n.Int64()) + min
+	return &ret, nil
+}

--- a/operators/pkg/tenant-controller/common_utils.go
+++ b/operators/pkg/tenant-controller/common_utils.go
@@ -15,3 +15,23 @@ func randomRange(min, max int) (*int, error) {
 	ret := int(n.Int64()) + min
 	return &ret, nil
 }
+
+// Helper functions to check and remove string from a slice of strings.
+func containsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+func removeString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -405,7 +405,7 @@ func updateTnResQuota(rq *v1.ResourceQuota) {
 
 	resourceList := make(v1.ResourceList)
 
-	resourceList["limits.cpu"] = *resource.NewQuantity(10, resource.DecimalSI)
+	resourceList["limits.cpu"] = *resource.NewQuantity(15, resource.DecimalSI)
 	resourceList["limits.memory"] = *resource.NewQuantity(25*1024*1024*1024, resource.BinarySI)
 	resourceList["requests.cpu"] = *resource.NewQuantity(10, resource.DecimalSI)
 	resourceList["requests.memory"] = *resource.NewQuantity(25*1024*1024*1024, resource.BinarySI)

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -41,8 +41,8 @@ var _ = Describe("Tenant controller", func() {
 		wsManagerRole = "workspace-ws1:manager"
 
 		tnName          = "mariorossi"
-		tnFirstName     = "mario"
-		tnLastName      = "rossi"
+		tnFirstName     = "marià"
+		tnLastName      = "ròssì"
 		tnWorkspaces    = []crownlabsv1alpha1.UserWorkspaceData{{WorkspaceRef: crownlabsv1alpha1.GenericRef{Name: "ws1"}, Role: crownlabsv1alpha1.User}}
 		tnEmail         = "mario.rossi@email.com"
 		userID          = "userID"
@@ -80,7 +80,6 @@ var _ = Describe("Tenant controller", func() {
 			gomock.Eq(kcTargetRealm),
 			gomock.Eq(gocloak.GetUsersParams{Username: &tnName}),
 		).Return([]*gocloak.User{}, nil).AnyTimes()
-		// .MinTimes(1).MaxTimes(2)
 
 		mKcClient.EXPECT().CreateUser(
 			gomock.AssignableToTypeOf(context.Background()),
@@ -96,7 +95,6 @@ var _ = Describe("Tenant controller", func() {
 					EmailVerified: &fa,
 				}),
 		).Return(userID, nil).AnyTimes()
-		// .MinTimes(1).MaxTimes(2)
 
 		mKcClient.EXPECT().ExecuteActionsEmail(
 			gomock.AssignableToTypeOf(context.Background()),
@@ -107,7 +105,6 @@ var _ = Describe("Tenant controller", func() {
 				Lifespan: &emailActionLifespan,
 				Actions:  &reqActions,
 			})).Return(nil).AnyTimes()
-		// .MinTimes(1).MaxTimes(2)
 
 		mKcClient.EXPECT().GetClientRole(
 			gomock.AssignableToTypeOf(context.Background()),
@@ -232,6 +229,12 @@ var _ = Describe("Tenant controller", func() {
 			}
 			// check if labels have been correctly updated
 			if tn.Labels[wsLabelKey] != string(crownlabsv1alpha1.User) {
+				return false
+			}
+			if tn.Labels["crownlabs.polito.it/first-name"] != "mari" {
+				return false
+			}
+			if tn.Labels["crownlabs.polito.it/last-name"] != "rss" {
 				return false
 			}
 			return true

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -237,6 +237,9 @@ var _ = Describe("Tenant controller", func() {
 			if tn.Labels["crownlabs.polito.it/last-name"] != "rss" {
 				return false
 			}
+			if !containsString(tn.Finalizers, "crownlabs.polito.it/tenant-operator") {
+				return false
+			}
 			return true
 		}, timeout, interval).Should(BeTrue())
 

--- a/operators/pkg/tenant-controller/workspace_controller_test.go
+++ b/operators/pkg/tenant-controller/workspace_controller_test.go
@@ -102,24 +102,14 @@ var _ = Describe("Workspace controller", func() {
 			if !ws.Status.Namespace.Created || ws.Status.Namespace.Name != nsName {
 				return false
 			}
-			return true
-		}, timeout, interval).Should(BeTrue())
-
-		By("By checking that the corresponding keycloak roles have been created")
-
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, wsLookupKey, ws)
-			if err != nil {
-				return false
-			}
 			if ws.Status.Subscriptions["keycloak"] != crownlabsv1alpha1.SubscrOk {
 				return false
 			}
-
+			if !containsString(ws.Finalizers, "crownlabs.polito.it/tenant-operator") {
+				return false
+			}
 			return true
 		}, timeout, interval).Should(BeTrue())
-		By("By checking that the keycloak deleteRole methods get called when a workspace is deleted")
-
 	})
 
 })


### PR DESCRIPTION
# Description

This PR includes:
- fix issue when getting users in keycloak in case the username of a user is part of a username of other users
- add labels to tenant resource for firstName and lastName
- make `ready` field required in API declaration to allow proper visualization in case field is false (useful when using `kubectl get tenants | grep false` for first glance feedback)
- add support for finalizers in tenant controller, to allow proper deletion of internal/external resources
- add tests for cluster resources creation. This should not increase the coverage but should be useful in case something changes in the future.

# How Has This Been Tested?

This PR adds tests to:
- check the correct addition of the finalizer reference to the workspace/tenant
- checks that the pair `mariò ròssì` gets turned into `mari rss` when adding the labels for firstName and lastName to the tenant
