### PR TITLE
Add PVC support for docker instances

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -111,8 +111,10 @@ type EnvironmentResources struct {
 	Memory resource.Quantity `json:"memory"`
 
 	// The size of the persistent disk allocated for the given environment.
-	// This field is meaningful only in case of persistent environments, while
-	// it is silently ignored in the other cases.
+	// This field is meaningful only in case of persistent or container-based
+	// environments, while it is silently ignored in the other cases.
+	// In case of containers, when this field is not specified, an emptyDir will be
+	// attached to the pod but this could result in data loss whenever the pod dies.
 	Disk resource.Quantity `json:"disk,omitempty"`
 }
 

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -124,8 +124,11 @@ spec:
                           - type: string
                           description: The size of the persistent disk allocated for
                             the given environment. This field is meaningful only in
-                            case of persistent environments, while it is silently
-                            ignored in the other cases.
+                            case of persistent or container-based environments, while
+                            it is silently ignored in the other cases. In case of
+                            containers, when this field is not specified, an emptyDir
+                            will be attached to the pod but this could result in data
+                            loss whenever the pod dies.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         memory:

--- a/operators/deploy/instance-operator/templates/clusterrole.yaml
+++ b/operators/deploy/instance-operator/templates/clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
   verbs: ["get","list","watch"]
 
 - apiGroups: [""]
-  resources: ["secrets","services","events"]
+  resources: ["secrets","services","events","persistentvolumeclaims"]
   verbs: ["get","list","watch","create","patch","update"]
 
 - apiGroups: ["apps"]


### PR DESCRIPTION
# Description
This PR adds support for attaching PVC storages onto container-based environment in order to avoid data loss if the pod associated to the instance dies. The PVC is bound to the instance and is deleted when the instance is destroyed. This behaviour applies when a value is provided for the `Disk` field in the templates resources.

# How Has This Been Tested?
- [x] Added an explicit test to see if the PVC is created.