### PR TITLE
Instance operator: fix incorrect side effect

### DIFF
--- a/operators/pkg/forge/labels.go
+++ b/operators/pkg/forge/labels.go
@@ -34,11 +34,8 @@ const (
 // InstanceLabels receives in input a set of labels and returns the updated set depending on the specified template,
 // along with a boolean value indicating whether an update should be performed.
 func InstanceLabels(labels map[string]string, template *clv1alpha2.Template) (map[string]string, bool) {
+	labels = deepCopyLabels(labels)
 	update := false
-	if labels == nil {
-		labels = map[string]string{}
-		update = true
-	}
 
 	update = updateLabel(labels, labelManagedByKey, labelManagedByValue) || update
 	update = updateLabel(labels, labelWorkspaceKey, template.Spec.WorkspaceRef.Name) || update
@@ -50,9 +47,8 @@ func InstanceLabels(labels map[string]string, template *clv1alpha2.Template) (ma
 
 // InstanceObjectLabels receives in input a set of labels and returns the updated set depending on the specified instance.
 func InstanceObjectLabels(labels map[string]string, instance *clv1alpha2.Instance) map[string]string {
-	if labels == nil {
-		labels = map[string]string{}
-	}
+	labels = deepCopyLabels(labels)
+
 	labels[labelManagedByKey] = labelManagedByValue
 	labels[labelInstanceKey] = instance.Name
 	labels[labelTemplateKey] = instance.Spec.Template.Name
@@ -68,6 +64,15 @@ func InstanceSelectorLabels(instance *clv1alpha2.Instance) map[string]string {
 		labelTemplateKey: instance.Spec.Template.Name,
 		labelTenantKey:   instance.Spec.Tenant.Name,
 	}
+}
+
+// deepCopyLabels creates a copy of the labels map.
+func deepCopyLabels(input map[string]string) map[string]string {
+	output := map[string]string{}
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
 }
 
 // updateLabel configures a map entry to a given value, and returns whether a change was performed.

--- a/operators/pkg/forge/labels_test.go
+++ b/operators/pkg/forge/labels_test.go
@@ -136,6 +136,18 @@ var _ = Describe("Labels forging", func() {
 				ExpectedValue:   "true",
 			}),
 		)
+
+		Context("Checking side effects", func() {
+			var input, expectedInput map[string]string
+
+			BeforeEach(func() {
+				input = map[string]string{"crownlabs.polito.it/managed-by": "whatever"}
+				expectedInput = map[string]string{"crownlabs.polito.it/managed-by": "whatever"}
+			})
+
+			JustBeforeEach(func() { forge.InstanceLabels(input, &template) })
+			It("The original labels map is not modified", func() { Expect(input).To(Equal(expectedInput)) })
+		})
 	})
 
 	Describe("The forge.InstanceObjectLabels function", func() {
@@ -200,6 +212,18 @@ var _ = Describe("Labels forging", func() {
 				},
 			}),
 		)
+
+		Context("Checking side effects", func() {
+			var input, expectedInput map[string]string
+
+			BeforeEach(func() {
+				input = map[string]string{"crownlabs.polito.it/managed-by": "whatever"}
+				expectedInput = map[string]string{"crownlabs.polito.it/managed-by": "whatever"}
+			})
+
+			JustBeforeEach(func() { forge.InstanceObjectLabels(input, &instance) })
+			It("The original labels map is not modified", func() { Expect(input).To(Equal(expectedInput)) })
+		})
 	})
 
 	Describe("The forge.InstanceSelectorLabels function", func() {


### PR DESCRIPTION
# Description

This PR fixes a side effect of the `forge.Instance*Labels` functions, causing the modification of the original labels map. This, in turn, caused a nop update of the labels due to the patch construction, hence preventing their update if at least one label was already present.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Existing unit tests
- [X] Ad-hoc additional unit tests
