### PR TITLE
First components of activePage

### DIFF
--- a/frontend/src/components/activePage/ActiveLanding/ActiveLanding.stories.tsx
+++ b/frontend/src/components/activePage/ActiveLanding/ActiveLanding.stories.tsx
@@ -1,0 +1,73 @@
+import { Story } from '@storybook/react';
+import { Title, Description, Stories } from '@storybook/addon-docs/blocks';
+import ActiveLanding, { IActiveLandingProps } from './ActiveLanding';
+import { someKeysOf } from '../../../utils';
+
+export default {
+  title: 'Components/ActivePage/ActiveLanding/ActiveLanding',
+  component: ActiveLanding,
+  parameters: {
+    docs: {
+      page: () => {
+        <>
+          <Title />
+          <Description />
+        </>;
+      },
+    },
+  },
+  decorators: [
+    (Story: any) => (
+      <div style={{ height: '500px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+const defaultArgs: someKeysOf<IActiveLandingProps> = {
+  isTenantManager: false,
+};
+
+const Template: Story<IActiveLandingProps> = args => (
+  <ActiveLanding {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = defaultArgs;
+Default.parameters = {
+  docs: {
+    // eslint-disable-next-line react/no-multi-comp
+    page: () => {
+      return (
+        <>
+          <Title>Active landing page</Title>
+          <Description>
+            This component showcases the dynamic toggle between **user view**
+            and **manager view**. The switch is going to be visible only for
+            tenants with manager privileges.
+          </Description>
+          <Stories includePrimary />
+        </>
+      );
+    },
+  },
+};
+
+export const Manager = Template.bind({});
+
+Manager.args = { ...defaultArgs, isTenantManager: true };
+Manager.parameters = {
+  docs: {
+    // eslint-disable-next-line react/no-multi-comp
+    page: () => {
+      return (
+        <>
+          <Title>Active landing page - manager</Title>
+          <Stories />
+        </>
+      );
+    },
+  },
+};

--- a/frontend/src/components/activePage/ActiveLanding/ActiveLanding.tsx
+++ b/frontend/src/components/activePage/ActiveLanding/ActiveLanding.tsx
@@ -1,0 +1,39 @@
+import { FC, useState } from 'react';
+import { Col } from 'antd';
+import NestedTables from '../NestedTables/NestedTables';
+import ViewModeButton from '../ActiveLanding/ViewModeButton/ViewModeButton';
+import { workspaces, templates } from '../tempData';
+import Box from '../../common/Box';
+
+export interface IActiveLandingProps {
+  isTenantManager: boolean;
+}
+
+const ActiveLanding: FC<IActiveLandingProps> = ({ ...props }) => {
+  const [managerView, setManagerView] = useState(false);
+  const { isTenantManager } = props;
+  return (
+    <Box
+      header={{
+        size: 'small',
+        right: isTenantManager && (
+          <ViewModeButton
+            setManagerView={setManagerView}
+            managerView={managerView}
+          />
+        ),
+      }}
+    >
+      <Col>
+        <NestedTables
+          workspaces={workspaces}
+          templates={templates}
+          isManager={managerView}
+          destroyAll={() => alert('VMs deleted')}
+        />
+      </Col>
+    </Box>
+  );
+};
+
+export default ActiveLanding;

--- a/frontend/src/components/activePage/ActiveLanding/ViewModeButton/ViewModeButton.stories.tsx
+++ b/frontend/src/components/activePage/ActiveLanding/ViewModeButton/ViewModeButton.stories.tsx
@@ -1,0 +1,46 @@
+import { Story } from '@storybook/react';
+import { Title, Description, Stories } from '@storybook/addon-docs/blocks';
+import ViewModeButton, { IViewModeButtonProps } from './ViewModeButton';
+import { someKeysOf } from '../../../../utils';
+
+export default {
+  title: 'Components/ActivePage/ActiveLanding/ViewModeButton/ViewModeButton',
+  component: ViewModeButton,
+  parameters: {
+    docs: {
+      page: () => {
+        <>
+          <Title />
+          <Description />
+        </>;
+      },
+    },
+  },
+};
+
+const defaultArgs: someKeysOf<IViewModeButtonProps> = {
+  managerView: false,
+  setManagerView: () => null,
+};
+
+const Template: Story<IViewModeButtonProps> = args => (
+  <ViewModeButton {...args} />
+);
+
+export const Default = Template.bind({});
+
+Default.args = defaultArgs;
+Default.parameters = {
+  docs: {
+    // eslint-disable-next-line react/no-multi-comp
+    page: () => {
+      return (
+        <>
+          <Title>View Mode Dropdown</Title>
+          <Description>Selector for the manager/user view modes.</Description>
+          <Stories includePrimary />
+        </>
+      );
+    },
+  },
+};

--- a/frontend/src/components/activePage/ActiveLanding/ViewModeButton/ViewModeButton.tsx
+++ b/frontend/src/components/activePage/ActiveLanding/ViewModeButton/ViewModeButton.tsx
@@ -1,0 +1,23 @@
+import { FC, Dispatch, SetStateAction } from 'react';
+import { Radio } from 'antd';
+
+export interface IViewModeButtonProps {
+  managerView: boolean;
+  setManagerView: Dispatch<SetStateAction<boolean>>;
+}
+
+const ViewModeButton: FC<IViewModeButtonProps> = ({ ...props }) => {
+  const { setManagerView, managerView } = props;
+
+  return (
+    <Radio.Group
+      value={managerView}
+      onChange={e => setManagerView(e.target.value)}
+    >
+      <Radio.Button value={false}>Personal Instances</Radio.Button>
+      <Radio.Button value={true}>Managed Instances</Radio.Button>
+    </Radio.Group>
+  );
+};
+
+export default ViewModeButton;

--- a/frontend/src/components/activePage/NestedTables/NestedTables.stories.tsx
+++ b/frontend/src/components/activePage/NestedTables/NestedTables.stories.tsx
@@ -1,0 +1,88 @@
+import NestedTables, { INestedTablesProps } from './NestedTables';
+import { Story } from '@storybook/react';
+import {
+  Title,
+  Description,
+  Stories,
+  Primary,
+} from '@storybook/addon-docs/blocks';
+import { someKeysOf } from '../../../utils';
+import { templates, workspaces } from '../tempData';
+
+export default {
+  title: 'Components/ActivePage/NestedTables/NestedTables',
+  component: NestedTables,
+  argTypes: {
+    destroyAll: { action: 'clicked' },
+  },
+  parameters: {
+    docs: {
+      page: () => {
+        <>
+          <Title>Workpaces/Templates table</Title>
+          <Description />
+        </>;
+      },
+    },
+  },
+  decorators: [
+    (Story: any) => (
+      <div style={{ height: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+const defaultArgs: someKeysOf<INestedTablesProps> = {
+  workspaces: workspaces,
+  templates: templates,
+  isManager: false,
+};
+
+const Template: Story<INestedTablesProps> = args => <NestedTables {...args} />;
+
+export const UserView = Template.bind({});
+
+UserView.args = defaultArgs;
+UserView.parameters = {
+  docs: {
+    // eslint-disable-next-line react/no-multi-comp
+    page: () => {
+      return (
+        <>
+          <Title>Active Templates Table</Title>
+          <Description>
+            Table containing active personal templates. This is the default view
+            for any tenant and also the only view for user-privileged tenants.
+            All active VM instances are stored inside the respective template.
+          </Description>
+          <Primary />
+        </>
+      );
+    },
+  },
+};
+
+export const ManagerView = Template.bind({});
+
+ManagerView.args = { ...defaultArgs, isManager: true };
+ManagerView.parameters = {
+  docs: {
+    // eslint-disable-next-line react/no-multi-comp
+    page: () => {
+      return (
+        <>
+          <Title>Active Workspaces Table</Title>
+          <Description>
+            Table containing workspaces which in turn contain a nested table of
+            templates. This layout is intended to be viewed only by
+            manager-level tenants to help them organize the active templates
+            they own and that are used by other tenants.
+          </Description>
+          <Stories />
+        </>
+      );
+    },
+  },
+};

--- a/frontend/src/components/activePage/NestedTables/NestedTables.tsx
+++ b/frontend/src/components/activePage/NestedTables/NestedTables.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { FC, useState } from 'react';
+import { Table } from 'antd';
+import { CaretRightOutlined } from '@ant-design/icons';
+import RowHeading from '../RowHeading/RowHeading';
+
+export interface IWorkspace {
+  key: string;
+  id: string;
+  name: string;
+  templates: Array<ITemplate>;
+}
+
+export interface ITemplate {
+  key: string;
+  id: string;
+  name: string;
+  workspace: string;
+  nActiveInstances: number;
+}
+export interface INestedTablesProps {
+  workspaces: Array<IWorkspace>;
+  templates: Array<ITemplate>;
+  isManager: boolean;
+  destroyAll: () => void;
+}
+
+type rowType = IWorkspace | ITemplate;
+
+const NestedTables: FC<INestedTablesProps> = ({ ...props }) => {
+  const { workspaces, templates, isManager, destroyAll } = props;
+  const { Column } = Table;
+  const [expandedID, setExpandedID] = useState(['']);
+
+  const accordion = (expanded: boolean, record: rowType) => {
+    const expId = !expanded
+      ? ''
+      : isManager
+      ? (record as IWorkspace).key
+      : (record as ITemplate).key;
+    setExpandedID([expId]);
+  };
+  const data = (isManager ? workspaces : templates) as rowType[];
+  return (
+    <Table
+      dataSource={data}
+      pagination={false}
+      showHeader={false}
+      expandable={{
+        expandedRowKeys: expandedID,
+        // eslint-disable-next-line react/no-multi-comp
+        expandIcon: ({ expanded, onExpand, record }) => (
+          <CaretRightOutlined
+            onClick={e => onExpand(record, e)}
+            rotate={expanded ? 90 : 0}
+          />
+        ),
+        // eslint-disable-next-line react/no-multi-comp
+        expandedRowRender: record =>
+          isManager ? (
+            <NestedTables
+              workspaces={workspaces}
+              templates={(record as IWorkspace).templates}
+              isManager={false}
+              destroyAll={destroyAll}
+            />
+          ) : (
+            /* record will also be used here */
+            <ul>
+              <li>VM Instance 1</li>
+              <li>VM Instance 2</li>
+              <li>VM Instance 3</li>
+            </ul>
+          ),
+        expandRowByClick: true,
+      }}
+      onExpand={accordion}
+    >
+      <Column
+        title="Workspaces"
+        dataIndex="name"
+        key="key"
+        render={(text, record: IWorkspace | ITemplate) => {
+          return isManager ? (
+            <RowHeading
+              text={(record as IWorkspace).name}
+              nActive={(record as IWorkspace).templates.length}
+              newTempl={true}
+              destroyAll={destroyAll}
+            />
+          ) : (
+            <RowHeading
+              text={(record as ITemplate).name}
+              nActive={(record as ITemplate).nActiveInstances}
+              newTempl={true}
+              destroyAll={destroyAll}
+            />
+          );
+        }}
+      />
+    </Table>
+  );
+};
+
+export default NestedTables;

--- a/frontend/src/components/activePage/RowHeading/RowHeading.stories.tsx
+++ b/frontend/src/components/activePage/RowHeading/RowHeading.stories.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable react/no-multi-comp */
+import { Story } from '@storybook/react';
+import { Title, Description, Stories } from '@storybook/addon-docs/blocks';
+import RowHeading, { IRowHeadingProps } from './RowHeading';
+import { someKeysOf } from '../../../utils';
+
+export default {
+  title: 'Components/activePage/RowHeading',
+  component: RowHeading,
+  argTypes: { destroyAll: { action: 'clicked' } },
+  parameters: {
+    docs: {
+      page: () => {
+        <>
+          <Title />
+          <Description />
+        </>;
+      },
+    },
+  },
+};
+
+const defaultArgs: someKeysOf<IRowHeadingProps> = {
+  text: 'Example',
+  nActive: 1,
+  newTempl: false,
+};
+
+const Template: Story<IRowHeadingProps> = args => <RowHeading {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = defaultArgs;
+
+Default.args = defaultArgs;
+Default.parameters = {
+  docs: {
+    page: () => {
+      return (
+        <>
+          <Title>Active Templates Accordion</Title>
+          <Description>
+            Heading for each Worksapce or Template. It displays an avatar with
+            the number of templates or instances contained, a badge in case of
+            newly created elemets and a Destroy All button. It has a responsive
+            behavior as the avatar and the button collapse below the lg
+            breakpoint.
+          </Description>
+          <Stories includePrimary />
+        </>
+      );
+    },
+  },
+};
+
+export const withBadge = Template.bind({});
+
+withBadge.args = { ...defaultArgs, newTempl: true };
+withBadge.parameters = {
+  docs: {
+    page: () => {
+      return (
+        <>
+          <Title>Template header with badge</Title>
+          <Description>
+            A simple badge on the avatar highlights a recently created entry in
+            the Table
+          </Description>
+          <Stories />
+        </>
+      );
+    },
+  },
+};

--- a/frontend/src/components/activePage/RowHeading/RowHeading.tsx
+++ b/frontend/src/components/activePage/RowHeading/RowHeading.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react';
+import { Badge as BadgeAnt, Col, Row, Menu, Dropdown, Typography } from 'antd';
+import Button from 'antd-button-color';
+import { DeleteOutlined, MoreOutlined } from '@ant-design/icons';
+import Badge from '../../common/Badge';
+
+export interface IRowHeadingProps {
+  text: string;
+  nActive: number;
+  newTempl: boolean;
+  destroyAll: () => void;
+}
+
+const RowHeading: FC<IRowHeadingProps> = ({ ...props }) => {
+  const { text, nActive, newTempl, destroyAll } = props;
+  const { Text } = Typography;
+  return (
+    <Row className="items-center">
+      <Col className="flex items-center flex-grow">
+        {newTempl ? (
+          <BadgeAnt dot offset={[-8, 2]} className="hidden lg:inline-block">
+            <Badge size="small" value={nActive} />
+          </BadgeAnt>
+        ) : (
+          <Badge size="small" value={nActive} />
+        )}
+        <Text className="font-bold ml-4 w-48 sm:w-max" ellipsis={true}>
+          {text}
+        </Text>
+      </Col>
+      <Col>
+        <Button
+          type="danger"
+          shape="round"
+          size="middle"
+          icon={<DeleteOutlined />}
+          className="hidden lg:inline-block border-0"
+          onClick={e => {
+            e.stopPropagation();
+            destroyAll();
+          }}
+        >
+          Destory All
+        </Button>
+        <Dropdown
+          overlay={
+            <Menu
+              onClick={e => {
+                e.domEvent.preventDefault();
+                destroyAll();
+              }}
+              className="p-0 rounded-sm"
+            >
+              <Menu.Item
+                key={1}
+                icon={<DeleteOutlined className="text-lg" />}
+                className="rounded-sm"
+                danger
+              >
+                Destory All
+              </Menu.Item>
+            </Menu>
+          }
+          trigger={['click']}
+        >
+          <MoreOutlined
+            className="lg:hidden"
+            onClick={e => e.stopPropagation()}
+          />
+        </Dropdown>
+      </Col>
+    </Row>
+  );
+};
+
+export default RowHeading;

--- a/frontend/src/components/activePage/tempData.ts
+++ b/frontend/src/components/activePage/tempData.ts
@@ -1,0 +1,40 @@
+import { IWorkspace, ITemplate } from './NestedTables/NestedTables';
+
+export const templates: Array<ITemplate> = [
+  {
+    key: 'LANDC-labs',
+    id: 'LANDC-labs',
+    name: 'Laboratorio di Reti Locali e Data Center',
+    workspace: '01SQOOV',
+    nActiveInstances: 3,
+  },
+  {
+    key: 'TSR-labs',
+    id: 'TSR-labs',
+    name: 'Laboratorio di Tecnologie e Servizi di Rete',
+    workspace: '02KPNOV',
+    nActiveInstances: 2,
+  },
+  {
+    key: 'LANDC-project',
+    id: 'LANDC-project',
+    name: 'Progetto Design Rete Aziendale',
+    workspace: '01SQOOV',
+    nActiveInstances: 1,
+  },
+];
+
+export const workspaces: Array<IWorkspace> = [
+  {
+    key: '01SQOOV',
+    id: '01SQOOV',
+    name: 'Reti Locali e Data Center',
+    templates: [templates[0], templates[2]],
+  },
+  {
+    key: '02KPNOV',
+    id: '02KPNOV',
+    name: 'Tecnologie e Servizi di Rete',
+    templates: [templates[1]],
+  },
+];


### PR DESCRIPTION
# Description
Adding the following components to the activePage section:
- **ActiveTemplates** - accordion in both a simple and nested version. The simple is thought for the student view and contains simple VM instances, while the nested version is thought for the professor view and is divided into courses->termplates->VMs
- **TemplateHeader** - title of each accordion displaying the number of active VM/the number of templates and a "delete all" button. The button has a responsive behavior as it is substituted by a "more" icon when the page shrinks below the `md` breakpoint
- **ActiveLanding** - a generic temporary wrapper to better display the accordion on the local barebones website. It should be placed in the `<Route path="/active"></Route>` comopnent in `App.tsx`

# Notes
The data structures contained in `./activePage/utils/data` are temporary and are used only to showcase the components.

As pointed out in the Slack channel there are issues in the correct rendering of components on Storybook: some Tailwind properties conflict with some Ant properties. I've managed to work around most of them, however there are still issues with:
- background colors not being displayed
- responsive behavior not working: in the current iteration both the "Delete All" button and the "more" icon will be visible at all times

