### PR TITLE
Upgrade cert-manager

### DIFF
--- a/infrastructure/certificate-provisioning/configurations/cert-manager-values.yaml
+++ b/infrastructure/certificate-provisioning/configurations/cert-manager-values.yaml
@@ -274,6 +274,9 @@ webhook:
   # Optional additional labels to add to the Webhook Pods
   podLabels: {}
 
+  # Optional additional labels to add to the Webhook Service
+  serviceLabels: {}
+
   image:
     repository: quay.io/jetstack/cert-manager-webhook
     # You can manage a registry with
@@ -403,5 +406,85 @@ cainjector:
     # name: ""
     # Optional additional annotations to add to the controller's ServiceAccount
     # annotations: {}
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true
+
+# This startupapicheck is a Helm post-install hook that waits for the webhook
+# endpoints to become available.
+startupapicheck:
+  enabled: true
+
+  # Pod Security Context to be set on the startupapicheck component Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext:
+    runAsNonRoot: true
+
+  # Timeout for 'kubectl check api' command
+  timeout: 1m
+
+  # Job backoffLimit
+  backoffLimit: 4
+
+  # Optional additional annotations to add to the startupapicheck Job
+  jobAnnotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: hook-succeeded
+
+  # Optional additional annotations to add to the startupapicheck Pods
+  # podAnnotations: {}
+
+  # Optional additional arguments for startupapicheck
+  extraArgs: []
+
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  nodeSelector: {}
+
+  affinity: {}
+
+  tolerations: []
+
+  # Optional additional labels to add to the startupapicheck Pods
+  podLabels: {}
+
+  image:
+    repository: quay.io/jetstack/cert-manager-ctl
+    # You can manage a registry with
+    # registry: quay.io
+    # repository: jetstack/cert-manager-ctl
+
+    # Override the image tag to deploy by setting this variable.
+    # If no value is set, the chart's appVersion will be used.
+    # tag: canary
+
+    # Setting a digest will override any tag
+    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+
+    pullPolicy: IfNotPresent
+
+  rbac:
+    annotations:
+      helm.sh/hook: post-install
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: hook-succeeded
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # name: ""
+
+    # Optional additional annotations to add to the Job's ServiceAccount
+    annotations:
+      helm.sh/hook: post-install
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: hook-succeeded
+
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true

--- a/infrastructure/identity-provider/conf-files/keycloak-configuration.yaml
+++ b/infrastructure/identity-provider/conf-files/keycloak-configuration.yaml
@@ -332,6 +332,7 @@ ingress:
   # Ingress annotations
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/custom-http-errors: "418"
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   # ingress.kubernetes.io/affinity: cookie


### PR DESCRIPTION
# Description

This PR bumps the helm configuration of cert-manager to the latest version, and disables the custom error pages in keycloak, to prevent issues when accessed from API. 
