### PR TITLE
Faveo helpdesk installation

### DIFF
--- a/infrastructure/ticketing/README.md
+++ b/infrastructure/ticketing/README.md
@@ -1,0 +1,30 @@
+# Ticketing assistance - Faveo helpdesk
+
+Faveo is an open source ticket based support system with knowledge base. It’s specifically designed to cater the needs of Startup's & SME's empowering them with state of art, ticket based support system.
+
+More info at [Faveo's website](https://www.faveohelpdesk.com)
+### Pre-requisites
+Here we assume that exists a namespace in K8S cluster called **crownlabs-ticketing**
+
+### Install Procedure
+Now we can proceed by installing Faveo helpdesk by applying the following manifests:
+* [faveo-mysql-cluster-manifest.yaml](manifests/faveo-mysql-cluster-manifest.yaml), to expose a mysql instance for the database, it will create the `faveo-db-auth` secret with encrypted db username and db password;
+* [faveo-ingress.yaml](manifests/faveo-ingress.yaml), to expose faveo on Internet, it will be available [here](https://ticketing.crownlabs.polito.it);
+* [faveo-php-configmap.yaml](manifests/faveo-php-configmap.yaml), which contains environment variables for faveo, the following parameters have to be configured
+    * `DB_USERNAME` insert here the database name, it can be retrieved from the `faveo-db-auth` secret
+    * `DB_PASSWORD` insert here the database password, it can be retrieved from the `faveo-db-auth` secret
+    * `ADMIN_USERNAME` insert here username for the first admin user created
+    * `ADMIN_PASSWORD` insert here password for the first admin user created
+    * `JWT_SECRET` generate a 32-character string, or launch the `php artisan jwt:secret` command
+* [faveo-service.yaml](manifests/faveo-service.yaml), with clusterIP service for the deployment;
+* [faveo-deployment.yaml](manifests/faveo-deployment.yaml), for create and start a container with faveo.
+
+```bash
+kubectl apply -f faveo-mysql-cluster-manifest.yaml
+kubectl apply -f faveo-ingress.yaml
+kubectl apply -f faveo-php-configmap.yaml
+kubectl apply -f faveo-service.yaml
+kubectl apply -f faveo-deployment.yaml
+```
+### OIDC Login
+In this version of Faveo helpdesk we offer authentication through Keycloak. To configure it, or another openid-connect provider insert `base URL`, `Client ID` and `Client secret` in the Social setting section of Admin panel like for the other socialite providers

--- a/infrastructure/ticketing/manifests/faveo-deployment.yaml
+++ b/infrastructure/ticketing/manifests/faveo-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: faveo
+    app.kubernetes.io/part-of: faveo
+  name: faveo
+  namespace: crownlabs-ticketing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: faveo
+      app.kubernetes.io/part-of: faveo
+  template:
+    metadata:
+      name: faveo
+      labels:
+        app.kubernetes.io/name: faveo
+        app.kubernetes.io/part-of: faveo
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - faveo
+              - key: app.kubernetes.io/part-of
+                operator: In
+                values:
+                - faveo
+      volumes:
+      - name: php-configmap-volume
+        configMap:
+          name: faveo-php-configmap
+          items:
+          - key: .env
+            path: .env
+      initContainers:
+      - name: init-faveo
+        image: crownlabs/faveo:v1.11.1-crown
+        command: ["/bin/sh","-c"]
+        args: ["php artisan migrate --force && php artisan db:seed --force || true"]
+        volumeMounts:
+        - name: php-configmap-volume
+          mountPath: /usr/share/nginx/.env
+          subPath: .env
+      containers:
+      - image: crownlabs/faveo:v1.11.1-crown
+        name: faveo
+        ports:
+        - containerPort: 80
+          name: http
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "500m"
+          limits:
+            memory: "512Mi"
+            cpu: "1"
+        volumeMounts:
+        - name: php-configmap-volume
+          mountPath: /usr/share/nginx/.env
+          subPath: .env
+

--- a/infrastructure/ticketing/manifests/faveo-ingress.yaml
+++ b/infrastructure/ticketing/manifests/faveo-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+  name: faveo-ingress
+  namespace: crownlabs-ticketing
+spec:
+  ingressClassName: nginx-external
+  rules:
+  - host: ticketing.crownlabs.polito.it
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: faveo
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - ticketing.crownlabs.polito.it
+    secretName: crownlabs-ingress-secret

--- a/infrastructure/ticketing/manifests/faveo-mysql-cluster-manifest.yaml
+++ b/infrastructure/ticketing/manifests/faveo-mysql-cluster-manifest.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubedb.com/v1alpha2
+kind: MySQL
+metadata:
+  name: faveo-db
+  namespace: crownlabs-ticketing
+spec:
+  replicas: 3
+  topology:
+    mode: GroupReplication
+    group:
+      name: "c82b2207-b254-43b4-b7a7-215aaf16ade0"
+  version: "8.0.23-v1"
+  storageType: Durable
+  storage:
+    storageClassName: "rook-ceph-block"
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  podTemplate:
+    spec:
+      env:
+      - name: MYSQL_DATABASE
+        value: faveo
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: data

--- a/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
+++ b/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+data:
+  .env: |
+    APP_DEBUG=false
+    APP_BUGSNAG=true
+    APP_URL=https://ticketing.crownlabs.polito.it
+    APP_KEY=base64:edcbeW2vK8rIuavnG7lF4OM1qAUfOoG6vin5ZucJUug=
+    DB_TYPE=mysql
+    DB_HOST="faveo-db"
+    DB_PORT="3306"
+    DB_DATABASE="faveo"
+    DB_USERNAME=<insert db username here>
+    DB_PASSWORD=<insert db password here>
+    ADMIN_USERNAME=<insert admin username here>
+    ADMIN_PASSWORD=<insert admin password here>
+    MAIL_DRIVER=smtp
+    MAIL_HOST=mailtrap.io
+    MAIL_PORT=2525
+    MAIL_USERNAME=null
+    MAIL_PASSWORD=null
+    CACHE_DRIVER=file
+    SESSION_DRIVER=file
+    SESSION_COOKIE_NAME=faveo_4601
+    QUEUE_DRIVER=sync
+    JWT_TTL=4
+    FCM_SERVER_KEY=AIzaSyCyx5OFnsRFUmDLTMbPV50ZMDUGSG-bLw4
+    FCM_SENDER_ID=661051343223
+    REDIS_DATABASE=0
+    JWT_SECRET=<insert jwt secret here>
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: faveo
+    app.kubernetes.io/part-of: faveo
+  name: faveo-php-configmap

--- a/infrastructure/ticketing/manifests/faveo-service.yaml
+++ b/infrastructure/ticketing/manifests/faveo-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: faveo
+    app.kubernetes.io/part-of: faveo
+  name: faveo
+  namespace: crownlabs-ticketing
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app.kubernetes.io/name: faveo
+    app.kubernetes.io/part-of: faveo
+  type: ClusterIP


### PR DESCRIPTION
This PR contains the YAML files to install Faveo helpdesk, which will be used for provide assistance via ticket.
To proceed with the installation apply the following manifests with kubectl command:
- `manifests/faveo-mysql-manifest.yaml` to expose a mysql instance for the database (for now only for testing)
- `manifests/faveo-ingress.yaml` to expose faveo on Internet, it will be available on https://ticketing.crownlabs.polito.it
- `manifests/faveo-php-configmap.yaml` which contains environment variables for faveo
- `manifests/faveo-service.yaml` with clusterIP service for the deployment
- `manifests/faveo-deployment.yaml` for create and start a container with faveo
