### PR TITLE
Increase instance operator deployment memory

### DIFF
--- a/operators/deploy/instance-operator/values.yaml
+++ b/operators/deploy/instance-operator/values.yaml
@@ -53,10 +53,10 @@ securityContext:
 
 resources:
   limits:
-    memory: 250Mi
+    memory: 500Mi
     cpu: 1000m
   requests:
-    memory: 100Mi
+    memory: 200Mi
     cpu: 100m
 
 rbacResourcesName: crownlabs-instance-operator


### PR DESCRIPTION
# Description
This PR increases memory deployment resources requests and limit by doubling them since recent updates and usage increased the memory usage.
