### PR TITLE
Helm: add permissions to get workspaces information

### DIFF
--- a/deploy/crownlabs/templates/clusterrolebindings.yaml
+++ b/deploy/crownlabs/templates/clusterrolebindings.yaml
@@ -2,6 +2,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: crownlabs-view-workspaces
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crownlabs-view-workspaces
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: crownlabs-view-image-lists
   labels:
     {{- include "crownlabs.labels" . | nindent 4 }}


### PR DESCRIPTION
# Description

This PR adds the ClusterRoleBinding necessary to enable users to access the CrownLabs workspace information. 
