### PR TITLE
Fixed tenant operator target label behavior

### DIFF
--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -57,6 +57,13 @@ func (r *TenantReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if tn.Labels[r.TargetLabelKey] != r.TargetLabelValue {
+		// if entered here it means that is in the reconcile
+		// which has been requed after
+		// the last successful one with the old target label
+		return ctrl.Result{}, nil
+	}
+
 	var retrigErr error = nil
 	if tn.Status.Subscriptions == nil {
 		// make initial len is 2 (keycloak and nextcloud)

--- a/operators/pkg/tenant-controller/workspace_controller.go
+++ b/operators/pkg/tenant-controller/workspace_controller.go
@@ -52,6 +52,13 @@ func (r *WorkspaceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if ws.Labels[r.TargetLabelKey] != r.TargetLabelValue {
+		// if entered here it means that is in the reconcile
+		// which has been requed after
+		// the last successful one with the old target label
+		return ctrl.Result{}, nil
+	}
+
 	var retrigErr error = nil
 	if !ws.ObjectMeta.DeletionTimestamp.IsZero() {
 		klog.Infof("Processing deletion of workspace %s", ws.Name)


### PR DESCRIPTION
# Description

This PR fixes a little bug in the tenant operator related to the targetLabel behavior. The bug is that the filter performed at the event-level in the `SetupWithManager` function does not apply when entering the reconcile after returning from the previous reconcile with a non-nil `RequeeAfter`. This causes the resource to be reconciled by contrasting operators.

### How it has been discovered

The issue appeared after changing the label on a tenant from `production` to `pre-production`. Doing this, the tenant will be later reconciled by the `pre-production` operator. But on the last reconcile performed by the `production` operator, a `RequeAfter` set the next reconcile in 1-2 hours, which will not be filtered by the event-filter mentioned before and will change the label on all resources related to the tenant (namespaces, roleBindings,..). This behavior leaves the label on the tenant with the value `pre-production` but effectively brings back the tenant from `pre-production` to `production` through the change on every related resource.

### Note

The fix is not the best solution. The best solution would be probably trying to update the `controller-runtime` dependencies to the latest version and see if this has been fixed., if not, we could write to the `kubeBuilder` guys.

# How Has This Been Tested?

This has been tested manually using kind locally