### PR TITLE
Fix deletion bug in tenant operator

### DIFF
--- a/operators/cmd/tenant-operator/main.go
+++ b/operators/cmd/tenant-operator/main.go
@@ -113,7 +113,7 @@ func main() {
 
 	go checkAndRenewTokenPeriodically(context.Background(), kcA.Client, kcA.Token, kcTnOpUser, kcTnOpPsw, kcLoginRealm, 2*time.Minute, 5*time.Minute)
 
-	httpClient := resty.New()
+	httpClient := resty.New().SetCookieJar(nil)
 	NcA := controllers.NcActor{TnOpUser: ncTnOpUser, TnOpPsw: ncTnOpPsw, Client: httpClient, BaseURL: ncURL}
 	if err = (&controllers.TenantReconciler{
 		Client:           mgr.GetClient(),

--- a/operators/pkg/tenant-controller/common_utils.go
+++ b/operators/pkg/tenant-controller/common_utils.go
@@ -31,16 +31,6 @@ func containsString(slice []string, s string) bool {
 	return false
 }
 
-func removeString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}
-
 func generateToken() (*string, error) {
 	// the size of b is equal to double the length of the generated token
 	b := make([]byte, 20)

--- a/operators/pkg/tenant-controller/keycloak_utils.go
+++ b/operators/pkg/tenant-controller/keycloak_utils.go
@@ -3,6 +3,7 @@ package tenant_controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	gocloak "github.com/Nerzal/gocloak/v7"
@@ -107,7 +108,7 @@ func (kcA *KcActor) getUserInfo(ctx context.Context, username string) (userID, e
 		if exactMatches == 1 {
 			return &exactID, &exactEmail, nil
 		}
-		return nil, nil, errors.New("found too many users")
+		return nil, nil, fmt.Errorf("found %d keycloak users for username %s, too many", exactMatches, username)
 	}
 }
 

--- a/operators/pkg/tenant-controller/nextcloud_utils.go
+++ b/operators/pkg/tenant-controller/nextcloud_utils.go
@@ -95,6 +95,7 @@ func (ncA *NcActor) UpdateUserData(username, param, value string) error {
 		klog.Errorf("Error when sending request for %s update in nextcloud for user %s -> %s", param, username, err)
 		return err
 	}
+
 	statusCode, message, err := parseOCSResponseMeta(res.Body())
 	if err != nil {
 		klog.Errorf("Error when parsing response of %s update in nextcloud of user %s -> %s", param, username, err)

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // TenantReconciler reconciles a Tenant object
@@ -66,18 +67,21 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if !tn.ObjectMeta.DeletionTimestamp.IsZero() {
 		klog.Infof("Processing deletion of tenant %s", tn.Name)
-		if containsString(tn.ObjectMeta.Finalizers, crownlabsv1alpha1.TnOperatorFinalizerName) {
+		if ctrlUtil.ContainsFinalizer(&tn, crownlabsv1alpha1.TnOperatorFinalizerName) {
 			// reconcile was triggered by a delete request
 			if err := r.handleDeletion(ctx, tn.Name); err != nil {
 				klog.Errorf("error when deleting external resources on tenant %s deletion -> %s", tn.Name, err)
 				retrigErr = err
 			}
-			// remove finalizer from the tenant
-			tn.ObjectMeta.Finalizers = removeString(tn.ObjectMeta.Finalizers, crownlabsv1alpha1.TnOperatorFinalizerName)
-			if err := r.Update(context.Background(), &tn); err != nil {
-				klog.Errorf("Error when removing tenant operator finalizer from tenant %s -> %s", tn.Name, err)
-				tnOpinternalErrors.WithLabelValues("tenant", "self-update").Inc()
-				retrigErr = err
+			// can remove the finalizer from the tenant if the eternal resources have been successfully deleted
+			if retrigErr == nil {
+				// remove finalizer from the tenant
+				ctrlUtil.RemoveFinalizer(&tn, crownlabsv1alpha1.TnOperatorFinalizerName)
+				if err := r.Update(context.Background(), &tn); err != nil {
+					klog.Errorf("Error when removing tenant operator finalizer from tenant %s -> %s", tn.Name, err)
+					tnOpinternalErrors.WithLabelValues("tenant", "self-update").Inc()
+					retrigErr = err
+				}
 			}
 		}
 		if retrigErr == nil {
@@ -91,8 +95,8 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	klog.Infof("Reconciling tenant %s", tn.Name)
 
 	// add tenant operator finalizer to tenant
-	if !containsString(tn.ObjectMeta.Finalizers, crownlabsv1alpha1.TnOperatorFinalizerName) {
-		tn.ObjectMeta.Finalizers = append(tn.ObjectMeta.Finalizers, crownlabsv1alpha1.TnOperatorFinalizerName)
+	if !ctrlUtil.ContainsFinalizer(&tn, crownlabsv1alpha1.TnOperatorFinalizerName) {
+		ctrlUtil.AddFinalizer(&tn, crownlabsv1alpha1.TnOperatorFinalizerName)
 		if err := r.Update(context.Background(), &tn); err != nil {
 			klog.Errorf("Error when adding finalizer to tenant %s -> %s ", tn.Name, err)
 			retrigErr = err

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -114,7 +114,7 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			retrigErr = err
 			tnOpinternalErrors.WithLabelValues("tenant", "cluster-resources").Inc()
 		}
-		klog.Infof("Cluster resourcess for workspace %s updated", tn.Name)
+		klog.Infof("Cluster resourcess for tenant %s updated", tn.Name)
 	} else {
 		klog.Errorf("Unable to update namespace of tenant %s -> %s", tn.Name, err)
 		tn.Status.PersonalNamespace.Created = false


### PR DESCRIPTION
# Description

This PR includes:
- _fix the deletion logic regarding the finalizers for the tenant operator_. When a resource was deleted and the deletion of external resources (keycloak/nextcloud) failed, the operator removed the finalizers from the resource regardless of the outcome of the previous deletion, making the finalizers useless.
- _fix the interaction between the tenant operator and nextcloud_. The problem was related to the authentication management of nextcloud: after 30 minutes of using the API with HTTP basic auth to authenticate the tenant-operator account to edit nextcloud user, the server required the password confirmation of the user (a bit of a 2nd WTF for nextcloud 😅). By forcing go resty client to not store cookies every request results as new one from nextcloud and gets accepted regardless of the 30 minutes


# How Has This Been Tested?

This has not been tested,.
- The first behavior showed when, after having deleted a tenant, nextcloud had some errors and the tenant was successfully deleted by the garbage collection. The tenats had still the corresponding users in nextcloud.
- The second fix did not result in any other issues when creating/updating users, it can be seen in the logs of the tenant operator in the namespace `tenant-409`