### PR TITLE
Operators: specify priority of addional print columns of CRDs

### DIFF
--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -113,8 +113,8 @@ type TenantStatus struct {
 // +kubebuilder:resource:scope="Cluster"
 // +kubebuilder:printcolumn:name="First Name",type=string,JSONPath=`.spec.firstName`
 // +kubebuilder:printcolumn:name="Last Name",type=string,JSONPath=`.spec.lastName`
-// +kubebuilder:printcolumn:name="Email",type=string,JSONPath=`.spec.email`
-// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.personalNamespace.name`
+// +kubebuilder:printcolumn:name="Email",type=string,JSONPath=`.spec.email`,priority=10
+// +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.personalNamespace.name`,priority=10
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
 
 // Tenant describes a user of CrownLabs.

--- a/operators/api/v1alpha2/instance_types.go
+++ b/operators/api/v1alpha2/instance_types.go
@@ -69,8 +69,8 @@ type InstanceStatus struct {
 // +kubebuilder:resource:shortName="inst"
 // +kubebuilder:printcolumn:name="Running",type=string,JSONPath=`.spec.running`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
-// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
-// +kubebuilder:printcolumn:name="IP Address",type=string,JSONPath=`.status.ip`
+// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`,priority=10
+// +kubebuilder:printcolumn:name="IP Address",type=string,JSONPath=`.status.ip`,priority=10
 
 // Instance describes the instance of a CrownLabs environment Template.
 type Instance struct {

--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -121,10 +121,10 @@ type EnvironmentResources struct {
 // +kubebuilder:resource:shortName="tmpl"
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Pretty Name",type=string,JSONPath=`.spec.prettyName`
-// +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.environmentList[0].image`
-// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.environmentList[0].environmentType`
-// +kubebuilder:printcolumn:name="GUI",type=string,JSONPath=`.spec.environmentList[0].guiEnabled`
-// +kubebuilder:printcolumn:name="Persistent",type=string,JSONPath=`.spec.environmentList[0].persistent`
+// +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.environmentList[0].image`,priority=10
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.environmentList[0].environmentType`,priority=10
+// +kubebuilder:printcolumn:name="GUI",type=string,JSONPath=`.spec.environmentList[0].guiEnabled`,priority=10
+// +kubebuilder:printcolumn:name="Persistent",type=string,JSONPath=`.spec.environmentList[0].persistent`,priority=10
 
 // Template describes the template of a CrownLabs environment to be instantiated.
 type Template struct {

--- a/operators/deploy/crds/crownlabs.polito.it_instances.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_instances.yaml
@@ -27,9 +27,11 @@ spec:
       type: string
     - jsonPath: .status.url
       name: URL
+      priority: 10
       type: string
     - jsonPath: .status.ip
       name: IP Address
+      priority: 10
       type: string
     name: v1alpha2
     schema:

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -24,15 +24,19 @@ spec:
       type: string
     - jsonPath: .spec.environmentList[0].image
       name: Image
+      priority: 10
       type: string
     - jsonPath: .spec.environmentList[0].environmentType
       name: Type
+      priority: 10
       type: string
     - jsonPath: .spec.environmentList[0].guiEnabled
       name: GUI
+      priority: 10
       type: string
     - jsonPath: .spec.environmentList[0].persistent
       name: Persistent
+      priority: 10
       type: string
     name: v1alpha2
     schema:

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -25,9 +25,11 @@ spec:
       type: string
     - jsonPath: .spec.email
       name: Email
+      priority: 10
       type: string
     - jsonPath: .status.personalNamespace.name
       name: Namespace
+      priority: 10
       type: string
     - jsonPath: .status.ready
       name: Ready


### PR DESCRIPTION
# Description

This PR introduces a small modification in the CrownLabs API definitions, to specify the additional columns which are shown by default (e.g. with `kubectl get tenants`) and the ones shown only if the `-o wide` flag is specified. This avoids issues when presenting the output on smaller screens and side-by-side terminals. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Deploying the modified CRD in the cluster and checking the outputs
