### PR TITLE
Changed default viewport sizes

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,5 +1,22 @@
 import '../src/theming';
 
+const customViewports = {
+  pixel2XL: {
+    name: 'Mobile',
+    styles: {
+      width: '411px',
+      height: '823px',
+    },
+  },
+  iPad: {
+    name: 'Tablet',
+    styles: {
+      width: '768px',
+      height: '1024px',
+    },
+  },
+};
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
@@ -14,5 +31,10 @@ export const parameters = {
       { name: 'light', class: 'light', color: '#fafafa' },
       { name: 'dark', class: 'dark', color: '#1a1a1a' },
     ],
+  },
+  viewport: {
+    viewports: {
+      ...customViewports,
+    },
   },
 };


### PR DESCRIPTION
# Description

This PR changes the additional storybook viewport sizes. It now includes only:
- a mobile view (based on the pixel2xl size of the chrome dev tools) 
- a tablet view based on the iPad size

# How Has This Been Tested?

If you check the storybook you can see the correct viewports
