### PR TITLE
Add custom metrics and label filter to tenant operator

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -19,7 +19,6 @@ dashboard:
       clientSecret: <client-secret>
       providerUrl: https://auth.example.com/auth/realms/crownlabs
 
-
 instance-operator:
   replicaCount: 1
   image:
@@ -38,13 +37,13 @@ instance-operator:
       clientSecret: <client-secret>
       providerUrl: https://auth.example.com/auth/realms/crownlabs
 
-
 tenant-operator:
   replicaCount: 1
   image:
     repository: crownlabs/tenant-operator
   rbacResourcesName: crownlabs-tenant-operator
   configurations:
+    targetLabel: crownlabs.polito.it/operator-selector=production
     keycloak:
       url: "https://auth.crownlabs.example.com/"
       loginRealm: master
@@ -57,7 +56,6 @@ tenant-operator:
       user: username
       pass: password
 
-
 bastion-operator:
   replicaCount: 1
   image:
@@ -65,7 +63,6 @@ bastion-operator:
     repositorySidecar: crownlabs/bastion-operator
   rbacResourcesName: crownlabs-bastion-operator
   serviceAnnotations: {}
-
 
 image-list:
   replicaCount: 1
@@ -77,7 +74,6 @@ image-list:
     advRegistryName: registry.crownlabs.example.com
     imageListName: crownlabs-virtual-machine-images
     updateInterval: 60
-
 
 delete-stale-instances:
   image:

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -53,13 +53,14 @@ endif
 
 run-tenant: generate fmt vet manifests
 	go run  cmd/tenant-operator/main.go\
-				--kc-URL=$(KEYCLOAK_URL)\
+				--target-label=reconcile=true\
+				--kc-url=$(KEYCLOAK_URL)\
 				--kc-tenant-operator-user=$(KEYCLOAK_TENANT_OPERATOR_USER)\
 				--kc-tenant-operator-psw=$(KEYCLOAK_TENANT_OPERATOR_PSW)\
 				--kc-login-realm=$(KEYCLOAK_LOGIN_REALM)\
 				--kc-target-realm=$(KEYCLOAK_TARGET_REALM)\
 				--kc-target-client=$(KEYCLOAK_TARGET_CLIENT)\
-				--nc-URL=$(NEXTCLOUD_URL)\
+				--nc-url=$(NEXTCLOUD_URL)\
 				--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)\
 				--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)
 

--- a/operators/crd-examples/tenant.yml
+++ b/operators/crd-examples/tenant.yml
@@ -2,6 +2,8 @@ apiVersion: crownlabs.polito.it/v1alpha1
 kind: Tenant
 metadata:
   name: mariorossi
+  labels:
+    reconcile: "true"
 spec:
   firstName: mario
   lastName: rossi

--- a/operators/crd-examples/workspace.yml
+++ b/operators/crd-examples/workspace.yml
@@ -2,13 +2,23 @@ apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
   name: tea
+  labels:
+    reconcile: "true"
 spec:
-  prettyName: A cup of tea from hte queen
-
+  prettyName: A cup of tea from the queen
 ---
 apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
   name: coffee
+  labels:
+    reconcile: "true"
 spec:
   prettyName: Just coffee
+---
+apiVersion: crownlabs.polito.it/v1alpha1
+kind: Workspace
+metadata:
+  name: chill-pepper
+spec:
+  prettyName: A bit spicy

--- a/operators/deploy/tenant-operator/templates/configmap.yaml
+++ b/operators/deploy/tenant-operator/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "tenant-operator.labels" . | nindent 4 }}
 data:
+  target-label: {{ .Values.configurations.targetLabel }}
   keycloak-url: {{ .Values.configurations.keycloak.url }}
   keycloak-login-realm: {{ .Values.configurations.keycloak.loginRealm }}
   keycloak-target-realm: {{ .Values.configurations.keycloak.targetRealm }}

--- a/operators/deploy/tenant-operator/templates/deployment.yaml
+++ b/operators/deploy/tenant-operator/templates/deployment.yaml
@@ -36,13 +36,14 @@ spec:
           command:
             - /usr/bin/controller
           args:
-            - "--kc-URL=$(KEYCLOAK_URL)"
+            - "--target-label=$(TARGET_LABEL)"
+            - "--kc-url=$(KEYCLOAK_URL)"
             - "--kc-login-realm=$(KEYCLOAK_LOGIN_REALM)"
             - "--kc-target-realm=$(KEYCLOAK_TARGET_REALM)"
             - "--kc-target-client=$(KEYCLOAK_TARGET_CLIENT)"
             - "--kc-tenant-operator-user=$(KEYCLOAK_TENANT_OPERATOR_USER)"
             - "--kc-tenant-operator-psw=$(KEYCLOAK_TENANT_OPERATOR_PSW)"
