### PR TITLE
Dashboard: fix tooltips

### DIFF
--- a/dashboard/views/crownLabs/Instances.js
+++ b/dashboard/views/crownLabs/Instances.js
@@ -158,16 +158,14 @@ export default function Instances(props) {
                 template.spec.environmentList[0].guiEnabled &&
                 lab.status &&
                 lab.status.phase === 'VmiReady' ? (
-                  <Tooltip title={'Connect VM'}>
-                    <a target={'_blank'} href={url}>
-                      <Button
-                        icon={<ExportOutlined style={{ fontSize: 20 }} />}
-                        size={'small'}
-                        shape={'circle'}
-                        style={{ border: 'none', background: 'none' }}
-                      />
-                    </a>
-                  </Tooltip>
+                  <a target={'_blank'} href={url}>
+                    <Button
+                      icon={<ExportOutlined style={{ fontSize: 20 }} />}
+                      size={'small'}
+                      shape={'circle'}
+                      style={{ border: 'none', background: 'none' }}
+                    />
+                  </a>
                 ) : null,
               props: {
                 title: ''

--- a/dashboard/views/crownLabs/Templates.js
+++ b/dashboard/views/crownLabs/Templates.js
@@ -56,14 +56,14 @@ export default function Templates(props) {
         sorter: {
           compare: (a, b) => a['Persistence'] - b['Persistence']
         },
-        render: text => {
+        render: persistence => {
           return {
-            children: text ? (
-              <Tooltip title={'GUI enabled'}>
+            children: persistence ? (
+              <Tooltip title={"Persistent"}>
                 <CheckOutlined style={{ fontSize: 15, color: colorBlue }} />
               </Tooltip>
             ) : (
-              <Tooltip title={'CLI only'}>
+              <Tooltip title={"Ephemeral"}>
                 <CloseOutlined style={{ fontSize: 15 }} />
               </Tooltip>
             ),


### PR DESCRIPTION
# Description

This PR brings a small fix to the tooltips in the dashboard that manages persistent VMs.

In details:
1. it fixes the tooltip on the ❎ and ✅ symbols in the column "Persistence" explaining them to "Ephemeral" and "Persistent"
2. it removes a redundant information on the tooltip in the column "Connect" of the instances table that said just "Connect VM"

![immagine](https://user-images.githubusercontent.com/32904044/111283299-43979000-863f-11eb-92ac-c35d9ef61427.png)


# How Has This Been Tested?

Manually tested in a local environment
