### PR TITLE
qlkube: parametrize exposed and subscription-enabled APIs

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -49,6 +49,9 @@ qlkube:
   ingress:
     hostname: qlkube.crownlabs.example.com
   configuration:
+    exposedAPIs:
+      apis:
+      - crownlabs.polito.it
     subscriptions:
       apis:
       - group: crownlabs.polito.it

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -48,6 +48,17 @@ qlkube:
   rbacResourcesName: crownlabs-qlkube
   ingress:
     hostname: qlkube.crownlabs.example.com
+  configuration:
+    subscriptions:
+      apis:
+      - group: crownlabs.polito.it
+        resources:
+        - resource: instances
+          version: v1alpha2
+          mapping: itPolitoCrownlabsV1alpha2Instance
+        - resource: templates
+          version: v1alpha2
+          mapping: itPolitoCrownlabsV1alpha2Template
 
 instance-operator:
   replicaCount: 1
@@ -79,7 +90,7 @@ instance-operator:
       exportImageTag: ""
     privateContainerRegistry:
       url: registry.crownlabs.example.com
-      secretName: registry-credentials      
+      secretName: registry-credentials
 
 tenant-operator:
   replicaCount: 1

--- a/qlkube/deploy/qlkube/templates/clusterrole.yaml
+++ b/qlkube/deploy/qlkube/templates/clusterrole.yaml
@@ -4,20 +4,16 @@ metadata:
   name: {{ .Values.rbacResourcesName }}
   labels: {{- include "qlkube.labels" . | nindent 4 }}
 rules:
+  {{- range .Values.configuration.subscriptions.apis }}
   - apiGroups:
-      - crownlabs.polito.it
+      - {{ .group }}
     resources:
-      - instances
-      - instances/status
-      - instancesnapshots
-      - instancesnapshots/status
-      - templates
-      - templates/status
-      - workspaces
-      - workspaces/status
-      - tenants
-      - tenants/status
+    {{- range .resources }}
+      - {{ .resource }}
+      - {{ .resource }}/status
+    {{- end }}
     verbs:
       - get
       - list
       - watch
+  {{- end }}

--- a/qlkube/deploy/qlkube/templates/configmap.yaml
+++ b/qlkube/deploy/qlkube/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "qlkube.fullname" . }}
+  labels:
+    {{- include "qlkube.labels" . | nindent 4 }}
+data:
+  {{ .Values.configuration.subscriptions.fileName }}: |
+    const subscriptions = [
+      {{- range $api := .Values.configuration.subscriptions.apis }}
+      {{- range .resources }}
+      {
+        api: 'apis',
+        group: '{{ $api.group }}',
+        version: '{{ .version }}',
+        resource: '{{ .resource }}',
+        type: '{{ .mapping }}',
+      },
+      {{- end }}
+      {{- end }}
+    ];
+
+    module.exports = { subscriptions };

--- a/qlkube/deploy/qlkube/templates/configmap.yaml
+++ b/qlkube/deploy/qlkube/templates/configmap.yaml
@@ -5,6 +5,17 @@ metadata:
   labels:
     {{- include "qlkube.labels" . | nindent 4 }}
 data:
+  {{ .Values.configuration.exposedAPIs.fileName }}: |
+    const apiGroups = {
+      paths: [
+        {{- range .Values.configuration.exposedAPIs.apis }}
+          '{{ . }}',
+        {{- end }}
+      ],
+    };
+
+    module.exports = { apiGroups };
+
   {{ .Values.configuration.subscriptions.fileName }}: |
     const subscriptions = [
       {{- range $api := .Values.configuration.subscriptions.apis }}

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -42,11 +42,15 @@ spec:
             httpGet:
               path: /healthz
               port: http
+            initialDelaySeconds: 60
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           volumeMounts:
+          - name: configuration
+            mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.exposedAPIs.fileName }}"
+            subPath: "{{ .Values.configuration.exposedAPIs.fileName }}"
           - name: configuration
             mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.subscriptions.fileName }}"
             subPath: "{{ .Values.configuration.subscriptions.fileName }}"

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -46,6 +46,14 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+          - name: configuration
+            mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.subscriptions.fileName }}"
+            subPath: "{{ .Values.configuration.subscriptions.fileName }}"
+      volumes:
+      - name: configuration
+        configMap:
+          name: "{{ include "qlkube.fullname" . }}"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -10,11 +10,30 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+configuration:
+  mountPath: /qlkube/src
+
+  # This subscription configuration maps to the current content
+  # of the src/subscriptions.js file
+  subscriptions:
+    fileName: subscriptions.js
+    apis:
+    - group: crownlabs.polito.it
+      resources:
+      - resource: instances
+        version: v1alpha2
+        mapping: itPolitoCrownlabsV1alpha2Instance
+      - resource: templates
+        version: v1alpha2
+        mapping: itPolitoCrownlabsV1alpha2Template
+
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-deploymentAnnotations: {}
+deploymentAnnotations:
+  reloader.stakater.com/auto: "true"
 podAnnotations: {}
 
 securityContext:

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -13,8 +13,15 @@ image:
 configuration:
   mountPath: /qlkube/src
 
+  # ExposedAPIs represents the list of Kubernetes APIs which are
+  # exposed through graphql.
+  exposedAPIs:
+    fileName: apiGroups.js
+    apis:
+    - crownlabs.polito.it
+
   # This subscription configuration maps to the current content
-  # of the src/subscriptions.js file
+  # of the src/subscriptions.js file. Must be a subset of exposedAPIs.
   subscriptions:
     fileName: subscriptions.js
     apis:

--- a/qlkube/src/apiGroups.js
+++ b/qlkube/src/apiGroups.js
@@ -1,3 +1,7 @@
+// This file serves development/testing purposes only.
+// When qlkube is deployed with Helm, it is overwritten by an equivalent
+// one automatically generated from the configuration therein specified.
+
 const apiGroups = {
   paths: ['crownlabs.polito.it'],
 };

--- a/qlkube/src/subscriptions.js
+++ b/qlkube/src/subscriptions.js
@@ -1,3 +1,7 @@
+// This file serves development/testing purposes only.
+// When qlkube is deployed with Helm, it is overwritten by an equivalent
+// one automatically generated from the configuration therein specified.
+
 const subscriptions = [
   {
     api: 'apis',


### PR DESCRIPTION
# Description

This PR introduces the possibility to parametrize through helm the set of APIs exposed through graphql and the ones for which subscriptions are enabled.

# How Has This Been Tested?

- [x] Staging environment
