### PR TITLE
Policies hook: bump kubectl version and increase limits

### DIFF
--- a/policies/values.yaml
+++ b/policies/values.yaml
@@ -44,7 +44,7 @@ gatekeeperNamespace: gatekeeper-system
 
 # Hook configurations
 hook:
-  kubectlImage: bitnami/kubectl:1.19
+  kubectlImage: bitnami/kubectl:1.21
   pullPolicy: IfNotPresent
   securityContext:
     capabilities:
@@ -57,10 +57,10 @@ hook:
     privileged: false
   resources:
     limits:
-      memory: 100Mi
+      memory: 250Mi
       cpu: 1000m
     requests:
-      memory: 100Mi
+      memory: 250Mi
       cpu: 10m
 
 nameOverride: ""


### PR DESCRIPTION
# Description

This PR bumps the kubectl version used by the policies post-install hook to match the one of the cluster, and increases the memory limits to prevent the OOMkills experienced during the last release deployment.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- Untested :)
