### PR TITLE
Add support for file manager sidecar container (File Browser)

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -41,6 +41,8 @@ instance-operator:
       vncImage: crownlabs/tigervnc
       websockifyImage: crownlabs/websockify
       novncImage: crownlabs/novnc
+      filebrowserImage: filebrowser/filebrowser
+      filebrowserImageTag: latest
 
 tenant-operator:
   replicaCount: 1

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -68,6 +68,8 @@ func main() {
 	var containerEnvVncImg string
 	var containerEnvWebsockifyImg string
 	var containerEnvNovncImg string
+	var containerEnvFileBrowserImg string
+	var containerEnvFileBrowserImgTag string
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -85,6 +87,8 @@ func main() {
 	flag.StringVar(&containerEnvVncImg, "container-env-vnc-img", "crownlabs/tigervnc", "The image name for the vnc image (sidecar for graphical container environment)")
 	flag.StringVar(&containerEnvWebsockifyImg, "container-env-websockify-img", "crownlabs/websockify", "The image name for the websockify image (sidecar for graphical container environment)")
 	flag.StringVar(&containerEnvNovncImg, "container-env-novnc-img", "crownlabs/novnc", "The image name for the novnc image (sidecar for graphical container environment)")
+	flag.StringVar(&containerEnvFileBrowserImg, "container-env-filebrowser-img", "filebrowser/filebrowser", "The image name for the filebrowser image (sidecar for gui-based file manager)")
+	flag.StringVar(&containerEnvFileBrowserImgTag, "container-env-filebrowser-img-tag", "latest", "The tag for the FileBrowser container (the gui-based file manager)")
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -114,10 +118,12 @@ func main() {
 		OidcClientSecret:   oidcClientSecret,
 		OidcProviderURL:    oidcProviderURL,
 		ContainerEnvOpts: instance_controller.ContainerEnvOpts{
-			ImagesTag:     containerEnvSidecarsTag,
-			VncImg:        containerEnvVncImg,
-			WebsockifyImg: containerEnvWebsockifyImg,
-			NovncImg:      containerEnvNovncImg,
+			ImagesTag:         containerEnvSidecarsTag,
+			VncImg:            containerEnvVncImg,
+			WebsockifyImg:     containerEnvWebsockifyImg,
+			NovncImg:          containerEnvNovncImg,
+			FileBrowserImg:    containerEnvFileBrowserImg,
+			FileBrowserImgTag: containerEnvFileBrowserImgTag,
 		},
 	}).SetupWithManager(mgr); err != nil {
 		klog.Fatal(err, "unable to create controller", "controller", "Instance")

--- a/operators/deploy/instance-operator/templates/deployment.yaml
+++ b/operators/deploy/instance-operator/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
             - "--container-env-vnc-img={{ .Values.configurations.containerEnvironmentOptions.vncImage }}"
             - "--container-env-websockify-img={{ .Values.configurations.containerEnvironmentOptions.websockifyImage }}"
             - "--container-env-novnc-img={{ .Values.configurations.containerEnvironmentOptions.novncImage }}"
+            - "--container-env-filebrowser-img={{ .Values.configurations.containerEnvironmentOptions.filebrowserImage }}"
+            - "--container-env-filebrowser-img-tag={{ .Values.configurations.containerEnvironmentOptions.filebrowserImageTag }}"
           ports:
             - name: metrics
               containerPort: 8080

--- a/operators/deploy/instance-operator/values.yaml
+++ b/operators/deploy/instance-operator/values.yaml
@@ -21,6 +21,8 @@ configurations:
     vncImage: crownlabs/tigervnc
     websockifyImage: crownlabs/websockify
     novncImage: crownlabs/novnc
+    filebrowserImage: filebrowser/filebrowser
+    filebrowserImageTag: latest
 
 image:
   repository: crownlabs/instance-operator

--- a/operators/pkg/instance-controller/common_logic.go
+++ b/operators/pkg/instance-controller/common_logic.go
@@ -13,22 +13,37 @@ import (
 )
 
 // CreateInstanceExpositionEnvironment creates the components necessary to access the environment (service, ingress and oauth2-proxy related resources).
+// Additionally, it makes the service expose another port and creates an ingress for FileBrowser sidecar container (only for container environments).
 func (r *InstanceReconciler) CreateInstanceExpositionEnvironment(
 	ctx context.Context,
 	instance *crownlabsv1alpha2.Instance,
-	name string,
-) (v1.Service, networkingv1.Ingress, error) {
+	name string, hasFileBrowser bool,
+) (v1.Service, networkingv1.Ingress, string, error) {
 	// create Service to expose the pod
 	service := instance_creation.ForgeService(name, instance.Namespace)
+
+	fileBrowserPortName := "filebrowser"
+	if hasFileBrowser {
+		service.Spec.Ports = append(service.Spec.Ports, v1.ServicePort{
+			Name:     fileBrowserPortName,
+			Protocol: v1.ProtocolTCP,
+			Port:     8080,
+		})
+	}
 
 	if _, err := ctrl.CreateOrUpdate(ctx, r.Client, &service, func() error {
 		return ctrl.SetControllerReference(instance, &service, r.Scheme)
 	}); err != nil {
 		r.setInstanceStatus(ctx, "Could not create service "+service.Name+" in namespace "+service.Namespace+": "+err.Error(), "Error", "ServiceNotCreated", instance, "", "")
-		return v1.Service{}, networkingv1.Ingress{}, err
+		return v1.Service{}, networkingv1.Ingress{}, "", err
 	}
 
-	r.setInstanceStatus(ctx, "Service "+service.Name+" correctly created in namespace "+service.Namespace, "Normal", "ServiceCreated", instance, "", "")
+	msg := "Service " + service.Name + " correctly created in namespace " + service.Namespace
+	if hasFileBrowser {
+		msg += " (includes FileBrowser exposition)"
+	}
+
+	r.setInstanceStatus(ctx, msg, "Normal", "ServiceCreated", instance, "", "")
 
 	urlUUID := uuid.New().String()
 
@@ -39,14 +54,31 @@ func (r *InstanceReconciler) CreateInstanceExpositionEnvironment(
 		return ctrl.SetControllerReference(instance, &ingress, r.Scheme)
 	}); err != nil {
 		r.setInstanceStatus(ctx, "Could not create ingress "+ingress.Name+" in namespace "+ingress.Namespace+": "+err.Error(), "Error", "IngressNotCreated", instance, "", "")
-		return service, networkingv1.Ingress{}, err
+		return service, networkingv1.Ingress{}, "", err
 	}
 
 	r.setInstanceStatus(ctx, "Ingress "+ingress.Name+" correctly created in namespace "+ingress.Namespace, "Normal", "IngressCreated", instance, "", "")
 
-	if err := r.createOAUTHlogic(name, instance, instance.Namespace, urlUUID); err != nil {
-		return service, ingress, err
+	// Overwrite using the actual ingress' url UUID
+	urlUUID = ingress.Annotations["crownlabs.polito.it/url-uuid"]
+
+	if hasFileBrowser {
+		// create separate Ingress for FileBrowser to manage the same service
+		fileBrowserIngress := instance_creation.ForgeFileBrowserIngress(name, instance.Namespace, &service, urlUUID, r.WebsiteBaseURL, fileBrowserPortName)
+
+		if _, err := ctrl.CreateOrUpdate(ctx, r.Client, &fileBrowserIngress, func() error {
+			return ctrl.SetControllerReference(instance, &fileBrowserIngress, r.Scheme)
+		}); err != nil {
+			r.setInstanceStatus(ctx, "Could not create ingress "+fileBrowserIngress.Name+" in namespace "+fileBrowserIngress.Namespace+": "+err.Error(), "Error", "IngressNotCreated", instance, "", "")
+			return service, networkingv1.Ingress{}, urlUUID, err
+		}
+
+		r.setInstanceStatus(ctx, "Ingress "+fileBrowserIngress.Name+" correctly created in namespace "+fileBrowserIngress.Namespace, "Normal", "IngressCreated", instance, "", "")
 	}
 
-	return service, ingress, nil
+	if err := r.createOAUTHlogic(name, instance, instance.Namespace, urlUUID); err != nil {
+		return service, ingress, urlUUID, err
+	}
+
+	return service, ingress, urlUUID, nil
 }

--- a/operators/pkg/instance-controller/controller.go
+++ b/operators/pkg/instance-controller/controller.go
@@ -40,10 +40,12 @@ import (
 
 // ContainerEnvOpts contains images name and tag for container environment.
 type ContainerEnvOpts struct {
-	ImagesTag     string
-	VncImg        string
-	WebsockifyImg string
-	NovncImg      string
+	ImagesTag         string
+	VncImg            string
+	WebsockifyImg     string
+	NovncImg          string
+	FileBrowserImg    string
+	FileBrowserImgTag string
 }
 
 // InstanceReconciler reconciles a Instance object.

--- a/operators/pkg/instance-controller/logic.go
+++ b/operators/pkg/instance-controller/logic.go
@@ -56,7 +56,7 @@ func (r *InstanceReconciler) CreateVMEnvironment(instance *crownlabsv1alpha2.Ins
 		r.setInstanceStatus(ctx, "Secret "+secret.Name+" correctly created in namespace "+secret.Namespace, "Normal", "SecretCreated", instance, "", "")
 	}
 
-	service, ingress, err := r.CreateInstanceExpositionEnvironment(ctx, instance, name)
+	service, ingress, _, err := r.CreateInstanceExpositionEnvironment(ctx, instance, name, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR includes the support to a file manager sidecar container to run along with the containers of the container environment instance. In particular, the file manager is implemented using [File Browser](https://github.com/filebrowser/filebrowser).
The idea is to provide a web-based interface that lets the user:
- upload files to be consumed by the main application container, and
- download files produced by the main application container.

# How Has This Been Tested?

Ran as a deployment on the cluster.
