### PR TITLE
Policies: fix the instance-template-reference policy and improve testing

### DIFF
--- a/policies/policies/instance-template-reference_test.rego
+++ b/policies/policies/instance-template-reference_test.rego
@@ -1,130 +1,156 @@
 package crownlabs_instance_template_reference
 
-test_namespace_notexist {
-	namet := "temp2"
-	nst := "notexist"
-	ns1 := "test-space1"
-	ns2 := "test-space1"
-	ns3 := "test-space2"
-	input := {"review": input_review(namet, nst)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) > 0
+test_generic_namespace_not_exists {
+	input := {"review": input_review_with_namespace("workspace-not-existing", "whatever")}
+	results := violation with input as input with data.inventory as data_inventory
+	count(results) > 0
 }
 
-test_namespace_empty {
-	namet := "temp2"
-	nst := "test-space3"
-	ns1 := "test-space1"
-	ns2 := "test-space3"
-	ns3 := "test-space2"
-	input := {"review": input_review(namet, nst)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) > 0
+test_generic_namespace_empty {
+	input1 := {"review": input_review_with_namespace("workspace-empty-1", "whatever")}
+	input2 := {"review": input_review_with_namespace("workspace-empty-2", "whatever")}
+	input3 := {"review": input_review_with_namespace("workspace-empty-3", "whatever")}
+	input4 := {"review": input_review_with_namespace("workspace-empty-4", "whatever")}
+
+	results1 := violation with input as input1 with data.inventory as data_inventory
+	results2 := violation with input as input2 with data.inventory as data_inventory
+	results3 := violation with input as input3 with data.inventory as data_inventory
+	results4 := violation with input as input4 with data.inventory as data_inventory
+
+	count(results1) > 0
+	count(results2) > 0
+	count(results3) > 0
+	count(results4) > 0
 }
 
-test_nametemplate_notexist {
-	namet := "notexist"
-	nst := "test-space2"
-	ns1 := "test-space1"
-	ns2 := "test-space1"
-	ns3 := "test-space2"
-	input := {"review": input_review(namet, nst)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) > 0
+test_generic_namespace_template_not_exists {
+	# This template exists but in a different namespace
+	input := {"review": input_review_with_namespace("workspace-coffee", "green-tea")}
+	results := violation with input as input with data.inventory as data_inventory
+	count(results) > 0
 }
 
-test_namespace_exist {
-	namet := "temp1"
-	nst := "test-space1"
-	ns1 := "test-space1"
-	ns2 := "test-space3"
-	ns3 := "test-space2"
-	input := {"review": input_review(namet, nst)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) == 0
+test_generic_namespace_template_exists_single {
+	input := {"review": input_review_with_namespace("workspace-coffee", "dark-coffee")}
+	results := violation with input as input with data.inventory as data_inventory
+	count(results) == 0
 }
 
-test_namespace_default_fail {
-	namet := "temp2"
-	ns1 := "default"
-	ns2 := "test-space1"
-	ns3 := "test-space2"
-	input := {"review": input_review1(namet)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) > 0
+test_generic_namespace_template_exists_multiple {
+	input1 := {"review": input_review_with_namespace("workspace-tea", "green-tea")}
+	input2 := {"review": input_review_with_namespace("workspace-tea", "white-tea")}
+
+	results1 := violation with input as input1 with data.inventory as data_inventory
+	results2 := violation with input as input2 with data.inventory as data_inventory
+
+	count(results1) == 0
+	count(results2) == 0
 }
 
-test_namespace_default {
-	namet := "temp1"
-	ns1 := "test-space3"
-	ns2 := "test-space1"
-	ns3 := "test-space2"
-	input := {"review": input_review1(namet)}
-	my_data := data_inventory(ns1, ns2, ns3)
-	result := violation with input as input with data.inventory as my_data
-	count(result) == 0
+test_default_namespace_empty {
+	input := {"review": input_review_without_namespace("whatever")}
+	results := violation with input as input with data.inventory as data_inventory_empty_default_namespace
+	count(results) > 0
 }
 
-input_review(namet, nst) = output {
+test_default_namespace_template_not_exists {
+	input := {"review": input_review_without_namespace("not-existing")}
+	results := violation with input as input with data.inventory as data_inventory
+	count(results) > 0
+}
+
+test_default_namespace_template_exists {
+	input1 := {"review": input_review_without_namespace("chilly-pepper")}
+	input2 := {"review": input_review_without_namespace("just-pepper")}
+
+	results1 := violation with input as input1 with data.inventory as data_inventory
+	results2 := violation with input as input2 with data.inventory as data_inventory
+
+	count(results1) == 0
+	count(results2) == 0
+}
+
+input_review_with_namespace(template_namespace, template_name) = output {
 	output = {"object": {
 		"metadata": {
-			"name": "test-name",
-			"namespace": "test-namespace",
+			"name": "instance-name",
+			"namespace": "instance-namespace",
 		},
 		"spec": {
 			"template.crownlabs.polito.it/TemplateRef": {
-				"name": namet,
-				"namespace": nst,
+				"name": template_name,
+				"namespace": template_namespace,
 			},
-			"tenant.crownlabs.polito.it/TenantRef": {"name": "test-tenant-name"},
+			"tenant.crownlabs.polito.it/TenantRef": {"name": "tenant-name"},
 		},
 	}}
 }
 
-input_review1(namet) = output {
+input_review_without_namespace(template_name) = output {
 	output = {"object": {
 		"metadata": {
-			"name": "test-name",
-			"namespace": "test-namespace",
+			"name": "instance-name",
+			"namespace": "instance-namespace",
 		},
 		"spec": {
-			"template.crownlabs.polito.it/TemplateRef": {"name": namet},
-			"tenant.crownlabs.polito.it/TenantRef": {"name": "test-tenant-name"},
+			"template.crownlabs.polito.it/TemplateRef": {"name": template_name},
+			"tenant.crownlabs.polito.it/TenantRef": {"name": "tenant-name"},
 		},
 	}}
 }
 
-data_inventory(ns1, ns2, ns3) = output {
-	output = {"namespace": {
-		ns1: {"crownlabs.polito.it/v1alpha2": {"Template": {"temp1": {
+data_inventory = {"namespace": {
+	"workspace-tea": {"crownlabs.polito.it/v1alpha2": {"Template": {
+		"green-tea": {
 			"apiVersion": "crownlabs.polito.it/v1alpha2",
 			"kind": "Template",
 			"metadata": {
-				"name": "temp1",
-				"namespace": ns1,
+				"name": "green-tea",
+				"namespace": "workspace-tea",
 			},
-		}}}},
-		ns3: {"crownlabs.polito.it/v1alpha2": {"Template": {"temp2": {
+		},
+		"white-tea": {
 			"apiVersion": "crownlabs.polito.it/v1alpha2",
 			"kind": "Template",
 			"metadata": {
-				"name": "temp2",
-				"namespace": ns3,
+				"name": "white-tea",
+				"namespace": "workspace-tea",
 			},
-		}}}},
-		ns2: {"crownlabs.polito.it/v1alpha2": {"Template": {}}},
-		"default": {"crownlabs.polito.it/v1alpha2": {"Template": {"temp1": {
+		},
+	}}},
+	"workspace-coffee": {
+		"crownlabs.polito.it/v1alpha2": {"Template": {"dark-coffee": {
 			"apiVersion": "crownlabs.polito.it/v1alpha2",
 			"kind": "Template",
 			"metadata": {
-				"name": "temp1",
+				"name": "dark-coffee",
+				"namespace": "workspace-coffee",
+			},
+		}}},
+		"foo.bar.com/v1alpha1": {"Baz": {}},
+	},
+	"workspace-empty-1": {},
+	"workspace-empty-2": {"foo.bar.com/v1alpha1": {"Baz": {}}},
+	"workspace-empty-3": {"crownlabs.polito.it/v1alpha2": {"Baz": {}}},
+	"workspace-empty-4": {"crownlabs.polito.it/v1alpha2": {"Template": {}}},
+	"default": {"crownlabs.polito.it/v1alpha2": {"Template": {
+		"chilly-pepper": {
+			"apiVersion": "crownlabs.polito.it/v1alpha2",
+			"kind": "Template",
+			"metadata": {
+				"name": "chilly-pepper",
 				"namespace": "default",
 			},
-		}}}},
-	}}
-}
+		},
+		"just-pepper": {
+			"apiVersion": "crownlabs.polito.it/v1alpha2",
+			"kind": "Template",
+			"metadata": {
+				"name": "just-pepper",
+				"namespace": "default",
+			},
+		},
+	}}},
+}}
+
+data_inventory_empty_default_namespace = {"namespace": {"default": {"crownlabs.polito.it/v1alpha2": {"Template": {}}}}}


### PR DESCRIPTION
# Description

This PR improves the *instance-template-reference* policy to fix the problem mentioned in #415. Additionally, it introduces new tests to prevent regressions and ensure those cases are correctly handled (and slightly modifies the others to improve clarity, at least IMO).

Secifically, the fix involves two main problems:
* The policy did not return an error in certain conditions if the referenced namespace had no templates.
* The policy incorrectly returned an error if the referenced namespace contained multiple templates.

@ChiaraOggeri @sofymunari Could you have a look whether the modifications seem ok to you (seems I cannot specify you as reviewers until you accept the invitation)? I am definitely not a rego/gatekeeper expert.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Unit testing (adding new tests regarding the identified problematic situations)
- [X] Manual testing with a kind cluster, replicating the templates and instances currently present in CrownLabs.
