### PR TITLE
Try to make blender aware of available cpu cores

### DIFF
--- a/operators/pkg/instance-controller/container_logic.go
+++ b/operators/pkg/instance-controller/container_logic.go
@@ -223,6 +223,23 @@ func buildContainerInstanceDeploymentSpec(
 				environment.Resources.ReservedCPUPercentage,
 				environment.Resources.Memory,
 			),
+			Env: []v1.EnvVar{{
+				ValueFrom: &v1.EnvVarSource{
+					ResourceFieldRef: &v1.ResourceFieldSelector{
+						ContainerName: name,
+						Resource:      "requests.cpu",
+					},
+				},
+				Name: "CROWNLABS_CPU_REQUESTS",
+			}, {
+				ValueFrom: &v1.EnvVarSource{
+					ResourceFieldRef: &v1.ResourceFieldSelector{
+						ContainerName: name,
+						Resource:      "limits.cpu",
+					},
+				},
+				Name: "CROWNLABS_CPU_LIMITS",
+			}},
 			SecurityContext: &contSecCtx,
 			VolumeMounts: []v1.VolumeMount{{
 				Name:      "shared",

--- a/provisioning/containers/blender/Dockerfile
+++ b/provisioning/containers/blender/Dockerfile
@@ -29,16 +29,15 @@ RUN apt-get update && apt-get install -y \
 ARG BLENDER_VERSION_MAJOR="2.92"
 ARG BLENDER_VERSION_MINOR="0"
 ENV BLENDER_VER="${BLENDER_VERSION_MAJOR}.${BLENDER_VERSION_MINOR}-linux64"
-ENV PATH "$PATH:/bin/${BLENDER_VERSION_MAJOR}/python/bin/"
-ENV BLENDER_PATH "/bin/${BLENDER_VERSION_MAJOR}"
-ENV BLENDERPIP "/bin/${BLENDER_VERSION_MAJOR}/python/bin/pip3"
-ENV BLENDERPY "/bin/${BLENDER_VERSION_MAJOR}/python/bin/python3.7m"
+ENV BLENDER_PATH="/bin/${BLENDER_VERSION_MAJOR}"
+ENV PATH "$PATH:${BLENDER_PATH}/python/bin/"
+ENV BLENDERPIP="${BLENDER_PATH}/python/bin/pip3"
+ENV BLENDERPY="${BLENDER_PATH}/python/bin/python3.7m"
 
 # Download and install Blender
-RUN wget -q https://ftp.nluug.nl/pub/graphics/blender/release/Blender${BLENDER_VERSION_MAJOR}/blender-${BLENDER_VER}.tar.xz \ 
+RUN wget -q https://ftp.nluug.nl/pub/graphics/blender/release/Blender${BLENDER_VERSION_MAJOR}/blender-${BLENDER_VER}.tar.xz \
   && tar -xf blender-${BLENDER_VER}.tar.xz --strip-components=1 -C /bin \ 
   && rm -rf blender-${BLENDER_VER}.tar.xz \ 
-  && rm -rf blender-${BLENDER_VER} \
   && rm -rf ${BLENDER_PATH}/python/lib/python3.7/site-packages/numpy
 
 # Download the Python source since it is not bundled with Blender
@@ -46,7 +45,7 @@ RUN wget -q https://ftp.nluug.nl/pub/graphics/blender/release/Blender${BLENDER_V
 # Must first ensurepip to install Blender pip3 and then new numpy
 RUN wget -q https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz \ 
   && tar -xzf Python-3.7.10.tgz \ 
-  && cp -r Python-3.7.10/Include/* $BLENDER_PATH/python/include/python3.7m/ \ 
+  && cp -r Python-3.7.10/Include/* ${BLENDER_PATH}/python/include/python3.7m/ \ 
   && rm -rf Python-3.7.10.tgz \ 
   && rm -rf Python-3.7.10 \
   && ${BLENDERPY} -m ensurepip \
@@ -67,6 +66,9 @@ RUN mkdir -p $HOME && useradd -ms /bin/bash -u ${UID} $USER
 
 # Set permissions on user home
 RUN chown -R $USER:$USER $HOME
+
+# Copy the startup script for resources limiting
+COPY autolimits.py ${BLENDER_PATH}/scripts/startup/crownlabs_autolimits.py
 
 # Set the user to use
 USER $USER

--- a/provisioning/containers/blender/autolimits.py
+++ b/provisioning/containers/blender/autolimits.py
@@ -1,0 +1,22 @@
+import os
+import bpy
+from bpy.app.handlers import persistent
+import math
+
+
+@persistent  # Keep across file reloads
+def cpulimits_setter(_):  # An argument has to be present for handlers
+    try:
+        maxThreads = math.ceil(float(os.environ['CROWNLABS_CPU_LIMITS']))  # Round possible floats
+        # There might be more than a scene, we cycle them all
+        for scn in bpy.data.scenes:
+            scn.render.threads_mode = 'FIXED'
+            scn.render.threads = maxThreads
+    except Exception as e:
+        print("Error while setting rendering threads", e)
+
+
+def register():  # Required method, called on startup
+    # Handlers are called on certain events,
+    # load_post occurs after a file has been loaded
+    bpy.app.handlers.load_post.append(cpulimits_setter)


### PR DESCRIPTION
# Description

Blender automatically gets the number of available cpu cores to decide how many threads spawn for rendering. This PR includes:
- Environment variables for the containers in order to let them know their actual cpu limits and requests
- Blender startup script to set those values on scene load

# How Has This Been Tested?

- [x] Local blender setup
- [x] Blender on CrownLabs