### PR TITLE
Release pipeline: fix incorrect image name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
             echo "::set-output name=ref::${{ github.sha }}"
           fi
 
-          # The suffix to append to the repository name if not triggered by a push to master
-          [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/master" ]] && \
+          # The suffix to append to the repository name if not triggered by a push
+          [[ "${{ github.event_name }}" == "push" && "${{ github.event.repository.full_name }}" == "${{ github.repository }}" ]] && \
             echo "::set-output name=repo-suffix::" || \
             echo "::set-output name=repo-suffix::-dev"
 


### PR DESCRIPTION
# Description

This PR fixes the release pipeline, which introduced the `-dev` suffix to the images of tagged releases.

