### PR TITLE
slash-command-dispatch: use workaround version to fix permissions issue

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Dispatch Slash Commands
-        uses: peter-evans/slash-command-dispatch@v2
+        uses: peter-evans/slash-command-dispatch@permissions
         with:
           token: ${{ secrets.CI_TOKEN }}
           reaction-token: ${{ secrets.CI_TOKEN }}


### PR DESCRIPTION
# Description

This PR switches the version of the `peter-evans/slash-command-dispatch` action to the one with the workaround for the permissions issue.
See peter-evans/slash-command-dispatch#126 for more details

