### PR TITLE
Updated ApolloClientSetup and BrowserRouter

### DIFF
--- a/frontend/src/components/common/AppLayout/AppLayout.tsx
+++ b/frontend/src/components/common/AppLayout/AppLayout.tsx
@@ -9,6 +9,7 @@ import Logo from '../Logo';
 import './AppLayout.less';
 import { RouteData } from '../Navbar/Navbar';
 import { TooltipButtonData } from '../TooltipButton/TooltipButton';
+import { PUBLIC_URL } from '../../../env';
 
 const { Content } = Layout;
 
@@ -34,7 +35,7 @@ const AppLayout: FC<IAppLayoutProps> = ({ ...props }) => {
   } = props;
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={PUBLIC_URL}>
       <Layout className="h-full">
         <Navbar
           logoutHandler={logout}

--- a/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
+++ b/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
@@ -12,7 +12,7 @@ import { ApolloLink, split } from 'apollo-link';
 import { REACT_APP_CROWNLABS_GRAPHQL_URL } from '../../env';
 
 const httpUri = REACT_APP_CROWNLABS_GRAPHQL_URL;
-const wsUri = httpUri.replace(/^https?/, 'ws') + 'subscription';
+const wsUri = httpUri.replace(/^http?/, 'ws') + '/subscription';
 export interface Definition {
   kind: string;
   operation?: string;


### PR DESCRIPTION
Components updated

- ApolloClientSetup
- AppLayout

This PR change the websocket uri used by apollo client and the basename used by the BrowserRouter.