### PR TITLE
Add blender lab for graphical containers environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
           - tigervnc
           - websockify
           - pycharm
+          - blender
 
         include:
           # Operators
@@ -117,6 +118,8 @@ jobs:
             context: ./provisioning/containers/gui-common/websockify
           - component: pycharm
             context: ./provisioning/containers/pycharm
+          - component: blender
+            context: ./provisioning/containers/blender
 
           # SSH bastion
           - component: ssh-bastion

--- a/provisioning/containers/blender/Dockerfile
+++ b/provisioning/containers/blender/Dockerfile
@@ -1,0 +1,24 @@
+# Start from https://github.com/nytimes/rd-blender-docker
+FROM nytimes/blender:2.92-cpu-ubuntu18.04
+
+# Define user and user id default arguments
+ARG USER=crownlabs
+ARG UID=1010
+
+# Define basic default enviroment variables
+ENV DISPLAY=:0 \
+  USER=${USER} \
+  HOME=/home/$USER
+
+# Create new user and set a set a valid shell for them
+RUN useradd -ms /bin/bash -u ${UID} $USER
+
+# Set permissions on user home
+RUN chown -R $USER:$USER $HOME
+
+# Set the user to use
+USER $USER
+
+WORKDIR $HOME
+
+CMD blender


### PR DESCRIPTION
# Description
This PR includes the Dockerfile for the Blender container to run inside the container environment instance and the relative build configuration.

# How Has This Been Tested?
Ran as a pod with a replicated container environment on the cluster.
