### PR TITLE
Github Actions: add caching to buildx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.component }}-buildx-${{ hashFiles(format('{0}/**', matrix.context), matrix.dockerfile) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.component }}-buildx-
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -164,6 +172,16 @@ jobs:
           push: ${{ needs.configure.outputs.repo-push }}
           file: ${{ steps.parameters.outputs.dockerfile }}
           context: ${{ matrix.context }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temporary fix, to prevent the cache from continuing growing
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   trigger-events-master:
     name: Trigger events upon successful push to master


### PR DESCRIPTION
# Description

This PR adds a caching step to the build and the test pipelines, to speed-up execution when no changes are performed.

From some initial tests, buildx caching leads to a great advantage (especially in case of long builds, such as the frontend).

The advantage brought in by caching golang and python packages, instead, is much less (very few seconds) and I am thinking to delete it as it uses space with almost no advantage. Greater savings could be obtained caching the test results, but I feel it is better to always test from scratch to achieve better confidence. Let me know your thoughts

Thanks @qcfe for the suggestion about using caching to speed-up buildx.

# How Has This Been Tested?

Executing the actions and verifying the outcome, with and without caching

- [Build - Without caching](https://github.com/netgroup-polito/CrownLabs/actions/runs/766297945)
- [Build - With caching](https://github.com/netgroup-polito/CrownLabs/actions/runs/766369644)
- [Test - Without caching](https://github.com/netgroup-polito/CrownLabs/actions/runs/766297948)
- [Test - With caching](https://github.com/netgroup-polito/CrownLabs/actions/runs/766369643)
