### PR TITLE
Extend timeout in qlkube ingress

### DIFF
--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -74,6 +74,9 @@ ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+
   hostname: qlkube.crownlabs.example.com
   path: /
   secret: qlkube-certificate


### PR DESCRIPTION
# Description

This PR extends the read and send timeouts in the qlkube ingress configuration to 10 minutes, to reduce issues with websockets. 