### PR TITLE
Fix content downloader Dockerfile

### DIFF
--- a/provisioning/containers/content-downloader/Dockerfile
+++ b/provisioning/containers/content-downloader/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*.*
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT /entrypoint.sh
 


### PR DESCRIPTION
# Description

This PR fixes the content-downloader dockerfile (building on Windows seems to implicitly set the execution flag on copied files)
