### PR TITLE
Tune FileBrowser resources and add annotations to FileBrowser ingress

### DIFF
--- a/operators/pkg/instance-controller/container_logic.go
+++ b/operators/pkg/instance-controller/container_logic.go
@@ -162,9 +162,18 @@ func buildContainerInstanceDeploymentSpec(
 			ReadinessProbe: &tigerVncProbe,
 		},
 		{
-			Name:      "filebrowser",
-			Image:     o.FileBrowserImg + ":" + o.FileBrowserImgTag,
-			Resources: buildResRequirements(0.1, 10, resource.MustParse("100Mi")), // actual: ~10MiB
+			Name:  "filebrowser",
+			Image: o.FileBrowserImg + ":" + o.FileBrowserImgTag,
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					"cpu":    resource.MustParse(fmt.Sprintf("%f", 0.01)),
+					"memory": resource.MustParse("100Mi"),
+				},
+				Limits: v1.ResourceList{
+					"cpu":    resource.MustParse(fmt.Sprintf("%f", 0.25)),
+					"memory": resource.MustParse("500Mi"),
+				},
+			},
 			Args: []string{
 				"--port=" + fmt.Sprintf("%d", fileBrowserPort),
 				"--root=" + mountPath,

--- a/operators/pkg/instance-creation/exposition.go
+++ b/operators/pkg/instance-creation/exposition.go
@@ -117,8 +117,12 @@ func ForgeFileBrowserIngress(
 			Namespace: namespace,
 			Labels:    nil,
 			Annotations: map[string]string{
-				"nginx.ingress.kubernetes.io/auth-signin": "https://$host/" + urlUUID + "/oauth2/start?rd=$escaped_request_uri",
-				"nginx.ingress.kubernetes.io/auth-url":    "https://$host/" + urlUUID + "/oauth2/auth",
+				"nginx.ingress.kubernetes.io/auth-signin":              "https://$host/" + urlUUID + "/oauth2/start?rd=$escaped_request_uri",
+				"nginx.ingress.kubernetes.io/auth-url":                 "https://$host/" + urlUUID + "/oauth2/auth",
+				"nginx.ingress.kubernetes.io/proxy-body-size":          "0",
+				"nginx.ingress.kubernetes.io/proxy-read-timeout":       "600",
+				"nginx.ingress.kubernetes.io/proxy-send-timeout":       "600",
+				"nginx.ingress.kubernetes.io/proxy-max-temp-file-size": "0",
 			},
 		},
 		Spec: networkingv1.IngressSpec{


### PR DESCRIPTION
# Description

This PR aims to fine-tune the resources (requests and limits) for the FileBrowser container.

Moreover, it adds some useful annotations to the dedicated FileBrowser ingress of the container-based Instance. These annotations remove the limit of 1 MB for the maximum allowed size of the client request body, as well as increase connection timeouts between two requests or responses, and other minor tweaks that overall increase the final user experience when dealing with FileBrowser.