### PR TITLE
Environment customization (towards intanceset)

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -25,11 +25,24 @@ import (
 // can be instantiated in CrownLabs.
 type EnvironmentType string
 
+// +kubebuilder:validation:Enum="Standard";"Exam";"Exercise"
+
+// EnvironmentMode is an enumeration of the mode in which associated instances should be started:
+// each mode consists in presets for exposition and deployment.
+type EnvironmentMode string
+
 const (
 	// ClassContainer -> the environment is constituted by a Docker container.
 	ClassContainer EnvironmentType = "Container"
 	// ClassVM -> the environment is constituted by a Virtual Machine.
 	ClassVM EnvironmentType = "VirtualMachine"
+
+	// ModeStandard -> Normal operation (authentication, ssh, files access).
+	ModeStandard EnvironmentMode = "Standard"
+	// ModeExam -> Restricted access (no authentication, no mydrive access).
+	ModeExam EnvironmentMode = "Exam"
+	// ModeExercise -> Restricted access (no authentication, no mydrive access).
+	ModeExercise EnvironmentMode = "Exercise"
 )
 
 // TemplateSpec is the specification of the desired state of the Template.
@@ -84,6 +97,11 @@ type Environment struct {
 
 	// The amount of computational resources associated with the environment.
 	Resources EnvironmentResources `json:"resources"`
+
+	// +kubebuilder:default="Standard"
+
+	// The mode associated with the environment (Standard, Exam, Exercise)
+	Mode EnvironmentMode `json:"mode,omitempty"`
 }
 
 // EnvironmentResources is the specification of the amount of resources
@@ -122,6 +140,7 @@ type EnvironmentResources struct {
 // +kubebuilder:resource:shortName="tmpl"
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Pretty Name",type=string,JSONPath=`.spec.prettyName`
+// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.environmentList[0].mode`
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.environmentList[0].image`,priority=10
 // +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.environmentList[0].environmentType`,priority=10
 // +kubebuilder:printcolumn:name="GUI",type=string,JSONPath=`.spec.environmentList[0].guiEnabled`,priority=10

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.prettyName
       name: Pretty Name
       type: string
+    - jsonPath: .spec.environmentList[0].mode
+      name: Mode
+      type: string
     - jsonPath: .spec.environmentList[0].image
       name: Image
       priority: 10
@@ -95,6 +98,15 @@ spec:
                     image:
                       description: The VM or container to be started when instantiating
                         the environment.
+                      type: string
+                    mode:
+                      default: Standard
+                      description: The mode associated with the environment (Standard,
+                        Exam, Exercise)
+                      enum:
+                      - Standard
+                      - Exam
+                      - Exercise
                       type: string
                     name:
                       description: The name identifying the specific environment.

--- a/operators/pkg/forge/ingresses.go
+++ b/operators/pkg/forge/ingresses.go
@@ -108,6 +108,20 @@ func IngressAuthenticationAnnotations(annotations map[string]string, instancesAu
 	return annotations
 }
 
+// HostName returns the hostname based on the given EnvironmentMode.
+func HostName(baseHostName string, mode clv1alpha2.EnvironmentMode) string {
+	switch mode {
+	case clv1alpha2.ModeStandard:
+		return baseHostName
+	case clv1alpha2.ModeExam:
+		return "exam." + baseHostName
+	case clv1alpha2.ModeExercise:
+		return "exercise." + baseHostName
+	}
+
+	return baseHostName
+}
+
 // IngressGUIPath returns the path of the ingress targeting the environment GUI.
 func IngressGUIPath(instance *clv1alpha2.Instance) string {
 	return strings.TrimRight(fmt.Sprintf("/%v/%v", instance.UID, ingressGUIPathSuffix), "/")

--- a/operators/pkg/forge/ingresses_test.go
+++ b/operators/pkg/forge/ingresses_test.go
@@ -246,6 +246,35 @@ var _ = Describe("Ingresses", func() {
 			}
 		})
 
+		Describe("The forge.HostName function", func() {
+			const baseHost = "crownlabs.it"
+			type HostNameCase struct {
+				Mode           clv1alpha2.EnvironmentMode
+				ExpectedOutput string
+			}
+			DescribeTable("correctly generates the hostname",
+				func(c HostNameCase) {
+					Expect(forge.HostName(baseHost, c.Mode)).To(Equal(c.ExpectedOutput))
+				},
+				Entry("when the mode is Default", HostNameCase{
+					Mode:           clv1alpha2.ModeStandard,
+					ExpectedOutput: baseHost,
+				}),
+				Entry("when the mode is Exam", HostNameCase{
+					Mode:           clv1alpha2.ModeExam,
+					ExpectedOutput: "exam." + baseHost,
+				}),
+				Entry("when the mode is Exercise", HostNameCase{
+					Mode:           clv1alpha2.ModeExercise,
+					ExpectedOutput: "exercise." + baseHost,
+				}),
+				Entry("when the mode is invalid/unset", HostNameCase{
+					Mode:           "",
+					ExpectedOutput: baseHost,
+				}),
+			)
+		})
+
 		Describe("The forge.IngressGUIPath function", func() {
 			JustBeforeEach(func() {
 				path = forge.IngressGUIPath(&instance)

--- a/operators/pkg/instance-controller/controller_test.go
+++ b/operators/pkg/instance-controller/controller_test.go
@@ -128,6 +128,7 @@ var _ = Describe("Instance Operator controller", func() {
 				{
 					Name:       "Test",
 					GuiEnabled: true,
+					Mode:       crownlabsv1alpha2.ModeStandard,
 					Resources: crownlabsv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,

--- a/operators/pkg/instance-controller/exposition_test.go
+++ b/operators/pkg/instance-controller/exposition_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Generation of the exposition environment", func() {
 				Tenant:   clv1alpha2.GenericRef{Name: tenantName},
 			},
 		}
-		environment = clv1alpha2.Environment{Name: environmentName}
+		environment = clv1alpha2.Environment{Name: environmentName, Mode: clv1alpha2.ModeStandard}
 
 		serviceName = forge.NamespacedName(&instance)
 		ingressGUIName = forge.NamespacedNameWithSuffix(&instance, forge.IngressGUINameSuffix)

--- a/operators/pkg/instance-controller/virtualmachines.go
+++ b/operators/pkg/instance-controller/virtualmachines.go
@@ -34,10 +34,12 @@ func (r *InstanceReconciler) EnforceVMEnvironment(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 
-	// Enforce the cloud-init secret
-	if err := r.EnforceCloudInitSecret(ctx); err != nil {
-		log.Error(err, "failed to enforce the cloud-init secret existence")
-		return err
+	// Enforce the cloud-init secret when environment is not restricted
+	if environment.Mode == clv1alpha2.ModeStandard {
+		if err := r.EnforceCloudInitSecret(ctx); err != nil {
+			log.Error(err, "failed to enforce the cloud-init secret existence")
+			return err
+		}
 	}
 
 	// Enforce the service and the ingress to expose the environment.

--- a/operators/pkg/instance-controller/virtualmachines_test.go
+++ b/operators/pkg/instance-controller/virtualmachines_test.go
@@ -136,9 +136,38 @@ var _ = Describe("Generation of the virtual machine and virtual machine instance
 		err = reconciler.EnforceVMEnvironment(ctx)
 	})
 
-	It("Should enforce the cloud-init secret", func() {
-		// Here, we only check the secret presence to assert the function execution, leaving the other assertions to the proper tests.
-		Expect(reconciler.Get(ctx, objectName, &secret)).To(Succeed())
+	Context("The environment mode is Standard", func() {
+		BeforeEach(func() {
+			environment.Mode = clv1alpha2.ModeStandard
+		})
+		It("Should enforce the cloud-init secret", func() {
+			// Here, we only check the secret presence to assert the function execution, leaving the other assertions to the proper tests.
+			Expect(reconciler.Get(ctx, objectName, &secret)).To(Succeed())
+		})
+	})
+
+	Context("The environment mode is Exam", func() {
+		BeforeEach(func() {
+			environment.Mode = clv1alpha2.ModeExam
+		})
+		It("Should not enforce the cloud-init secret", func() {
+			// Here, we only check the secret absence to assert the function execution, leaving the other assertions to the proper tests.
+			Expect(reconciler.Get(ctx, objectName, &secret)).To(
+				MatchError(kerrors.NewNotFound(corev1.Resource("secrets"), objectName.Name)),
+			)
+		})
+	})
+
+	Context("The environment mode is Exercise", func() {
+		BeforeEach(func() {
+			environment.Mode = clv1alpha2.ModeExercise
+		})
+		It("Should not enforce the cloud-init secret", func() {
+			// Here, we only check the secret absence to assert the function execution, leaving the other assertions to the proper tests.
+			Expect(reconciler.Get(ctx, objectName, &secret)).To(
+				MatchError(kerrors.NewNotFound(corev1.Resource("secrets"), objectName.Name)),
+			)
+		})
 	})
 
 	It("Should enforce the environment exposition objects", func() {


### PR DESCRIPTION
# Description

This PR adds a `mode` to the template CRD, inside the environment struct. Such mode changes the current behavior of instances based on templates with mode different than `Default`. By setting `mode: Exam` or `mode: Exercise` the following behaviors change:
- custom hostname (mainly thought to ease LDB whitelisting), respectively exam.$baseHostname and exercise.$baseHostname
- restrict interaction (mainly to avoid deploying unnecessary resources)
- disable authentication 

# How Has This Been Tested?
- [x] Locally
- [x] Staging
