### PR TITLE
Component Box - Fixes

### DIFF
--- a/frontend/src/components/common/Box/Box.less
+++ b/frontend/src/components/common/Box/Box.less
@@ -12,6 +12,6 @@
     border-color: #f1f1f1;
   }
   .inner {
-    min-height: 25px;
+    min-height: 1.5rem;
   }
 }

--- a/frontend/src/components/common/Box/Box.stories.tsx
+++ b/frontend/src/components/common/Box/Box.stories.tsx
@@ -11,108 +11,132 @@ export default {
   argTypes: {
     header: {
       options: [
-        'Small_Simple',
-        'Middle_Simple',
-        'Large_Simple',
-        'Small_Custom',
-        'Middle_Custom',
-        'Large_Custom',
+        'Center_Only_small',
+        'Center_Only_middle',
+        'Center_Only_large',
+        'Left_Center_Right_small',
+        'Left_Center_Right_middle',
+        'Left_Center_Right_large',
       ],
       mapping: {
-        Small_Simple: {
+        Center_Only_small: {
           size: 'small' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Simple Header small</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Simple Header small</b>
+              </p>
+            </div>
           ),
         },
-        Middle_Simple: {
+        Center_Only_middle: {
           size: 'middle' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Simple Header middle</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Simple Header middle</b>
+              </p>
+            </div>
           ),
         },
-        Large_Simple: {
+        Center_Only_large: {
           size: 'large' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Simple Header large</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Simple Header large</b>
+              </p>
+            </div>
           ),
         },
-        Small_Custom: {
+        Left_Center_Right_small: {
           size: 'small' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Custom Header small</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Custom Header small</b>
+              </p>
+            </div>
           ),
           left: (
-            <Button
-              type="primary"
-              shape="circle"
-              size="large"
-              icon={<UserSwitchOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pl-10">
+              <Button
+                type="primary"
+                shape="circle"
+                size="large"
+                icon={<UserSwitchOutlined />}
+              />
+            </div>
           ),
           right: (
-            <Button
-              type="lightdark"
-              shape="circle"
-              size="large"
-              icon={<PlusOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pr-10">
+              <Button
+                type="lightdark"
+                shape="circle"
+                size="large"
+                icon={<PlusOutlined />}
+              />
+            </div>
           ),
         },
-        Middle_Custom: {
+        Left_Center_Right_middle: {
           size: 'middle' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Custom Header middle</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Custom Header middle</b>
+              </p>
+            </div>
           ),
           left: (
-            <Button
-              type="primary"
-              shape="circle"
-              size="large"
-              icon={<UserSwitchOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pl-10">
+              <Button
+                type="primary"
+                shape="circle"
+                size="large"
+                icon={<UserSwitchOutlined />}
+              />
+            </div>
           ),
           right: (
-            <Button
-              type="lightdark"
-              shape="circle"
-              size="large"
-              icon={<PlusOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pr-10">
+              <Button
+                type="lightdark"
+                shape="circle"
+                size="large"
+                icon={<PlusOutlined />}
+              />
+            </div>
           ),
         },
-        Large_Custom: {
+        Left_Center_Right_large: {
           size: 'large' as BoxHeaderSize,
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>Custom Header large</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>Custom Header large</b>
+              </p>
+            </div>
           ),
           left: (
-            <Button
-              type="primary"
-              shape="circle"
-              size="large"
-              icon={<UserSwitchOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pl-10">
+              <Button
+                type="primary"
+                shape="circle"
+                size="large"
+                icon={<UserSwitchOutlined />}
+              />
+            </div>
           ),
           right: (
-            <Button
-              type="lightdark"
-              shape="circle"
-              size="large"
-              icon={<PlusOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pr-10">
+              <Button
+                type="lightdark"
+                shape="circle"
+                size="large"
+                icon={<PlusOutlined />}
+              />
+            </div>
           ),
         },
       },
@@ -121,11 +145,32 @@ export default {
       options: ['Yes', 'None'],
       mapping: {
         Yes: (
-          <Button type="success" shape="round" size={'large'} disabled={false}>
-            Button Footer Example
-          </Button>
+          <div className="w-full py-10 flex justify-center">
+            <Button
+              type="success"
+              shape="round"
+              size={'large'}
+              disabled={false}
+            >
+              Button Footer Example
+            </Button>
+          </div>
         ),
         None: undefined,
+      },
+    },
+    headerMinHeight: {
+      options: ['Yes', 'None'],
+      mapping: {
+        Yes: true,
+        None: false,
+      },
+    },
+    footerMinHeight: {
+      options: ['Yes', 'None'],
+      mapping: {
+        Yes: true,
+        None: false,
       },
     },
   },
@@ -158,16 +203,20 @@ User.args = {
   ...defaultArgs,
   header: {
     center: (
-      <p className="md:text-4xl text-2xl text-center mb-0">
-        <b>User View</b>
-      </p>
+      <div className="h-full flex justify-center items-center pl-10">
+        <p className="md:text-4xl text-2xl text-center mb-0">
+          <b>User View</b>
+        </p>
+      </div>
     ),
     size: 'large' as BoxHeaderSize,
   },
   footer: (
-    <Button type="success" shape="round" size={'large'} disabled={false}>
-      Button Footer
-    </Button>
+    <div className="w-full py-10 flex justify-center">
+      <Button type="success" shape="round" size={'large'} disabled={false}>
+        Button Footer Example
+      </Button>
+    </div>
   ),
 };
 
@@ -177,31 +226,39 @@ Manager.args = {
   ...defaultArgs,
   header: {
     center: (
-      <p className="md:text-4xl text-2xl text-center mb-0">
-        <b>Manager View</b>
-      </p>
+      <div className="h-full flex justify-center items-center px-5">
+        <p className="md:text-4xl text-2xl text-center mb-0">
+          <b>Manager View</b>
+        </p>
+      </div>
     ),
     left: (
-      <Button
-        type="primary"
-        shape="circle"
-        size="large"
-        icon={<UserSwitchOutlined />}
-      />
+      <div className="h-full flex justify-center items-center pl-10">
+        <Button
+          type="primary"
+          shape="circle"
+          size="large"
+          icon={<UserSwitchOutlined />}
+        />
+      </div>
     ),
     right: (
-      <Button
-        type="lightdark"
-        shape="circle"
-        size="large"
-        icon={<PlusOutlined />}
-      />
+      <div className="h-full flex justify-center items-center pr-10">
+        <Button
+          type="lightdark"
+          shape="circle"
+          size="large"
+          icon={<PlusOutlined />}
+        />
+      </div>
     ),
     size: 'large' as BoxHeaderSize,
   },
   footer: (
-    <Button type="success" shape="round" size={'large'} disabled={false}>
-      Button Footer
-    </Button>
+    <div className="w-full py-10 flex justify-center">
+      <Button type="success" shape="round" size={'large'} disabled={false}>
+        Button Footer Example
+      </Button>
+    </div>
   ),
 };

--- a/frontend/src/components/common/Box/Box.tsx
+++ b/frontend/src/components/common/Box/Box.tsx
@@ -4,7 +4,7 @@ import './Box.less';
 import { BoxHeaderSize } from '../../../utils';
 export interface IBoxProps {
   header?: BoxHeader;
-  footer?: JSX.Element;
+  footer?: React.ReactNode;
 }
 
 export type BoxHeader = {
@@ -30,39 +30,21 @@ const Box: FC<IBoxProps> = ({ ...props }) => {
         className="flex-auto flex flex-col shadow-lg rounded-3xl cl-card-box"
         bordered={false}
       >
-        <div className="inner">
+        <div className="w-full flex-none">
           {header && (
             <div
               className={`${
                 size ? classPerSize[size] : ''
-              } flex-none w-full flex justify-center items-center box-header`}
+              } flex justify-center items-center box-header`}
             >
-              {left && (
-                <div className="flex-none h-full flex justify-center items-center pl-10">
-                  {left}
-                </div>
-              )}
-              {center && (
-                <div className="flex-grow h-full flex justify-center items-center px-5">
-                  {center}
-                </div>
-              )}
-              {right && (
-                <div className="flex-none h-full flex justify-center items-center pr-10">
-                  {right}
-                </div>
-              )}
+              <div className="flex-none h-full">{left}</div>
+              <div className="flex-grow h-full">{center}</div>
+              <div className="flex-none h-full">{right}</div>
             </div>
           )}
         </div>
-        {children}
-        <div className="inner">
-          {footer && (
-            <div className="flex-none w-full py-10 flex justify-center">
-              {footer}
-            </div>
-          )}
-        </div>
+        <div className="w-full flex-grow">{children}</div>
+        <div className="w-full flex-none inner">{footer}</div>
       </Card>
     </>
   );

--- a/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.less
+++ b/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.less
@@ -1,0 +1,8 @@
+// WE HAVE TO FIX THIS HARD CODED HEIGHT
+// document.documentElement.style.setProperty('--box-ext-height', `${value}px`); 
+
+.cl-templates-table{
+  min-height: 171px;  
+  height: calc(100vh - var(--box-ext-height, 380px)); //465px if we want to add a Box footer
+
+}

--- a/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
@@ -1,22 +1,13 @@
 import { FC } from 'react';
-import { Col, Table } from 'antd';
+import { Table } from 'antd';
 import { TemplatesTableRow } from '../TemplatesTableRow';
-import { DownOutlined, RightOutlined } from '@ant-design/icons';
+import { RightOutlined } from '@ant-design/icons';
 import { useState } from 'react';
-import { WorkspaceRole } from '../../../../utils';
+import { Template, WorkspaceRole } from '../../../../utils';
+import './TemplatesTable.less';
 
 export interface ITemplatesTableProps {
-  templates: Array<{
-    id: string;
-    name: string;
-    gui: boolean;
-    instances: Array<{
-      id: number;
-      name: string;
-      ip: string;
-      status: boolean;
-    }>;
-  }>;
+  templates: Array<Template>;
   role: WorkspaceRole;
   editTemplate: (id: string) => void;
   deleteTemplate: (id: string) => void;
@@ -33,18 +24,8 @@ const TemplatesTable: FC<ITemplatesTableProps> = ({ ...props }) => {
     {
       title: 'Template',
       key: 'template',
-      /* eslint-disable react/no-multi-comp */
-      render: (record: {
-        id: string;
-        name: string;
-        gui: boolean;
-        instances: Array<{
-          id: number;
-          name: string;
-          ip: string;
-          status: boolean;
-        }>;
-      }) => (
+      // eslint-disable-next-line react/no-multi-comp
+      render: (record: Template) => (
         <TemplatesTableRow
           id={record.id}
           name={record.name}
@@ -55,7 +36,6 @@ const TemplatesTable: FC<ITemplatesTableProps> = ({ ...props }) => {
           deleteTemplate={deleteTemplate}
         />
       ),
-      /* eslint-enable react/no-multi-comp */
     },
   ];
 
@@ -74,57 +54,39 @@ const TemplatesTable: FC<ITemplatesTableProps> = ({ ...props }) => {
    */
   const [expandedId, setExpandedId] = useState(['']);
 
-  const handleAccordion = (
-    expanded: boolean,
-    record: {
-      id: string;
-      name: string;
-      gui: boolean;
-      instances: Array<{
-        id: number;
-        name: string;
-        ip: string;
-        status: boolean;
-      }>;
-    }
-  ) => {
+  const handleAccordion = (expanded: boolean, record: Template) => {
     expanded ? setExpandedId([record.id]) : setExpandedId(['']);
   };
 
   return (
-    <div
-      className="w-full flex-grow flex-wrap content-between py-0 overflow-auto scrollbar"
-      style={{ height: 'calc(100vh - 380px)', minHeight: '171px' }} //465px if we want to add a Box footer
-    >
-      <Col span={24} className="flex-auto">
-        <Table
-          size={'small'}
-          showHeader={false}
-          rowKey={record => record.id}
-          columns={columns}
-          dataSource={templates}
-          pagination={false}
-          onExpand={handleAccordion}
-          expandable={{
-            rowExpandable: record => !!record.instances.length,
-            expandedRowKeys: expandedId,
-            expandIcon: ({ expanded, onExpand, record }) =>
-              record.instances.length ? (
-                expanded ? (
-                  <DownOutlined onClick={e => onExpand(record, e)} />
-                ) : (
-                  <RightOutlined onClick={e => onExpand(record, e)} />
-                )
-              ) : (
-                false
-              ),
-            /**
-             * Here we render the expandable content, for example with a nested Table
-             */
-            expandedRowRender: template => 'Running Instances',
-          }}
-        />
-      </Col>
+    <div className="w-full flex-grow flex-wrap content-between py-0 overflow-auto scrollbar cl-templates-table">
+      <Table
+        size={'small'}
+        showHeader={false}
+        rowKey={record => record.id}
+        columns={columns}
+        dataSource={templates}
+        pagination={false}
+        onExpand={handleAccordion}
+        expandable={{
+          rowExpandable: record => !!record.instances.length,
+          expandedRowKeys: expandedId,
+          // eslint-disable-next-line react/no-multi-comp
+          expandIcon: ({ expanded, onExpand, record }) =>
+            record.instances.length ? (
+              <RightOutlined
+                onClick={e => onExpand(record, e)}
+                rotate={expanded ? 90 : 0}
+              />
+            ) : (
+              false
+            ),
+          /**
+           * Here we render the expandable content, for example with a nested Table
+           */
+          expandedRowRender: template => 'Running Instances',
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
+++ b/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
@@ -4,24 +4,14 @@ import Button from 'antd-button-color';
 import { TemplatesTable } from '../Templates/TemplatesTable';
 import { TemplatesEmpty } from '../Templates/TemplatesEmpty';
 import Box from '../../common/Box';
-import { WorkspaceRole } from '../../../utils';
+import { Template, WorkspaceRole } from '../../../utils';
 
 export interface IWorkspaceContainerProps {
   workspace: {
     id: number;
     title: string;
     role: WorkspaceRole;
-    templates: Array<{
-      id: string;
-      name: string;
-      gui: boolean;
-      instances: Array<{
-        id: number;
-        name: string;
-        ip: string;
-        status: boolean;
-      }>;
-    }>;
+    templates: Array<Template>;
   };
 }
 
@@ -44,25 +34,31 @@ const WorkspaceContainer: FC<IWorkspaceContainerProps> = ({ ...props }) => {
         header={{
           size: 'large',
           center: (
-            <p className="md:text-4xl text-2xl text-center mb-0">
-              <b>{title}</b>
-            </p>
+            <div className="h-full flex justify-center items-center px-5">
+              <p className="md:text-4xl text-2xl text-center mb-0">
+                <b>{title}</b>
+              </p>
+            </div>
           ),
           left: role === 'manager' && (
-            <Button
-              type="primary"
-              shape="circle"
-              size="large"
-              icon={<UserSwitchOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pl-10">
+              <Button
+                type="primary"
+                shape="circle"
+                size="large"
+                icon={<UserSwitchOutlined />}
+              />
+            </div>
           ),
           right: role === 'manager' && (
-            <Button
-              type="lightdark"
-              shape="circle"
-              size="large"
-              icon={<PlusOutlined />}
-            />
+            <div className="h-full flex justify-center items-center pr-10">
+              <Button
+                type="lightdark"
+                shape="circle"
+                size="large"
+                icon={<PlusOutlined />}
+              />
+            </div>
           ),
         }}
       >

--- a/frontend/src/components/workspaces/WorkspaceWelcome/WorkspaceWelcome.tsx
+++ b/frontend/src/components/workspaces/WorkspaceWelcome/WorkspaceWelcome.tsx
@@ -10,9 +10,11 @@ const WorkspaceWelcome: FC<IWorkspaceWelcomeProps> = ({ ...args }) => {
       header={{
         size: 'large',
         center: (
-          <p className="md:text-4xl text-2xl text-center mb-0">
-            <b>Welcome to CrownLabs</b>
-          </p>
+          <div className="h-full flex justify-center items-center px-5">
+            <p className="md:text-4xl text-2xl text-center mb-0">
+              <b>Welcome to CrownLabs</b>
+            </p>
+          </div>
         ),
       }}
     >

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -2,3 +2,15 @@ export type someKeysOf<T> = { [key in keyof T]?: T[key] };
 export type WorkspaceRole = 'user' | 'manager';
 export type BadgeSize = 'small' | 'middle' | 'large';
 export type BoxHeaderSize = 'small' | 'middle' | 'large';
+export type Template = {
+  id: string;
+  name: string;
+  gui: boolean;
+  instances: Array<Instance>;
+};
+export type Instance = {
+  id: number;
+  name: string;
+  ip: string;
+  status: boolean;
+};


### PR DESCRIPTION
# Description

With this minor fix I solved some prolems with the header element disposition. Until now when a user tried to insert only one element on the left o right  without other content it was rendered on center. Now it's possible to also use only "left" and "right" properties of object "header" and fix respectively the content. Moreover i removed all that div blocks and their rigorous Style Classes that constrain content disposition (i.e. vertical and horizonal alignment), so now the Component is more customizable. Latest, i add the faculty to add a predefined min height for header or footer when the user doesn't intert "header" and "footer" content. This is usefull when a dynamic content (with scrollbar) or any other element hides rounded corner.

Fixes # (issue)

- Header content disposition
- Removed rigorous disposition Style Classes
- Added innerHeader and innerFooter properties