### PR TITLE
Updated Logo component: added fixedColor mode

### DIFF
--- a/frontend/src/components/common/Logo/Logo.stories.tsx
+++ b/frontend/src/components/common/Logo/Logo.stories.tsx
@@ -16,8 +16,20 @@ export default {
 const Template: Story<ILogoProps> = args => <Logo {...args} />;
 
 export const Default = Template.bind({});
+Default.argTypes = {
+  color: { table: { disable: true } },
+};
 Default.args = {
   widthPx: 300,
 };
 
 export const NoWidth = Template.bind({});
+NoWidth.argTypes = {
+  color: { table: { disable: true } },
+};
+
+export const FixedColor = Template.bind({});
+FixedColor.args = {
+  widthPx: 300,
+  color: 'rgba(255, 0, 0, 1)',
+};

--- a/frontend/src/components/common/Logo/Logo.tsx
+++ b/frontend/src/components/common/Logo/Logo.tsx
@@ -5,17 +5,17 @@ import { ReactComponent as SvgLogo } from '../../../assets/logo.svg';
 export interface ILogoProps {
   widthPx?: number;
   className?: string;
+  color?: string;
 }
 
 const Logo: FC<ILogoProps> = ({ ...props }) => {
-  const { widthPx, className } = props;
+  const { widthPx, className, color } = props;
   return (
-    <div className={'flex items-center justify-center m-0 p-0 ' + className}>
-      <SvgLogo
-        width={widthPx ? `${widthPx}px` : '100%'}
-        className={'logo-color'}
-      />
-    </div>
+    <SvgLogo
+      width={widthPx ? `${widthPx}px` : '100%'}
+      className={className + (!color ? ' logo-color' : '')}
+      style={{ fill: color }}
+    />
   );
 };
 


### PR DESCRIPTION
Components updated:

- Logo (common)

This PR adds the fixedColor prop, which allows you to set a fixed color for the logo, which will not change according to the selected theme.
This feature can be useful in CornerButton component, where button color don't change according to the  current theme