### PR TITLE
Set kube-score version tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: KubeScore Check
         run: |
-          docker run -v ${{ github.workspace }}:/CrownLabs zegl/kube-score score \
+          docker run -v ${{ github.workspace }}:/CrownLabs zegl/kube-score:v1.11.0 score \
               --ignore-test=pod-networkpolicy,container-security-context,container-image-pull-policy \
             /CrownLabs/deploy/crownlabs/rendered.yaml
 


### PR DESCRIPTION
# Description
This PR sets the kube-score image tag in the GitHub Actions to v1.11.0 to avoid unexpected checks to happen due to major changes to kube-score.
