### PR TITLE
Fix wrong VM instance generation

### DIFF
--- a/operators/pkg/instance-creation/creation.go
+++ b/operators/pkg/instance-creation/creation.go
@@ -212,8 +212,8 @@ func CreateOrUpdate(c client.Client, ctx context.Context, object interface{}) er
 }
 
 func CheckLabels(ns v1.Namespace, matchLabels map[string]string) bool {
-	for key := range matchLabels {
-		if _, ok := ns.Labels[key]; !ok {
+	for key, value := range matchLabels {
+		if v1, ok := ns.Labels[key]; !ok || v1 != value {
 			return false
 		}
 	}

--- a/operators/pkg/instance-creation/creation.go
+++ b/operators/pkg/instance-creation/creation.go
@@ -23,6 +23,7 @@ var memoryHypervisorReserved string = "500M"
 var registryCred string = "registry-credentials"
 
 func CreateVirtualMachineInstance(name string, namespace string, template *crownlabsv1alpha2.Environment, instanceName string, secretName string, references []metav1.OwnerReference) (*virtv1.VirtualMachineInstance, error) {
+	vmMemory := template.Resources.Memory
 	template.Resources.Memory.Add(resource.MustParse(memoryHypervisorReserved))
 	vm := virtv1.VirtualMachineInstance{
 		TypeMeta: metav1.TypeMeta{
@@ -52,7 +53,7 @@ func CreateVirtualMachineInstance(name string, namespace string, template *crown
 					Cores: template.Resources.CPU,
 				},
 				Memory: &virtv1.Memory{
-					Guest: &template.Resources.Memory,
+					Guest: &vmMemory,
 				},
 				Machine: virtv1.Machine{},
 				Devices: virtv1.Devices{

--- a/operators/pkg/instance-creation/creation_test.go
+++ b/operators/pkg/instance-creation/creation_test.go
@@ -115,6 +115,7 @@ func TestCreateVirtualMachineInstance(t *testing.T) {
 	assert.Equal(t, vm.Spec.Domain.Devices.Disks[1].Name, "cloudinitdisk")
 	assert.Equal(t, vm.Spec.Domain.CPU.Cores, uint32(1))
 	assert.Equal(t, vm.Spec.Domain.Resources.Limits.Memory().String(), "1524M")
+	assert.Equal(t, vm.Spec.Domain.Memory.Guest.String(), "1024M")
 	assert.Equal(t, vm.Spec.Domain.Resources.Limits.Cpu().String(), "1500m")
 	assert.Equal(t, vm.Spec.Domain.Resources.Requests.Cpu().String(), "250m")
 	assert.Equal(t, vm.Spec.Volumes[0].Name, "containerdisk")

--- a/operators/pkg/instance-creation/creation_test.go
+++ b/operators/pkg/instance-creation/creation_test.go
@@ -126,3 +126,40 @@ func TestCreateVirtualMachineInstance(t *testing.T) {
 	assert.Equal(t, vm.Kind, "VirtualMachineInstance")
 	assert.Equal(t, vm.APIVersion, "kubevirt.io/v1alpha3")
 }
+
+func TestCheckLabels(t *testing.T) {
+	labels := map[string]string{
+		"crownlabs.polito.it/operator-selector": "production",
+	}
+	ns := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"crownlabs.polito.it/operator-selector": "production",
+			},
+		},
+	}
+	ns1 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"crownlabs.polito.it/operator-selector": "preprod",
+			},
+		},
+	}
+	ns2 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"crownlabs.polito.it/other": "production",
+			},
+		},
+	}
+	ns3 := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{},
+		},
+	}
+	assert.Equal(t, CheckLabels(ns, labels), true)
+	assert.Equal(t, CheckLabels(ns1, labels), false)
+	assert.Equal(t, CheckLabels(ns2, labels), false)
+	assert.Equal(t, CheckLabels(ns3, labels), false)
+
+}


### PR DESCRIPTION
# Description

This PR fixes the memory quantity associated to a VM instance in the instance operator

# How Has This Been Tested?

Unit Tests
