### PR TITLE
Remove coveralls badge from markdown link check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<!-- markdown-link-check-disable -->
+
 [![Coverage Status](https://coveralls.io/repos/github/netgroup-polito/CrownLabs/badge.svg)](https://coveralls.io/github/netgroup-polito/CrownLabs)
+
+<!-- markdown-link-check-enable -->
 
 # CrownLabs
 


### PR DESCRIPTION
# Description

This PR disables the markdown link check for the coveralls badge. If problems will arise, they willstill be visible when looking at the README on the page of the repo