### PR TITLE
Add controller concurrency to tenant and instance controller

### DIFF
--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -73,6 +73,7 @@ func main() {
 	var containerKaniko string
 	var containerEnvFileBrowserImg string
 	var containerEnvFileBrowserImgTag string
+	var maxConcurrentReconciles int
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -96,6 +97,7 @@ func main() {
 	flag.StringVar(&containerKaniko, "container-kaniko-img", "gcr.io/kaniko-project/executor", "The image for the Kaniko container to be deployed")
 	flag.StringVar(&containerEnvFileBrowserImg, "container-env-filebrowser-img", "filebrowser/filebrowser", "The image name for the filebrowser image (sidecar for gui-based file manager)")
 	flag.StringVar(&containerEnvFileBrowserImgTag, "container-env-filebrowser-img-tag", "latest", "The tag for the FileBrowser container (the gui-based file manager)")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 8, "The maximum number of concurrent Reconciles which can be run")
 	klog.InitFlags(nil)
 	flag.Parse()
 

--- a/operators/pkg/instance-controller/controller.go
+++ b/operators/pkg/instance-controller/controller.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
@@ -59,6 +60,7 @@ type InstanceReconciler struct {
 	Oauth2ProxyImage   string
 	OidcClientSecret   string
 	OidcProviderURL    string
+	Concurrency        int
 	ContainerEnvOpts   ContainerEnvOpts
 
 	// This function, if configured, is deferred at the beginning of the Reconcile.
@@ -160,6 +162,9 @@ func (r *InstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Also Deployments are watched in order to better handle container environment.
 		Owns(&appsv1.Deployment{}).
 		Owns(&cdiv1.DataVolume{}, builder.WithPredicates(dataVolumePredicate())).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: r.Concurrency,
+		}).
 		Complete(r)
 }
 

--- a/operators/pkg/tenant-controller/suite_test.go
+++ b/operators/pkg/tenant-controller/suite_test.go
@@ -59,7 +59,7 @@ var reqActions = []string{"UPDATE_PASSWORD", "VERIFY_EMAIL"}
 var emailActionLifespan = 60 * 60 * 24 * 30
 var kcA = KcActor{
 	Client:                mKcClient,
-	Token:                 mToken,
+	token:                 mToken,
 	TargetRealm:           kcTargetRealm,
 	TargetClientID:        kcTargetClientID,
 	UserRequiredActions:   reqActions,


### PR DESCRIPTION
# Description

This PR sets MaxConcurrentReconciles to tenant and instance operator, aiming to reduce necessary time to reconcile a large number of objects. Also, the amount of time between tenant reconciles has been increased noticeably.
This aims to solve the tenant operator being almost always busy reconciling tenants and often being slow reacting to immediate tenant change requests.

A RWmutex has been added to the keycloak access token to avoid race conditions, on @giorio94's suggestion

# How Has This Been Tested?
- [x] Staging
- [ ] Production
