### PR TITLE
Delete stale instances: add never policy to prevent unwanted deletions

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -59,12 +59,13 @@ type TemplateSpec struct {
 	// The list of environments (i.e. VMs or containers) that compose the Template.
 	EnvironmentList []Environment `json:"environmentList"`
 
-	// +kubebuilder:validation:Pattern="^[0-9]+[mhd]$"
-	// +kubebuilder:default="7d"
+	// +kubebuilder:validation:Pattern="^(never|[0-9]+[mhd])$"
+	// +kubebuilder:default="never"
 
 	// The maximum lifetime of an Instance referencing the current Template.
 	// Once this period is expired, the Instance may be automatically deleted
-	// or stopped to save resources.
+	// or stopped to save resources. If set to "never", the instance will not be
+	// automatically terminated.
 	DeleteAfter string `json:"deleteAfter,omitempty"`
 }
 

--- a/operators/cmd/delete-stale-instances/README.md
+++ b/operators/cmd/delete-stale-instances/README.md
@@ -1,25 +1,11 @@
 
 # Delete Stale Instances
 
-## ABOUT THE APPLICATION
+## About the application
 
 - The application deletes all active instances that are expired.
-- The expiration threshold is retrieved from corresponding template. This value is set when the template is created in the deleteAfter field or, if not specified, it assumes the default value of 7 days. Therefore who creates the instance is not able to modify ( for now) the expiration time, but it inherits it from the template. 
-- You ca see the expiration threshold in the [template](../../deploy/crds/crownlabs.polito.it_templates.yaml) definition.
-- The expiration time has the following standard format `[0-9]+[mhd]` and
-represents the limit time for which an instance is allowed to run.
-- The expiration time is calculated from the creation timestamp of the instance, indeed the instance is deleted when the difference between the current timestamp and the creation timestamp exceeds the expiration threshold.
-- The application is run through a cronjob, every 15 minutes.
-
-## HOW TO RUN
-
-To create the docker image run:
-- cd inside /operators path
-- docker build -f ./build/delete-stale-instances/Dockerfile -t yourDockerRepo:version
-
-To run the application do the following steps:
-- kubectl create -f k8s-manifest.yaml
-- kubectl create -f k8s-cluster-role.yaml
-
-To see the cronjob running:
-- kubectl get cronjobs --namespace crownlabs-delete-stale-instances
+- The expiration threshold is retrieved from corresponding template (i.e, the `deleteAfter` field). Therefore who creates the instance is not able to modify (for now) the expiration time, since it is inherited from the template.
+- You can see the expiration threshold definition in the [template](../../deploy/crds/crownlabs.polito.it_templates.yaml) specification.
+- The expiration time has the following standard format `[0-9]+[mhd]` and represents the limit time for which an instance is allowed to run. Additionally, it can be set to `never`, to prevent the deletion of the corresponding instances.
+- The expiration time is calculated from the creation timestamp of the instance, and the instance is deleted when the difference between the current timestamp and the creation timestamp exceeds the expiration threshold.
+- The application is run through a cronjob.

--- a/operators/cmd/delete-stale-instances/test_delete_stale_instances.py
+++ b/operators/cmd/delete-stale-instances/test_delete_stale_instances.py
@@ -2,6 +2,7 @@ import unittest
 from delete_stale_instances import InstanceExpiredDeleter
 from datetime import datetime
 from datetime import timedelta
+import math
 
 
 class TestDeleteCron(unittest.TestCase):
@@ -15,7 +16,7 @@ class TestDeleteCron(unittest.TestCase):
         # take now time
         now = datetime.now()
         # define a expiration threshold for testing
-        threshold = 3600*24*2
+        threshold = 3600 * 24 * 2
         # define a delta time to test case expired
         expiration = threshold + 2
         # define expired time to test expired case
@@ -31,29 +32,43 @@ class TestDeleteCron(unittest.TestCase):
         # case not Expired so result should be False
         self.assertEqual(result_notexpired, False)
 
-    def test_convert_to_time(self):
+    def test_instance_is_expired_infinite(self):
         """
-        Test the correct behavior of convert_to_time function.
-        :Five test cases: minutes case, hour case, day case and two wrong format cases.
+        Test that the instance_is_expired function returns false when the lifespan is infinite.
         """
+
+        expired = InstanceExpiredDeleter.instance_is_expired(
+            math.inf, '2001-01-05T15:45:09Z')
+        self.assertEqual(expired, False)
+
+    def test_convert_to_life_span(self):
+        """
+        Test the correct behavior of convert_to_life_span function.
+        :Six test cases: never policy, minutes case, hour case, day case and two wrong format cases.
+        """
+        never_string = "never"
+        expected_never = math.inf
         minutes_string = "9m"
-        expected_minutes = 9*60
+        expected_minutes = 9 * 60
         hours_string = "20h"
-        expected_hours = 20*60*60
+        expected_hours = 20 * 60 * 60
         days_string = "2d"
-        expected_days = 2*24*60*60
+        expected_days = 2 * 24 * 60 * 60
         wrong_format1_string = "m10"
         wrong_format2_string = "25l"
         expected_wrong = None
-        minutes = InstanceExpiredDeleter.convert_to_time(minutes_string)
+
+        never = InstanceExpiredDeleter.convert_to_life_span(never_string)
+        self.assertEqual(never, expected_never)
+        minutes = InstanceExpiredDeleter.convert_to_life_span(minutes_string)
         self.assertEqual(minutes, expected_minutes)
-        hours = InstanceExpiredDeleter.convert_to_time(hours_string)
+        hours = InstanceExpiredDeleter.convert_to_life_span(hours_string)
         self.assertEqual(hours, expected_hours)
-        days = InstanceExpiredDeleter.convert_to_time(days_string)
+        days = InstanceExpiredDeleter.convert_to_life_span(days_string)
         self.assertEqual(days, expected_days)
-        wrong_format1 = InstanceExpiredDeleter.convert_to_time(wrong_format1_string)
+        wrong_format1 = InstanceExpiredDeleter.convert_to_life_span(wrong_format1_string)
         self.assertEqual(wrong_format1, expected_wrong)
-        wrong_format2 = InstanceExpiredDeleter.convert_to_time(wrong_format2_string)
+        wrong_format2 = InstanceExpiredDeleter.convert_to_life_span(wrong_format2_string)
         self.assertEqual(wrong_format2, expected_wrong)
 
 

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -67,11 +67,12 @@ spec:
               the Template.
             properties:
               deleteAfter:
-                default: 7d
+                default: never
                 description: The maximum lifetime of an Instance referencing the current
                   Template. Once this period is expired, the Instance may be automatically
-                  deleted or stopped to save resources.
-                pattern: ^[0-9]+[mhd]$
+                  deleted or stopped to save resources. If set to "never", the instance
+                  will not be automatically terminated.
+                pattern: ^(never|[0-9]+[mhd])$
                 type: string
               description:
                 description: A textual description of the Template.


### PR DESCRIPTION
# Description

This PR enhances the delete stale instances program to add a `never` deletion policy and prevent the removal of unwanted instances, so that it can be enabled in enforcement mode. Additionally, if fixes a couple of linting errors and updates the documentation removing obsolete information.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Unit testing
- [X] Executing the program and checking the result
