### PR TITLE
Infrastructure: add oauth2-proxy installation docs

### DIFF
--- a/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
+++ b/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
@@ -1,0 +1,303 @@
+# Oauth client configuration specifics
+config:
+  # OAuth client ID
+  clientID: "user-instances"
+  # OAuth client secret
+  clientSecret: "<redacted>"
+  # Create a new secret with the following command
+  # openssl rand -base64 32 | head -c 32 | base64
+  # Use an existing secret for OAuth2 credentials (see secret.yaml for required fields)
+  # Example:
+  # existingSecret: secret
+  cookieSecret: "<redacted>"
+  # The name of the cookie that oauth2-proxy will create
+  # If left empty, it will default to the release name
+  cookieName: "crownlabs-instances-auth"
+  google: {}
+    # adminEmail: xxxx
+    # serviceAccountJson: xxxx
+    # Alternatively, use an existing secret (see google-secret.yaml for required fields)
+    # Example:
+    # existingSecret: google-secret
+  # Default configuration, to be overridden
+  configFile: |-
+    cookie_expire = "168h0m0s"
+    cookie_path = "/"
+    cookie_refresh = "45m0s"
+    email_domains = [ "*" ]
+    oidc_issuer_url = "https://auth.crownlabs.polito.it/auth/realms/crownlabs"
+    provider = "oidc"
+    proxy_prefix = "/app/instances/oauth2"
+    reverse_proxy = true
+    skip_provider_button = true
+    silence_ping_logging = true
+    upstreams = [ "file:///dev/null" ]
+
+  # Custom configuration file: oauth2_proxy.cfg
+  # configFile: |-
+  #   pass_basic_auth = false
+  #   pass_access_token = true
+  # Use an existing config map (see configmap.yaml for required fields)
+  # Example:
+  # existingConfig: config
+
+image:
+  repository: "quay.io/oauth2-proxy/oauth2-proxy"
+  tag: "v7.1.3"
+  pullPolicy: "IfNotPresent"
+
+# Optionally specify an array of imagePullSecrets.
+# Secrets must be manually created in the namespace.
+# ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+# imagePullSecrets:
+  # - name: myRegistryKeySecretName
+
+extraArgs: {}
+extraEnv:
+  - name: OAUTH2_PROXY_REDIS_SENTINEL_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name:  crownlabs-instances-auth-redis
+        key: redis-password
+
+# To authorize individual email addresses
+# That is part of extraArgs but since this needs special treatment we need to do a separate section
+authenticatedEmailsFile:
+  enabled: false
+  # Defines how the email addresses file will be projected, via a configmap or secret
+  persistence: configmap
+  # template is the name of the configmap what contains the email user list but has been configured without this chart.
+  # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
+  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
+  template: ""
+  # One email per line
+  # example:
+  # restricted_access: |-
+  #   name1@domain
+  #   name2@domain
+  # If you override the config with restricted_access it will configure a user list within this chart what takes care of the
+  # config map resource.
+  restricted_access: ""
+  annotations: {}
+  # helm.sh/resource-policy: keep
+
+service:
+  type: ClusterIP
+  # when service.type is ClusterIP ...
+  # clusterIP: 192.0.2.20
+  # when service.type is LoadBalancer ...
+  # loadBalancerIP: 198.51.100.40
+  # loadBalancerSourceRanges: 203.0.113.0/24
+  portNumber: 80
+  annotations: {}
+  # foo.io/bar: "true"
+
+## Create or use ServiceAccount
+serviceAccount:
+  ## Specifies whether a ServiceAccount should be created
+  enabled: true
+  ## The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the fullname template
+  name:
+  annotations: {}
+
+ingress:
+  enabled: true
+  path: /app/instances/oauth2/
+  # Only used if API capabilities (networking.k8s.io/v1) allow it
+  pathType: Prefix
+  # Used to create an Ingress record.
+  hosts:
+    - crownlabs.polito.it
+  # Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  # Warning! The configuration is dependant on your current k8s API version capabilities (networking.k8s.io/v1)
+  # extraPaths:
+  # - path: /*
+  #   pathType: ImplementationSpecific
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls:
+    # Secrets must be manually created in the namespace.
+    - secretName: crownlabs-certificate
+      hosts:
+        - crownlabs.polito.it
+
+resources: # {}
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 300Mi
+
+extraVolumes: []
+  # - name: ca-bundle-cert
+  #   secret:
+  #     secretName: <secret-name>
+
+extraVolumeMounts: []
+  # - mountPath: /etc/ssl/certs/
+  #   name: ca-bundle-cert
+
+priorityClassName: ""
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: # {}
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - oauth2-proxy
+      topologyKey: kubernetes.io/hostname
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# Whether to use secrets instead of environment values for setting up OAUTH2_PROXY variables
+proxyVarsAsSecrets: true
+
+# Configure Kubernetes liveness and readiness probes.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+# Disable both when deploying with Istio 1.0 mTLS. https://istio.io/help/faq/security/#k8s-health-checks
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 0
+  timeoutSeconds: 1
+  periodSeconds: 10
+  successThreshold: 1
+
+# Configure Kubernetes security context for container
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  enabled: true
+  runAsNonRoot: true
+
+podAnnotations: {}
+podLabels: {}
+replicaCount: 3
+
+## PodDisruptionBudget settings
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+# Configure Kubernetes security context for pod
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
+# whether to use http or https
+httpScheme: http
+
+# Additionally authenticate against a htpasswd file. Entries must be created with "htpasswd -s" for SHA encryption.
+# Alternatively supply an existing secret which contains the required information.
+htpasswdFile:
+  enabled: false
+  existingSecret: ""
+  entries: {}
+  # One row for each user
+  # example:
+  # entries:
+  #  - testuser:{SHA}EWhzdhgoYJWy0z2gyzhRYlN9DSiv
+
+# Configure the session storage type, between cookie and redis
+sessionStorage:
+  # Can be one of the supported session storage cookie/redis
+  type: redis
+  redis:
+    # Secret name that holds the redis-password and redis-sentinel-password values
+    existingSecret: "crownlabs-instances-auth-redis"
+    password: true
+    # Can be one of sentinel/cluster/standalone
+    clientType: "sentinel"
+    standalone:
+      # If empty and sessionStorage type is redis, will automatically be generated.
+      connectionUrl: ""
+    cluster:
+      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
+      connectionUrls: []
+    sentinel:
+      # The password is injected as custom environment variable above, since secret key is different
+      password: ""
+      masterName: "crownlabs-instances-auth"
+      # connectionUrls: ["redis://127.0.0.1:8000", "redis://127.0.0.1:8000"]
+      connectionUrls: "\
+        redis://crownlabs-instances-auth-redis-master-0.crownlabs-instances-auth-redis-headless:26379,\
+        redis://crownlabs-instances-auth-redis-slave-0.crownlabs-instances-auth-redis-headless:26379,\
+        redis://crownlabs-instances-auth-redis-slave-1.crownlabs-instances-auth-redis-headless:26379\
+      "
+
+
+# Enables and configure the automatic deployment of the redis subchart
+redis:
+  # provision an instance of the redis sub-chart
+  enabled: true
+
+  # Redis specific helm chart settings, please see:
+  # https://github.com/bitnami/charts/tree/master/bitnami/redis#parameters
+  cluster:
+    enabled: true
+    slaveCount: 2
+
+  sentinel:
+    enabled: true
+    masterSet: "crownlabs-instances-auth"
+
+  master:
+    persistence:
+      size: 1Gi
+
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - redis
+          topologyKey: kubernetes.io/hostname
+
+  slave:
+    persistence:
+      size: 1Gi
+
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - redis
+          topologyKey: kubernetes.io/hostname
+
+  # redisPort: 6379
+  # cluster:
+  #   enabled: false
+  #   slaveCount: 1
+
+# Enables apiVersion deprecation checks
+checkDeprecation: true


### PR DESCRIPTION
# Description

This PR adds the documentation regarding the installation of the centralized oauth2-proxy deployment, which is used to prevent access to the graphical desktop of the user instances to unauthenticated users. Related to #490 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Performing the deployment of oath2-proxy in the cluster
