### PR TITLE
Instance operator: add initial ready time metric

### DIFF
--- a/operators/api/v1alpha2/instance_types.go
+++ b/operators/api/v1alpha2/instance_types.go
@@ -90,6 +90,10 @@ type InstanceStatus struct {
 	// be used to access it through the SSH protocol (leveraging the SSH bastion
 	// in case it is not contacted from another CrownLabs Instance).
 	IP string `json:"ip,omitempty"`
+
+	// The amount of time the Instance required to become ready for the first time
+	// upon creation.
+	InitialReadyTime string `json:"initialReadyTime,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -99,6 +103,7 @@ type InstanceStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`,priority=10
 // +kubebuilder:printcolumn:name="IP Address",type=string,JSONPath=`.status.ip`,priority=10
+// +kubebuilder:printcolumn:name="Ready In",type=string,JSONPath=`.status.initialReadyTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // Instance describes the instance of a CrownLabs environment Template.

--- a/operators/deploy/bastion-operator/templates/servicemonitor.yaml
+++ b/operators/deploy/bastion-operator/templates/servicemonitor.yaml
@@ -1,13 +1,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "bastion-operator.fullname" . }}-metrics
+  name: {{ include "bastion-operator.fullname" . }}
   labels:
     {{- include "bastion-operator.labels" . | nindent 4 }}
     {{- include "bastion-operator.metricsAdditionalLabels" . | nindent 4 }}
 spec:
   endpoints:
-    - interval: 5s
+    - interval: 15s
       path: /metrics
       port: metrics
   namespaceSelector:

--- a/operators/deploy/crds/crownlabs.polito.it_instances.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_instances.yaml
@@ -33,6 +33,9 @@ spec:
       name: IP Address
       priority: 10
       type: string
+    - jsonPath: .status.initialReadyTime
+      name: Ready In
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -104,6 +107,10 @@ spec:
             description: InstanceStatus reflects the most recently observed status
               of the Instance.
             properties:
+              initialReadyTime:
+                description: The amount of time the Instance required to become ready
+                  for the first time upon creation.
+                type: string
               ip:
                 description: The internal IP address associated with the remote environment,
                   which can be used to access it through the SSH protocol (leveraging

--- a/operators/deploy/instance-operator/templates/servicemonitor.yaml
+++ b/operators/deploy/instance-operator/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "instance-operator.metricsAdditionalLabels" . | nindent 4 }}
 spec:
   endpoints:
-    - interval: 5s
+    - interval: 15s
       path: /metrics
       port: metrics
   namespaceSelector:

--- a/operators/deploy/tenant-operator/templates/servicemonitor.yaml
+++ b/operators/deploy/tenant-operator/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "tenant-operator.metricsAdditionalLabels" . | nindent 4 }}
 spec:
   endpoints:
-    - interval: 5s
+    - interval: 15s
       path: /metrics
       port: metrics
   namespaceSelector:

--- a/operators/pkg/instance-controller/metrics.go
+++ b/operators/pkg/instance-controller/metrics.go
@@ -1,0 +1,50 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instance_controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricInitialReadyTimesLabelWorkspace   = "workspace"
+	metricInitialReadyTimesLabelTemplate    = "template"
+	metricInitialReadyTimesLabelEnvironment = "environment"
+	metricInitialReadyTimesLabelType        = "type"
+	metricInitialReadyTimesLabelPersistent  = "persistent"
+)
+
+var (
+	metricInitialReadyTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "instance_initial_ready_time_second",
+		Help: "The number of seconds required by the Instances to become ready upon creation",
+		// Buckets (upper bound in seconds): 5, 10, 15, .., 50, 55, 60, 90, 120, .. 570, 600
+		Buckets: append(prometheus.LinearBuckets(5, 5, 11), prometheus.LinearBuckets(60, 30, 19)...),
+	},
+		[]string{
+			metricInitialReadyTimesLabelWorkspace,
+			metricInitialReadyTimesLabelTemplate,
+			metricInitialReadyTimesLabelEnvironment,
+			metricInitialReadyTimesLabelType,
+			metricInitialReadyTimesLabelPersistent,
+		},
+	)
+)
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	metrics.Registry.MustRegister(metricInitialReadyTimes)
+}


### PR DESCRIPTION
# Description

This PR introduces a prometheus metric to analyze the time required by the instances to become ready upon creation. The same value is also shown as an additional field of the instance itself.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Staging environment
