### PR TITLE
Updated ThemeSwitcher component: className exposed + new icons

### DIFF
--- a/frontend/src/components/misc/ThemeSwitcher/ThemeSwitcher.stories.tsx
+++ b/frontend/src/components/misc/ThemeSwitcher/ThemeSwitcher.stories.tsx
@@ -1,0 +1,26 @@
+import ThemeSwitcher, { IThemeSwitcherProps } from './ThemeSwitcher';
+import { Story, Meta } from '@storybook/react';
+import ThemeContextProvider from '../../../contexts/ThemeContext';
+
+export default {
+  title: 'Components/Misc/ThemeSwitcher',
+  component: ThemeSwitcher,
+  argTypes: {
+    onClick: { action: 'clicked' },
+  },
+  decorators: [
+    (Story: Story) => {
+      return (
+        <ThemeContextProvider>
+          <Story />
+        </ThemeContextProvider>
+      );
+    },
+  ],
+} as Meta;
+
+const Template: Story<IThemeSwitcherProps> = args => (
+  <ThemeSwitcher {...args} />
+);
+
+export const Default = Template.bind({});

--- a/frontend/src/components/misc/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/frontend/src/components/misc/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,25 +1,53 @@
-import { useContext } from 'react';
+import { FC, useContext } from 'react';
 import { Switch } from 'antd';
-import { BulbTwoTone, BulbOutlined } from '@ant-design/icons';
 import { ThemeContext } from '../../../contexts/ThemeContext';
 
-// this component doesn't include a story
-// since it conflicts with the storybook theme management
+export interface IThemeSwitcherProps {
+  className?: string;
+}
 
-const ThemeSwitcher = () => {
+const ThemeSwitcher: FC<IThemeSwitcherProps> = ({ ...props }) => {
+  const { className } = props;
   const { isDarkTheme, setIsDarkTheme } = useContext(ThemeContext);
 
   const onChange = () => {
     setIsDarkTheme(!isDarkTheme);
   };
 
+  const moonIcon = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      width="16px"
+      fill="white"
+      className="flex items-center"
+    >
+      <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
+    </svg>
+  );
+
+  const sunIcon = (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="white"
+      width="17px"
+      className="flex items-center"
+    >
+      <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" />
+    </svg>
+  );
+
   return (
-    <Switch
-      onChange={onChange}
-      checked={isDarkTheme}
-      checkedChildren={<BulbOutlined />}
-      unCheckedChildren={<BulbTwoTone />}
-    />
+    <>
+      <Switch
+        className={className}
+        onChange={onChange}
+        checked={isDarkTheme}
+        checkedChildren={moonIcon}
+        unCheckedChildren={sunIcon}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
Components updated:

- ThemeSwitcher (common)

This PR adds the className prop, in order to expose the internal switch's className and 2 new icons (sun/moon).

