### PR TITLE
SSHKeysForm + SSHKeysTable - Modal form for key addition

### DIFF
--- a/frontend/src/components/accountPage/SSHKeysForm/SSHKeysForm.stories.tsx
+++ b/frontend/src/components/accountPage/SSHKeysForm/SSHKeysForm.stories.tsx
@@ -1,0 +1,17 @@
+import SSHKeysForm, { ISSHKeysFormProps } from './SSHKeysForm';
+import { Story, Meta } from '@storybook/react';
+import { someKeysOf } from '../../../utils';
+
+export default {
+  title: 'Components/AccountPage/SSHKeysForm',
+  component: SSHKeysForm,
+  argTypes: {},
+} as Meta;
+
+const defaultArgs: someKeysOf<ISSHKeysFormProps> = {};
+
+const Template: Story<ISSHKeysFormProps> = args => <SSHKeysForm {...args} />;
+
+export const Default = Template.bind({});
+
+Default.args = defaultArgs;

--- a/frontend/src/components/accountPage/SSHKeysForm/SSHKeysForm.tsx
+++ b/frontend/src/components/accountPage/SSHKeysForm/SSHKeysForm.tsx
@@ -1,0 +1,124 @@
+import { Input, Form, Button, Row } from 'antd';
+import { FC, useState } from 'react';
+
+export interface ISSHKeysFormProps {
+  onSaveKey: (newKey: { name: string; key: string }) => void;
+  onCancel: () => void;
+}
+
+const acceptedAlgorithms = [
+  'sk-ecdsa-sha2-nistp256@openssh.com',
+  'ecdsa-sha2-nistp256',
+  'ecdsa-sha2-nistp384',
+  'ecdsa-sha2-nistp521',
+  'sk-ssh-ed25519@openssh.com',
+  'ssh-ed25519',
+  'ssh-dss',
+  'ssh-rsa',
+];
+
+const SSHKeysForm: FC<ISSHKeysFormProps> = props => {
+  const { onSaveKey, onCancel } = props;
+  const [validForm, setValidForm] = useState<boolean>(false);
+  const [form] = Form.useForm();
+
+  const cancelForm = () => {
+    form.resetFields();
+    onCancel();
+  };
+  const validateSSHKey = async (rules: any, key: string) => {
+    if (!key) throw new Error('Key field is mandatory');
+    const result = key.split(/\s+/); // split regardless the amount of spaces
+    if (result.length !== 2 && result.length !== 3)
+      throw new Error('Invalid key format');
+    if (result[1] === '') throw new Error('Empty SSH key');
+    if (!acceptedAlgorithms.includes(result[0]))
+      throw new Error('Unrecognized SSH key format');
+  };
+
+  // Used to disable Save button
+  const handleChange = async (
+    _: any,
+    { name, key }: { name: string; key: string }
+  ) => {
+    try {
+      if (key && name) {
+        await form.validateFields(['name', 'key']);
+        setValidForm(true);
+      } else if (key) await form.validateFields(['key']);
+      else await form.validateFields(['name']);
+    } catch (_) {
+      setValidForm(false);
+    }
+  };
+  const submitForm = ({ name, key }: { name: string; key: string }) => {
+    // the name field is appended to the key
+    const comment = key.split(/\s+/)[2];
+    name = name.trim();
+    if (comment) key = `${key}:${name}`;
+    else key = `${key} ${name}`;
+
+    onSaveKey({ name, key });
+    form.resetFields();
+  };
+
+  return (
+    <Form
+      form={form}
+      labelCol={{ span: 4 }}
+      wrapperCol={{ span: 24 }}
+      onFinish={submitForm}
+      onValuesChange={handleChange}
+    >
+      <Form.Item
+        name="name"
+        label="Name"
+        validateTrigger="onBlur"
+        rules={[
+          {
+            required: true,
+            message: 'Field required',
+          },
+        ]}
+      >
+        <Input />
+      </Form.Item>
+      <Form.Item
+        validateTrigger="onBlur"
+        name="key"
+        label="Public Key"
+        rules={[
+          {
+            required: true,
+            validator: validateSSHKey,
+          },
+        ]}
+      >
+        <Input.TextArea
+          rows={10}
+          placeholder={`Your PUBLIC KEY here \n Begins with ${acceptedAlgorithms
+            .map(el => "'" + el + "'")
+            .join(', ')}`}
+        />
+      </Form.Item>
+      ​
+      <Form.Item>
+        <Row justify="end">
+          <Button type="default" htmlType="button" onClick={cancelForm}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!validForm}
+            className="ml-2"
+            type="primary"
+            htmlType="submit"
+          >
+            Save
+          </Button>
+        </Row>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default SSHKeysForm;

--- a/frontend/src/components/accountPage/SSHKeysForm/index.ts
+++ b/frontend/src/components/accountPage/SSHKeysForm/index.ts
@@ -1,0 +1,2 @@
+import SSHKeysForm from './SSHKeysForm';
+export default SSHKeysForm;

--- a/frontend/src/components/accountPage/SSHKeysTable/SSHKeysTable.stories.tsx
+++ b/frontend/src/components/accountPage/SSHKeysTable/SSHKeysTable.stories.tsx
@@ -1,18 +1,14 @@
-import UserPanel, { IUserPanelProps } from './UserPanel';
+import SSHKeysTable, { ISSHKeysTableProps } from './SSHKeysTable';
 import { Story, Meta } from '@storybook/react';
 import { someKeysOf } from '../../../utils';
 
 export default {
-  title: 'Components/AccountPage/UserPanel',
-  component: UserPanel,
+  title: 'Components/AccountPage/SSHKeysTable',
+  component: SSHKeysTable,
   argTypes: {},
 } as Meta;
 
-const defaultArgs: someKeysOf<IUserPanelProps> = {
-  firstName: 'John',
-  lastName: 'Doe',
-  username: 's123456',
-  email: 'john.doe@studenti.polito.it',
+const defaultArgs: someKeysOf<ISSHKeysTableProps> = {
   sshKeys: [
     {
       name: 'Linux key',
@@ -32,12 +28,8 @@ const defaultArgs: someKeysOf<IUserPanelProps> = {
   ],
 };
 
-const Template: Story<IUserPanelProps> = args => <UserPanel {...args} />;
+const Template: Story<ISSHKeysTableProps> = args => <SSHKeysTable {...args} />;
 
 export const Default = Template.bind({});
 
-Default.args = { ...defaultArgs };
-
-export const NoSSHKeys = Template.bind({});
-const { sshKeys, ...otherArgs } = defaultArgs;
-NoSSHKeys.args = { ...otherArgs };
+Default.args = defaultArgs;

--- a/frontend/src/components/accountPage/SSHKeysTable/SSHKeysTable.tsx
+++ b/frontend/src/components/accountPage/SSHKeysTable/SSHKeysTable.tsx
@@ -1,0 +1,22 @@
+import { Table } from 'antd';
+import Column from 'antd/lib/table/Column';
+import { FC } from 'react';
+
+export interface ISSHKeysTableProps {
+  sshKeys?: { name: string; key: string }[];
+}
+
+const SSHKeysTable: FC<ISSHKeysTableProps> = props => {
+  const { sshKeys } = props;
+  return (
+    <Table
+      dataSource={sshKeys}
+      expandedRowRender={record => <p>{record.key}</p>}
+    >
+      <Column title="Name" dataIndex="name" width={120} />
+      <Column title="Key" dataIndex="key" ellipsis={true} />
+    </Table>
+  );
+};
+
+export default SSHKeysTable;

--- a/frontend/src/components/accountPage/SSHKeysTable/index.ts
+++ b/frontend/src/components/accountPage/SSHKeysTable/index.ts
@@ -1,0 +1,2 @@
+import SSHKeysTable from './SSHKeysTable';
+export default SSHKeysTable;

--- a/frontend/src/components/accountPage/UserPanel/UserPanel.tsx
+++ b/frontend/src/components/accountPage/UserPanel/UserPanel.tsx
@@ -1,25 +1,29 @@
-import { FC } from 'react';
-import { Row, Col, Avatar, Tabs, Table } from 'antd';
+import { FC, useState } from 'react';
+import { Row, Col, Avatar, Tabs, Button } from 'antd';
 import { UserOutlined } from '@ant-design/icons';
 import UserInfo from '../UserInfo/UserInfo';
+import SSHKeysTable from '../SSHKeysTable';
+import Modal from 'antd/lib/modal/Modal';
+import SSHKeysForm from '../SSHKeysForm';
 
 const { TabPane } = Tabs;
-const { Column } = Table;
 export interface IUserPanelProps {
   firstName: string;
   lastName: string;
   username: string;
   email: string;
   avatar?: string;
-  scrollKeys: boolean;
   sshKeys?: { name: string; key: string }[];
 }
 
 const UserPanel: FC<IUserPanelProps> = props => {
-  const { avatar, sshKeys, scrollKeys, ...otherInfo } = props;
+  const { avatar, sshKeys, ...otherInfo } = props;
+  const [showSSHModal, setShowSSHModal] = useState(false);
+
+  const closeModal = () => setShowSSHModal(false);
 
   return (
-    <Row className="p-4" align="middle">
+    <Row className="p-4" align="top">
       <Col xs={24} sm={8} className="text-center">
         <Avatar size="large" icon={avatar ?? <UserOutlined />} />
         <p>
@@ -34,20 +38,23 @@ const UserPanel: FC<IUserPanelProps> = props => {
             <UserInfo {...otherInfo} />
           </TabPane>
           <TabPane tab="SSH Keys" key="2">
-            <Table
-              dataSource={sshKeys}
-              expandedRowRender={record => <p>{record.key}</p>}
+            <SSHKeysTable sshKeys={sshKeys} />
+            <Button className="mt-3" onClick={() => setShowSSHModal(true)}>
+              Add SSH key
+            </Button>
+            <Modal
+              title="New SSH key"
+              visible={showSSHModal}
+              footer={null}
+              onCancel={closeModal}
             >
-              <Column title="Name" dataIndex="name" width={120} />
-              <Column
-                title="Key"
-                dataIndex="key"
-                className={
-                  scrollKeys ? 'overflow-auto overflow-clip' : 'overflow-hidden'
-                }
-                ellipsis={true}
+              <SSHKeysForm
+                onSaveKey={newKey => {
+                  closeModal();
+                }}
+                onCancel={closeModal}
               />
-            </Table>
+            </Modal>
           </TabPane>
         </Tabs>
       </Col>


### PR DESCRIPTION
# Description

This PR introduces 2 new components for the UserPanel section of the frontend:
- `SSHKeysTable` - A simple wrapper around the list of ssh keys, shown in the SSH Keys panel
- `SSHKeysForm` - A form where the user can add new SSH keys to its list (this component is wrapped by a `Modal` )

Co-authored-by: [Alessandro Bacci](https://github.com/Ale142)