### PR TITLE
Lower the permissions required for deploy-staging and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @netgroup-polito/crownlabs-maintainers will be requested for
+# review when someone opens a pull request.
+*       @netgroup-polito/crownlabs-maintainers

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -28,11 +28,11 @@ jobs:
               },
               {
                 "command": "deploy-staging",
-                "permission": "write"
+                "permission": "triage"
               },
               {
                 "command": "undeploy-staging",
-                "permission": "write"
+                "permission": "triage"
               },
               {
                 "command": "hold",


### PR DESCRIPTION
# Description

This PR lowers the permissions required to perform a `deploy-staging` operation. Additionally, it adds the CODEOWNERS file, in order to automatically request a review from @netgroup-polito/crownlabs-maintainers whenever a new PR is opened..