-            - "--nc-URL=$(NEXTCLOUD_URL)"
+            - "--nc-url=$(NEXTCLOUD_URL)"
             - "--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)"
             - "--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)"
           ports:
@@ -67,6 +68,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: TARGET_LABEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "tenant-operator.fullname" . }}
+                  key: target-label
             - name: KEYCLOAK_URL
               valueFrom:
                 configMapKeyRef:

--- a/operators/deploy/tenant-operator/values.yaml
+++ b/operators/deploy/tenant-operator/values.yaml
@@ -5,6 +5,7 @@
 replicaCount: 1
 
 configurations:
+  targetLabel: crownlabs.polito.it/operator-selector=production
   keycloak:
     url: "https://auth.crownlabs.example.com/"
     loginRealm: master

--- a/operators/pkg/tenant-controller/metrics.go
+++ b/operators/pkg/tenant-controller/metrics.go
@@ -1,0 +1,20 @@
+package tenant_controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	tnOpinternalErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "tenant_operator_internal_errors",
+		Help: "The number of errors occurred internally during the reconcile of the tenant operator",
+	},
+		[]string{"controller", "reason"},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(tnOpinternalErrors)
+}

--- a/operators/pkg/tenant-controller/suite_test.go
+++ b/operators/pkg/tenant-controller/suite_test.go
@@ -47,6 +47,9 @@ var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
+const targetLabelKey = "reconcile"
+const targetLabelValue = "true"
+
 const kcAccessToken = "keycloak-token"
 const kcTargetRealm = "targetRealm"
 const kcTargetClientID = "targetClientId"
