### PR TITLE
Add label for instance resources replication to tenant namespace

### DIFF
--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -361,6 +361,7 @@ func (r *TenantReconciler) updateTnNamespace(ns *v1.Namespace, tnName string) {
 	ns.Labels = r.updateTnResourceCommonLabels(ns.Labels)
 	ns.Labels["crownlabs.polito.it/type"] = "tenant"
 	ns.Labels["crownlabs.polito.it/name"] = tnName
+	ns.Labels["crownlabs.polito.it/instance-resources-replication"] = "true"
 }
 
 // updateTnResQuota updates the tenant resource quota.

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -281,6 +281,7 @@ func checkTnClusterResourceCreation(ctx context.Context, tnName, nsName string, 
 
 	Expect(createdNs.OwnerReferences).Should(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(tnName)})))
 	Expect(createdNs.Labels).Should(HaveKeyWithValue("crownlabs.polito.it/type", "tenant"))
+	Expect(createdNs.Labels).Should(HaveKeyWithValue("crownlabs.polito.it/instance-resources-replication", "true"))
 
 	By("By checking that the resource quota of the tenant has been created")
 	rqLookupKey := types.NamespacedName{Name: "crownlabs-resource-quota", Namespace: nsName}


### PR DESCRIPTION
# Description

This PR adds an option to set an explicit label for resources replication in the tenant namespace. Before this, resources replication was bound to type=tenant, which is limiting if instances have to be created in a non-tenant namespace.