### PR TITLE
Add LTS version of blender & set /mydrive as HOME

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
           - websockify
           - pycharm
           - blender
+          - blender-lts
 
         include:
           # Operators
@@ -138,6 +139,8 @@ jobs:
             context: ./provisioning/containers/pycharm
           - component: blender
             context: ./provisioning/containers/blender
+          - component: blender-lts
+            context: ./provisioning/containers/blender-lts
 
           # SSH bastion
           - component: ssh-bastion

--- a/provisioning/containers/blender-lts/Dockerfile
+++ b/provisioning/containers/blender-lts/Dockerfile
@@ -1,0 +1,75 @@
+# Original Dockerfile from https://github.com/nytimes/rd-blender-docker/blob/master/dist/2.83-cpu-ubuntu18.04/Dockerfile
+# Includes edits to update to the latest LTS version
+
+# ! With 18.04 there are issues with blender > 2.83.8
+FROM ubuntu:20.04
+
+# Enviorment variables
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \ 
+    wget \ 
+    libopenexr-dev \ 
+    bzip2 \ 
+    build-essential \ 
+    zlib1g-dev \ 
+    libxmu-dev \ 
+    libxi-dev \ 
+    libxxf86vm-dev \ 
+    libfontconfig1 \ 
+    libxrender1 \ 
+    libgl1-mesa-glx \ 
+    xz-utils \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*.*
+
+ARG BLENDER_VER="2.83.13-linux64" 
+ENV PATH "$PATH:/bin/2.83/python/bin/"
+ENV BLENDER_PATH "/bin/2.83"
+ENV BLENDERPIP "/bin/2.83/python/bin/pip3"
+ENV BLENDERPY "/bin/2.83/python/bin/python3.7m"
+ENV HW="CPU"
+
+# Download and install Blender
+RUN wget -q https://ftp.nluug.nl/pub/graphics/blender/release/Blender2.83/blender-${BLENDER_VER}.tar.xz \ 
+  && tar -xf blender-${BLENDER_VER}.tar.xz --strip-components=1 -C /bin \ 
+  && rm -rf blender-${BLENDER_VER}.tar.xz \ 
+  && rm -rf blender-${BLENDER_VER} \
+  && rm -rf ${BLENDER_PATH}/python/lib/python3.7/site-packages/numpy
+
+# Download the Python source since it is not bundled with Blender
+# Also upgrades the the bulndled outdated version of numpy with a modern one
+# Must first ensurepip to install Blender pip3 and then new numpy
+RUN wget -q https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz \ 
+  && tar -xzf Python-3.7.10.tgz \ 
+  && cp -r Python-3.7.10/Include/* $BLENDER_PATH/python/include/python3.7m/ \ 
+  && rm -rf Python-3.7.10.tgz \ 
+  && rm -rf Python-3.7.10 \
+  && ${BLENDERPY} -m ensurepip \
+  && ${BLENDERPIP} install --upgrade pip \
+  && ${BLENDERPIP} install numpy
+
+# Define user and user id default arguments
+ARG USER=crownlabs
+ARG UID=1010
+
+# Define basic default enviroment variables
+ENV DISPLAY=:0 \
+  USER=${USER} \
+  HOME=/mydrive
+
+# Create new user and set a set a valid shell for them
+RUN mkdir -p $HOME && useradd -ms /bin/bash -u ${UID} $USER
+
+# Set permissions on user home
+RUN chown -R $USER:$USER $HOME
+
+# Set the user to use
+USER $USER
+
+WORKDIR $HOME
+
+CMD blender

--- a/provisioning/containers/blender/Dockerfile
+++ b/provisioning/containers/blender/Dockerfile
@@ -8,10 +8,10 @@ ARG UID=1010
 # Define basic default enviroment variables
 ENV DISPLAY=:0 \
   USER=${USER} \
-  HOME=/home/$USER
+  HOME=/mydrive
 
 # Create new user and set a set a valid shell for them
-RUN useradd -ms /bin/bash -u ${UID} $USER
+RUN mkdir -p $HOME && useradd -ms /bin/bash -u ${UID} $USER
 
 # Set permissions on user home
 RUN chown -R $USER:$USER $HOME


### PR DESCRIPTION
# Description
This PR includes the LTS version of Blender (currently 2.83.13) and changes the HOME directory for the latest Blender package, to point to `/mydrive` so that it directly points to the shared storage folder.

# How Has This Been Tested?
The two images has been tested in a compatible local Docker environment.
