### PR TITLE
Enable k8s Instanceset-landing client when not dynamic

### DIFF
--- a/operators/cmd/instanceset-landing/main.go
+++ b/operators/cmd/instanceset-landing/main.go
@@ -31,10 +31,8 @@ func main() {
 		klog.Fatalf("invalid configuration: %w", err)
 	}
 
-	if isetlanding.Options.DynamicStartup {
-		if err := isetlanding.PrepareClient(); err != nil {
-			klog.Fatal(err)
-		}
+	if err := isetlanding.PrepareClient(); err != nil {
+		klog.Fatal(err)
 	}
 
 	http.HandleFunc("/healthz", healthzHandler)


### PR DESCRIPTION
# Description
This PR fixes an issue with the instanceset landing component, which did not set up the Kubernetes client on startup if the dynamic mode was disabled. This initial implementation didn't take into account to always get the instance URL starting from an existing instance. 
