### PR TITLE
CRDs: add Age field as additional printer column

### DIFF
--- a/infrastructure/monitoring/README.md
+++ b/infrastructure/monitoring/README.md
@@ -231,7 +231,9 @@ The access to Alertmanager and Prometheus is limited to users belonging to the `
 
 ### Monitor the Bind DNS Server
 
-[bind_exporter](https://github.com/prometheus-community/bind_exporter) is a Prometheus exporter from Bind. The following guide is an adapted version of this [blog post](https://computingforgeeks.com/how-to-monitor-bind-dns-server-with-prometheus-and-grafana/).
+[bind_exporter](https://github.com/prometheus-community/bind_exporter) is a Prometheus exporter from Bind.
+<!-- markdown-link-check-disable-next-line -->
+The following guide is an adapted version of this [blog post](https://computingforgeeks.com/how-to-monitor-bind-dns-server-with-prometheus-and-grafana/).
 
 #### Bind configuration
 1. Download the latest release of the `bind_exporter` binary:

--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -116,6 +116,7 @@ type TenantStatus struct {
 // +kubebuilder:printcolumn:name="Email",type=string,JSONPath=`.spec.email`,priority=10
 // +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.personalNamespace.name`,priority=10
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Tenant describes a user of CrownLabs.
 type Tenant struct {

--- a/operators/api/v1alpha1/workspace_types.go
+++ b/operators/api/v1alpha1/workspace_types.go
@@ -54,6 +54,7 @@ type WorkspaceStatus struct {
 // +kubebuilder:printcolumn:name="Pretty Name",type=string,JSONPath=`.spec.prettyName`
 // +kubebuilder:printcolumn:name="Namespace",type=string,JSONPath=`.status.namespace.name`
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.ready`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Workspace describes a workspace in CrownLabs.
 type Workspace struct {

--- a/operators/api/v1alpha2/instance_types.go
+++ b/operators/api/v1alpha2/instance_types.go
@@ -67,6 +67,7 @@ type InstanceStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`,priority=10
 // +kubebuilder:printcolumn:name="IP Address",type=string,JSONPath=`.status.ip`,priority=10
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Instance describes the instance of a CrownLabs environment Template.
 type Instance struct {

--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -125,6 +125,7 @@ type EnvironmentResources struct {
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.environmentList[0].environmentType`,priority=10
 // +kubebuilder:printcolumn:name="GUI",type=string,JSONPath=`.spec.environmentList[0].guiEnabled`,priority=10
 // +kubebuilder:printcolumn:name="Persistent",type=string,JSONPath=`.spec.environmentList[0].persistent`,priority=10
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Template describes the template of a CrownLabs environment to be instantiated.
 type Template struct {

--- a/operators/deploy/crds/crownlabs.polito.it_instances.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_instances.yaml
@@ -33,6 +33,9 @@ spec:
       name: IP Address
       priority: 10
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -38,6 +38,9 @@ spec:
       name: Persistent
       priority: 10
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha2
     schema:
       openAPIV3Schema:

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -34,6 +34,9 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
# Description

This PR introduces the Age field as additional printer column to the CrownLabs CRDs, as it is not displayed by default if other additional columns are present

# How Has This Been Tested?

Deploying the generated CRDs in the cluster