@@ -98,17 +101,21 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&WorkspaceReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		KcA:    &kcA,
+		Client:           k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		KcA:              &kcA,
+		TargetLabelKey:   targetLabelKey,
+		TargetLabelValue: targetLabelValue,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&TenantReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: k8sManager.GetScheme(),
-		KcA:    &kcA,
-		NcA:    mNcA,
+		Client:           k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		KcA:              &kcA,
+		NcA:              mNcA,
+		TargetLabelKey:   targetLabelKey,
+		TargetLabelValue: targetLabelValue,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -170,6 +170,7 @@ var _ = Describe("Tenant controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      wsName,
 				Namespace: wsNamespace,
+				Labels:    map[string]string{targetLabelKey: targetLabelValue},
 			},
 			Spec: crownlabsv1alpha1.WorkspaceSpec{
 				PrettyName: wsPrettyName,
@@ -186,6 +187,7 @@ var _ = Describe("Tenant controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      tnName,
 				Namespace: tnNamespace,
+				Labels:    map[string]string{targetLabelKey: targetLabelValue},
 			},
 			Spec: crownlabsv1alpha1.TenantSpec{
 				FirstName:  tnFirstName,

--- a/operators/pkg/tenant-controller/workspace_controller.go
+++ b/operators/pkg/tenant-controller/workspace_controller.go
@@ -32,8 +32,10 @@ import (
 // WorkspaceReconciler reconciles a Workspace object
 type WorkspaceReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	KcA    *KcActor
+	Scheme           *runtime.Scheme
+	KcA              *KcActor
+	TargetLabelKey   string
+	TargetLabelValue string
 }
 
 // +kubebuilder:rbac:groups=crownlabs.polito.it,resources=workspaces,verbs=get;list;watch;create;update;patch;delete
@@ -116,7 +118,7 @@ func (r *WorkspaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		ws.Status.Subscriptions = make(map[string]crownlabsv1alpha1.SubscriptionStatus, 1)
 	}
 	// handling keycloak resources
-	if err = r.KcA.createKcRoles(ctx, genWorkspaceKcRolesData(ws.Name, ws.Spec.PrettyName)); err != nil {
+	if err = r.KcA.createKcRoles(ctx, genWsKcRolesData(ws.Name, ws.Spec.PrettyName)); err != nil {
 		klog.Errorf("Error when creating roles for workspace %s -> %s", ws.Name, err)
 		ws.Status.Subscriptions["keycloak"] = crownlabsv1alpha1.SubscrFailed
 		retrigErr = err
@@ -155,6 +157,7 @@ func (r *WorkspaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(genPredicatesForMatchLabel(r.TargetLabelKey, r.TargetLabelValue)).
 		For(&crownlabsv1alpha1.Workspace{}).
 		Owns(&v1.Namespace{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
@@ -164,7 +167,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *WorkspaceReconciler) handleDeletion(ctx context.Context, wsName, wsPrettyName string) error {
 	var retErr error
-	rolesToDelete := genWorkspaceKcRolesData(wsName, wsPrettyName)
+	rolesToDelete := genWsKcRolesData(wsName, wsPrettyName)
 	if err := r.KcA.deleteKcRoles(ctx, rolesToDelete); err != nil {
 		klog.Errorf("Error when deleting roles of workspace %s -> %s", wsName, err)
 		tnOpinternalErrors.WithLabelValues("workspace", "self-update").Inc()
@@ -211,7 +214,7 @@ func (r *WorkspaceReconciler) createOrUpdateClusterResources(ctx context.Context
 	ns := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 
 	if _, nsErr := ctrl.CreateOrUpdate(ctx, r.Client, &ns, func() error {
-		updateWsNamespace(&ns)
+		r.updateWsNamespace(&ns)
 		return ctrl.SetControllerReference(ws, &ns, r.Scheme)
 	}); nsErr != nil {
 		klog.Errorf("Error when updating namespace of workspace %s -> %s", ws.Name, nsErr)
@@ -222,7 +225,7 @@ func (r *WorkspaceReconciler) createOrUpdateClusterResources(ctx context.Context
 	// handle clusterRoleBinding
 	crb := rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("crownlabs-manage-instances-%s", ws.Name)}}
 	crbOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &crb, func() error {
-		updateWsCrb(&crb, ws.Name)
+		r.updateWsCrb(&crb, ws.Name)
 		return ctrl.SetControllerReference(ws, &crb, r.Scheme)
 	})
 	if err != nil {
@@ -234,7 +237,7 @@ func (r *WorkspaceReconciler) createOrUpdateClusterResources(ctx context.Context
 	// handle roleBinding
 	rb := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-view-templates", Namespace: nsName}}
 	rbOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &rb, func() error {
-		updateWsRb(&rb, ws.Name)
+		r.updateWsRb(&rb, ws.Name)
 		return ctrl.SetControllerReference(ws, &rb, r.Scheme)
 	})
 	if err != nil {
@@ -246,7 +249,7 @@ func (r *WorkspaceReconciler) createOrUpdateClusterResources(ctx context.Context
 	// handle manager roleBinding
 	managerRb := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "crownlabs-manage-templates", Namespace: nsName}}
 	mngRbOpRes, err := ctrl.CreateOrUpdate(ctx, r.Client, &managerRb, func() error {
-		updateWsRbMng(&managerRb, ws.Name)
+		r.updateWsRbMng(&managerRb, ws.Name)
 		return ctrl.SetControllerReference(ws, &managerRb, r.Scheme)
 	})
 	if err != nil {
@@ -258,44 +261,48 @@ func (r *WorkspaceReconciler) createOrUpdateClusterResources(ctx context.Context
 	return true, retErr
 }
 
-func updateWsNamespace(ns *v1.Namespace) {
-	if ns.Labels == nil {
-		ns.Labels = make(map[string]string, 1)
-	}
+func (r *WorkspaceReconciler) updateWsNamespace(ns *v1.Namespace) {
+	ns.Labels = r.updateWsResourceCommonLabels(ns.Labels)
+
 	ns.Labels["crownlabs.polito.it/type"] = "workspace"
 }
 
-func updateWsCrb(crb *rbacv1.ClusterRoleBinding, wsName string) {
-	if crb.Labels == nil {
-		crb.Labels = make(map[string]string, 1)
-	}
-	crb.Labels["crownlabs.polito.it/managed-by"] = "workspace"
+func (r *WorkspaceReconciler) updateWsCrb(crb *rbacv1.ClusterRoleBinding, wsName string) {
+	crb.Labels = r.updateWsResourceCommonLabels(crb.Labels)
+
 	crb.RoleRef = rbacv1.RoleRef{Kind: "ClusterRole", Name: "crownlabs-manage-instances", APIGroup: "rbac.authorization.k8s.io"}
-	crb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWorkspaceKcRoleName(wsName, crownlabsv1alpha1.Manager)), APIGroup: "rbac.authorization.k8s.io"}}
+	crb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWsKcRoleName(wsName, crownlabsv1alpha1.Manager)), APIGroup: "rbac.authorization.k8s.io"}}
 }
 
-func updateWsRb(rb *rbacv1.RoleBinding, wsName string) {
-	if rb.Labels == nil {
-		rb.Labels = make(map[string]string, 1)
-	}
-	rb.Labels["crownlabs.polito.it/managed-by"] = "workspace"
+func (r *WorkspaceReconciler) updateWsRb(rb *rbacv1.RoleBinding, wsName string) {
+	rb.Labels = r.updateWsResourceCommonLabels(rb.Labels)
+
 	rb.RoleRef = rbacv1.RoleRef{Kind: "ClusterRole", Name: "crownlabs-view-templates", APIGroup: "rbac.authorization.k8s.io"}
-	rb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWorkspaceKcRoleName(wsName, crownlabsv1alpha1.User)), APIGroup: "rbac.authorization.k8s.io"}}
+	rb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWsKcRoleName(wsName, crownlabsv1alpha1.User)), APIGroup: "rbac.authorization.k8s.io"}}
 }
 
-func updateWsRbMng(rb *rbacv1.RoleBinding, wsName string) {
-	if rb.Labels == nil {
-		rb.Labels = make(map[string]string, 1)
-	}
-	rb.Labels["crownlabs.polito.it/managed-by"] = "workspace"
+func (r *WorkspaceReconciler) updateWsRbMng(rb *rbacv1.RoleBinding, wsName string) {
+	rb.Labels = r.updateWsResourceCommonLabels(rb.Labels)
+
 	rb.RoleRef = rbacv1.RoleRef{Kind: "ClusterRole", Name: "crownlabs-manage-templates", APIGroup: "rbac.authorization.k8s.io"}
-	rb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWorkspaceKcRoleName(wsName, crownlabsv1alpha1.Manager)), APIGroup: "rbac.authorization.k8s.io"}}
+	rb.Subjects = []rbacv1.Subject{{Kind: "Group", Name: fmt.Sprintf("kubernetes:%s", genWsKcRoleName(wsName, crownlabsv1alpha1.Manager)), APIGroup: "rbac.authorization.k8s.io"}}
 }
 
