### PR TITLE
Tenant operator: fix nextcloud secret issue

### DIFF
--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -14,7 +14,6 @@ package tenant_controller
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -503,10 +502,8 @@ func (r *TenantReconciler) updateTnNcSecret(sec *v1.Secret, username, password s
 
 	sec.Type = v1.SecretTypeOpaque
 	sec.Data = make(map[string][]byte, 2)
-	sec.Data["username"] = make([]byte, base64.StdEncoding.EncodedLen(len(username)))
-	sec.Data["password"] = make([]byte, base64.StdEncoding.EncodedLen(len(password)))
-	base64.StdEncoding.Encode(sec.Data["username"], []byte(username))
-	base64.StdEncoding.Encode(sec.Data["password"], []byte(password))
+	sec.Data["username"] = []byte(username)
+	sec.Data["password"] = []byte(password)
 }
 
 func updateTnLabels(tn *crownlabsv1alpha1.Tenant, tenantExistingWorkspaces []crownlabsv1alpha1.UserWorkspaceData) error {

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -368,4 +368,19 @@ func checkTnClusterResourceCreation(ctx context.Context, tnName, nsName string, 
 	Expect(createdNetPolAllow.Spec.Ingress).Should(HaveLen(1))
 	Expect(createdNetPolAllow.Spec.Ingress[0].From).Should(HaveLen(1))
 	Expect(createdNetPolAllow.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["crownlabs.polito.it/allow-instance-access"]).Should(Equal("true"))
+
+	By("By checking that the nextcloud-credentials secret of the tenant has been created")
+	ncSecretLookupKey := types.NamespacedName{Name: "nextcloud-credentials", Namespace: nsName}
+	createdNcSecret := &v1.Secret{}
+	doesEventuallyExists(ctx, ncSecretLookupKey, createdNcSecret, BeTrue(), timeout, interval)
+
+	By("By checking that the nextcloud-credentials secret of the tenant has a owner reference and label pointing to the tenant operator")
+	Expect(createdNcSecret.OwnerReferences).Should(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(tnName)})))
+	Expect(createdNcSecret.Labels).Should(HaveKeyWithValue("crownlabs.polito.it/managed-by", "tenant"))
+
+	By("By checking that the nextcloud-credentials secret of the tenant has a correct spec")
+	Expect(createdNcSecret.Type).Should(Equal(v1.SecretTypeOpaque))
+	Expect(createdNcSecret.Data).Should(HaveKeyWithValue("username", []byte("keycloak-"+tnName)))
+	Expect(createdNcSecret.Data).Should(HaveKey("password"))
+	Expect(createdNcSecret.Data["password"]).Should(HaveLen(40))
 }


### PR DESCRIPTION
# Description

This PR fixes the creation of the secret containing the nextcloud credentials, avoiding to apply the base64 enconding. Additionally, it introduces a new test ensuring the correctness of the secret creation.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
- [x] Ginkgo test
- [x] Staging environment
