### PR TITLE
Revert the test and lint pipelines to pull_request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Check linting
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -42,7 +42,7 @@ jobs:
       - name: Check linting
         uses: grantmcconnaughey/lintly-flake8-github-action@v1.0
         with:
-          token: ${{ secrets.CI_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           failIf: any
         env:
           LINTLY_PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     - master
     tags:
     - "v*"
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened
@@ -149,8 +149,9 @@ jobs:
               ```
             </details>
           reactions: confused
-        if: github.event_name != 'push' && failure()
-
+        if: |
+          github.event_name != 'push' && failure() &&
+          github.event.pull_request.head.repo.full_name == github.repository
 
   kubernetes-manifests:
     name: Kubernetes manifests


### PR DESCRIPTION
# Description

This PR reverts the test and lint pipelines to be triggered by the pull_request event, instead of pull_request_target 


