### PR TITLE
SSH access: run sshd as user bastion, add tenant schema to laboperator

### DIFF
--- a/operators/build/ssh-bastion/Dockerfile
+++ b/operators/build/ssh-bastion/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --no-cache dumb-init openssh
 # Create new user bastion with nologin
 RUN adduser -D -s /sbin/nologin bastion
 RUN passwd -u -d bastion
+RUN mkdir /ssh_pids && chmod 777 /ssh_pids
 
 # sshd configuration file
 COPY ./sshd_config_custom /etc/ssh/sshd_config_custom

--- a/operators/build/ssh-bastion/sshd_config_custom
+++ b/operators/build/ssh-bastion/sshd_config_custom
@@ -7,6 +7,9 @@ PubkeyAuthentication yes
 # We need this otherwise sshd will raise ownership issues about the file updated from the sidecar
 StrictModes no
 
+# Custom location for pid files
+PidFile /ssh_pids/sshd.pid
+
 # host_keys volume is expected to be mounted using a secret
 HostKey /host-keys/ssh_host_key_rsa
 HostKey /host-keys/ssh_host_key_ecdsa

--- a/operators/cmd/laboratory-operator/main.go
+++ b/operators/cmd/laboratory-operator/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	instance_controller "github.com/netgroup-polito/CrownLabs/operators/pkg/instance-controller"
 	// +kubebuilder:scaffold:imports
@@ -42,7 +43,7 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 
-	_ = crownlabsv1alpha2.AddToScheme(scheme)
+	_ = crownlabsv1alpha1.AddToScheme(scheme)
 
 	_ = crownlabsv1alpha2.AddToScheme(scheme)
 

--- a/operators/deploy/bastion-operator/k8s-cluster-role.yaml
+++ b/operators/deploy/bastion-operator/k8s-cluster-role.yaml
@@ -5,4 +5,4 @@ metadata:
 rules:
 - apiGroups: ["crownlabs.polito.it"]
   resources: ["tenants"]
-  verbs: ["get","watch"]
+  verbs: ["get","list","watch"]

--- a/operators/deploy/bastion-operator/k8s-manifest.yaml.tmpl
+++ b/operators/deploy/bastion-operator/k8s-manifest.yaml.tmpl
@@ -74,6 +74,13 @@ spec:
         resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          capabilities:
+            drop: ["all"]
+          allowPrivilegeEscalation: false
+          runAsUser: 1000
+          runAsGroup: 1000
+          privileged: false
         volumeMounts:
         - mountPath: /home/bastion/.ssh
           name: authorized-keys
@@ -90,7 +97,7 @@ spec:
         - name: host-keys
           secret:
             secretName: ssh-bastion-host-keys
-            defaultMode: 0400
+            defaultMode: 0444
 
 ---
 apiVersion: v1


### PR DESCRIPTION
# Description

This PR brings modifications to the deployment of bastion-operator as well as to the ssh-bastion image in order to run sshd as unprivileged user, in this case as 1000:1000 (bastion:bastion).

It adds also the Tenant scheme to the laboperator, fixing an issue that made impossible to the laboperator retrieve the s tenants and with them the ssh keys.

In addition it sets up the readiness and healty check to the bastion-operator and brings back the RBAC permission to list tenants in the bastion-operator cluster role since apparently on the first start it needs to list all tenants.

# How Has This Been Tested?

- applying deployment on a local kind cluster
- running the already present tests