-func genWorkspaceKcRolesData(wsName, wsPrettyName string) map[string]string {
-	return map[string]string{genWorkspaceKcRoleName(wsName, crownlabsv1alpha1.Manager): wsPrettyName, genWorkspaceKcRoleName(wsName, crownlabsv1alpha1.User): wsPrettyName}
+func genWsKcRolesData(wsName, wsPrettyName string) map[string]string {
+	return map[string]string{genWsKcRoleName(wsName, crownlabsv1alpha1.Manager): wsPrettyName, genWsKcRoleName(wsName, crownlabsv1alpha1.User): wsPrettyName}
 }
 
-func genWorkspaceKcRoleName(wsName string, role crownlabsv1alpha1.WorkspaceUserRole) string {
+func genWsKcRoleName(wsName string, role crownlabsv1alpha1.WorkspaceUserRole) string {
 	return fmt.Sprintf("workspace-%s:%s", wsName, role)
+}
+
+func (r *WorkspaceReconciler) updateWsResourceCommonLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels[r.TargetLabelKey] = r.TargetLabelValue
+	labels["crownlabs.polito.it/managed-by"] = "workspace"
+
+	// don't know why the initialization of the map doesn't work, so need to return a new one
+	return labels
 }

--- a/operators/pkg/tenant-controller/workspace_controller_test.go
+++ b/operators/pkg/tenant-controller/workspace_controller_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Workspace controller", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      wsName,
 				Namespace: wsNamespace,
+				Labels:    map[string]string{targetLabelKey: targetLabelValue},
 			},
 			Spec: crownlabsv1alpha1.WorkspaceSpec{
 				PrettyName: wsPrettyName,


### PR DESCRIPTION
# Description

This PR includes:
- added custom metrics to allow better visualization of errors during reconciliation (more details below)
- added label filter to allow deploying different versions of the operator to target different tenants/workspaces

### Custom Prometheus metric

The operator exposes only a new metric `tenant_operator_internal_errors` of type COUNTER. The metric contains 2 labels:
- `controller`
- `reason`:
The `controller` label can assume 2 values:
- _tenant_
- _workspace_
Depending on the `controller` label, the `reason` label can assume the following values:
- tenant:
  - _self-update_: related to changes to the spec/status/labels/finalizers of the reconciled resource
  - _cluster-resources_: related to the handling of the cluster resources (namespace, roleBindings,..) managed by the operator
  - _workspace-not-exist_: happens when a tenant is subscribed to a non-existing workspace
  - _keycloak_: related to the keycloak subscription
  - _nextcloud_: related to the nextcloud subscription
-  workspace
  - _self-update_: related to the handling of changes to the spec/status/labels/finalizers of the reconciled resource
  - _cluster-resources_: related to the handling of the cluster resources (namespace, roleBindings,..) managed by the operator
  - _tenant-unsubscription_: related to the subscription of a tenant when a workspace gets deleted
- _keycloak_: related to the keycloak subscription
  
# How Has This Been Tested?

This feature has not been tested