### PR TITLE
Include exams and exercises endpoints in oauth2-proxy config

### DIFF
--- a/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
+++ b/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
@@ -23,6 +23,7 @@ config:
   configFile: |-
     cookie_expire = "168h0m0s"
     cookie_path = "/"
+    cookie_domains = [ "crownlabs.polito.it" , "exams.crownlabs.polito.it" , "exercises.crownlabs.polito.it" ]
     cookie_refresh = "45m0s"
     email_domains = [ "*" ]
     oidc_issuer_url = "https://auth.crownlabs.polito.it/auth/realms/crownlabs"
@@ -32,6 +33,7 @@ config:
     skip_provider_button = true
     silence_ping_logging = true
     upstreams = [ "file:///dev/null" ]
+    whitelist_domains = [ "crownlabs.polito.it" , "exams.crownlabs.polito.it" , "exercises.crownlabs.polito.it" ]
 
   # Custom configuration file: oauth2_proxy.cfg
   # configFile: |-


### PR DESCRIPTION
# Description

This PR modifies the deployed configuration for the centralized oauth2-proxy, reflecting the one already deployed in the cluster.
This edit adds the support for setting cookies and correctly redirecting requests coming from instances available on exams and exercises endpoints.
