### PR TITLE
feat: add decorateBaseSchema function

### DIFF
--- a/qlkube/package.json
+++ b/qlkube/package.json
@@ -29,6 +29,7 @@
     "prettier": "^2.2.1"
   },
   "dependencies": {
+    "@graphql-tools/schema": "^7.1.4",
     "apollo-server-express": "^2.9.7",
     "compression": "^1.7.4",
     "express": "^4.17.1",

--- a/qlkube/src/decorateBaseSchema.js
+++ b/qlkube/src/decorateBaseSchema.js
@@ -1,0 +1,65 @@
+const { gql } = require('apollo-server-core');
+const { extendSchema } = require('graphql/utilities');
+const { addResolversToSchema } = require('@graphql-tools/schema');
+
+/**
+ *
+ * @param {*} targetQuery : Query wrapped int the extended object Type
+ * @param {*} extendedType : Object type that should be extended
+ * @param {*} argsNeeded : Optional arguments extracted from the father and passed from the wrapper
+ * @param {*} baseSchema : GraphQL Schema where the type and query are written
+ * @param {*} nameWrapper : Optional custom name for the wrapper
+ * @returns
+ */
+
+function capitalizeType(name) {
+  return name[0].toUpperCase() + name.slice(1);
+}
+
+module.exports = {
+  decorateBaseSchema: function (
+    targetQuery,
+    extendedType,
+    argsNeeded,
+    nameWrapper,
+    baseSchema
+  ) {
+    if (!targetQuery) return baseSchema;
+    if (!extendedType) return baseSchema;
+    const targetType = baseSchema.getQueryType().getFields()[targetQuery];
+    if (!targetType) return baseSchema;
+
+    nameWrapper = nameWrapper ? nameWrapper : 'fieldWrapper';
+    let typeWrapper = capitalizeType(nameWrapper);
+    let typeTargetQuery = capitalizeType(targetQuery);
+    const extension = gql`
+            extend type ${extendedType} {
+                ${nameWrapper}: ${typeWrapper}
+            }
+            type ${typeWrapper} {
+                ${targetQuery}: ${typeTargetQuery}
+            }
+        `;
+    const resolvers = {
+      [extendedType]: {
+        [nameWrapper]: (parent, args, context, info) => {
+          let newParent = {};
+          for (e of argsNeeded) {
+            newParent[e] = parent[e];
+          }
+          return newParent !== {} ? newParent : parent; // gestire errori
+        },
+      },
+      [typeWrapper]: {
+        [targetQuery]: (parent, args, context, info) => {
+          return targetType.resolve(parent, parent, context, info);
+        },
+      },
+    };
+
+    // extending the schema
+    const extendedSchema = extendSchema(baseSchema, extension);
+    const newSchema = addResolversToSchema(extendedSchema, resolvers);
+    return newSchema;
+  },
+};

--- a/qlkube/src/schema.js
+++ b/qlkube/src/schema.js
@@ -1,15 +1,27 @@
-const {
-  GraphQLString,
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLBoolean,
-} = require('graphql');
+const { GraphQLString, GraphQLSchema, GraphQLObjectType } = require('graphql');
 const { mergeSchemas } = require('graphql-tools');
 const { createGraphQlSchema } = require('oasgraph');
+const { decorateBaseSchema } = require('./decorateBaseSchema.js');
 
 exports.createSchema = async (oas, kubeApiUrl, token) => {
   let baseSchema = await oasToGraphQlSchema(oas, kubeApiUrl, token);
-  return decorateSchema(baseSchema);
+  let allSchema = decorateSchema(baseSchema);
+  let schemaWithInstanceTemplate = decorateBaseSchema(
+    'itPolitoCrownlabsV1alpha2Template',
+    'TemplateCrownlabsPolitoItTemplateRef',
+    ['name', 'namespace'],
+    'templateWrapper',
+    allSchema
+  );
+  let schemaWithInstanceTenant = decorateBaseSchema(
+    'itPolitoCrownlabsV1alpha1Tenant',
+    'TenantCrownlabsPolitoItTenantRef',
+    ['name'],
+    'tenantWrapper',
+    schemaWithInstanceTemplate
+  );
+
+  return schemaWithInstanceTenant;
 };
 
 async function oasToGraphQlSchema(oas, kubeApiUrl, token) {

--- a/qlkube/yarn.lock
+++ b/qlkube/yarn.lock
@@ -48,6 +48,13 @@
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
+"@ardatan/aggregate-error@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz#fe6924771ea40fc98dc7a7045c2e872dc8527609"
+  integrity sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==
+  dependencies:
+    tslib "~2.0.1"
+
 "@babel/code-frame@^7.0.0":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
@@ -80,6 +87,24 @@
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/@exodus/schemasafe/-/schemasafe-1.0.0-rc.3.tgz#dda2fbf3dafa5ad8c63dadff7e01d3fdf4736025"
   integrity sha512-GoXw0U2Qaa33m3eUcxuHnHpNvHjNlLo0gtV091XBpaRINaB4X6FGCG5XKxSFNFiPpugUDqNruHzaqpTdDm4AOg==
+
+"@graphql-tools/schema@^7.1.4":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-7.1.4.tgz#34ea86af336c7ff9fb294d25317cb5952cf1f86a"
+  integrity sha512-kkDLbCIMwGRUZAPdeRcnUFXu6wSaMWXNmDigWsIsepzhVx0nLQ2k58Ec7pBylKaut5xWi0344GctQ3qDhBUHDA==
+  dependencies:
+    "@graphql-tools/utils" "^7.1.2"
+    tslib "~2.2.0"
+    value-or-promise "~1.0.5"
+
+"@graphql-tools/utils@^7.1.2":
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.8.1.tgz#caa9f0f1b3c7ef12f48dc66215ef5413f288e131"
+  integrity sha512-LDbOweemjxPYgJuHXK5XZJgObsBkiD92ul98lcuZxgA49IzQazHho5Y1Hs3MluD93YtZpxsQg/f7gNPnAyR6yw==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    camel-case "4.1.2"
+    tslib "~2.2.0"
 
 "@josephg/resolvable@^1.0.0":
   version "1.0.0"
@@ -781,6 +806,14 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camel-case@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -2190,6 +2223,13 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -2326,6 +2366,14 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-fetch-h2@^2.3.0:
   version "2.3.0"
@@ -2624,6 +2672,14 @@ parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -3306,6 +3362,16 @@ tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.3, tslib@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -3460,6 +3526,11 @@ validate.io-number@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/validate.io-number/-/validate.io-number-1.0.3.tgz#f63ffeda248bf28a67a8d48e0e3b461a1665baf8"
   integrity sha1-9j/+2iSL8opnqNSODjtGGhZluvg=
+
+value-or-promise@~1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.6.tgz#218aa4794aa2ee24dcf48a29aba4413ed584747f"
+  integrity sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
# Description

New function has been added. `decorateBaseSchema` function allow to change the dynamic schema create on the fly by qlkube. This new function uses five parameters:
* @param {*} targetQuery : Query wrapped int the extended object Type
* @param {*} extendedType : Object type that should be extended
* @param {*} argsNeeded : Optional arguments extracted from the father and passed from the wrapper
* @param {*} nameWrapper : Optional custom name for the wrapper
* @param {*} baseSchema : GraphQL Schema where the type and query are written

then a new `GraphQLSchema` object is returned.

# How Has This Been Tested?

Below a test query used to test the new feature:

```graphql
query test {
  itPolitoCrownlabsV1alpha2Instance (
    name: "green-tea-6831",
    namespace: "tenant-john-doe"
  )
  {
    spec {
      running
      templateCrownlabsPolitoItTemplateRef {
        name
        namespace
        templateWrapper{
          itPolitoCrownlabsV1alpha2Template {
            kind
            spec {
              prettyName
            }
          }
        }
      }
    }
  }
}
```

- [ ] Test A
- [ ] Test B
