### PR TITLE
Refactor instance controller startup flags

### DIFF
--- a/operators/pkg/instance-controller/cloudinit.go
+++ b/operators/pkg/instance-controller/cloudinit.go
@@ -61,7 +61,7 @@ func (r *InstanceReconciler) EnforceCloudInitSecret(ctx context.Context) error {
 	log.V(utils.LogDebugLevel).Info("public keys correctly retrieved")
 
 	// Create the cloud-init secret
-	secret := instance_creation.CreateCloudInitSecret(namespacedName.Name, namespacedName.Namespace, user, password, r.NextcloudBaseURL, publicKeys)
+	secret := instance_creation.CreateCloudInitSecret(namespacedName.Name, namespacedName.Namespace, user, password, r.ServiceUrls.NextcloudBaseURL, publicKeys)
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &secret, func() error {
 		return ctrl.SetControllerReference(instance, &secret, r.Scheme)
 	})

--- a/operators/pkg/instance-controller/controller.go
+++ b/operators/pkg/instance-controller/controller.go
@@ -51,17 +51,22 @@ type InstanceReconciler struct {
 	Scheme             *runtime.Scheme
 	EventsRecorder     record.EventRecorder
 	NamespaceWhitelist metav1.LabelSelector
-	WebsiteBaseURL     string
-	NextcloudBaseURL   string
 	WebdavSecretName   string
-	InstancesAuthURL   string
 	Concurrency        int
+	ServiceUrls        ServiceUrls
 	ContainerEnvOpts   forge.ContainerEnvOpts
 
 	// This function, if configured, is deferred at the beginning of the Reconcile.
 	// Specifically, it is meant to be set to GinkgoRecover during the tests,
 	// in order to lead to a controlled failure in case the Reconcile panics.
 	ReconcileDeferHook func()
+}
+
+// ServiceUrls holds URL parameters for the instance reconciler.
+type ServiceUrls struct {
+	WebsiteBaseURL   string
+	NextcloudBaseURL string
+	InstancesAuthURL string
 }
 
 // Reconcile reconciles the state of an Instance resource.

--- a/operators/pkg/instance-controller/exposition.go
+++ b/operators/pkg/instance-controller/exposition.go
@@ -75,7 +75,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionPresence(ctx context.Conte
 	}
 
 	// Enforce the ingress to access the environment GUI
-	host := forge.HostName(r.WebsiteBaseURL, environment.Mode)
+	host := forge.HostName(r.ServiceUrls.WebsiteBaseURL, environment.Mode)
 
 	ingressGUI := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(instance, forge.IngressGUINameSuffix)}
 	res, err = ctrl.CreateOrUpdate(ctx, r.Client, &ingressGUI, func() error {
@@ -89,7 +89,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionPresence(ctx context.Conte
 		ingressGUI.SetLabels(forge.InstanceObjectLabels(ingressGUI.GetLabels(), instance))
 		ingressGUI.SetAnnotations(forge.IngressGUIAnnotations(ingressGUI.GetAnnotations()))
 		if environment.Mode == clv1alpha2.ModeStandard {
-			ingressGUI.SetAnnotations(forge.IngressAuthenticationAnnotations(ingressGUI.GetAnnotations(), r.InstancesAuthURL))
+			ingressGUI.SetAnnotations(forge.IngressAuthenticationAnnotations(ingressGUI.GetAnnotations(), r.ServiceUrls.InstancesAuthURL))
 		}
 		return ctrl.SetControllerReference(instance, &ingressGUI, r.Scheme)
 	})
@@ -119,7 +119,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionPresence(ctx context.Conte
 
 		ingressMyDrive.SetLabels(forge.InstanceObjectLabels(ingressMyDrive.GetLabels(), instance))
 		ingressMyDrive.SetAnnotations(forge.IngressMyDriveAnnotations(ingressMyDrive.GetAnnotations()))
-		ingressMyDrive.SetAnnotations(forge.IngressAuthenticationAnnotations(ingressMyDrive.GetAnnotations(), r.InstancesAuthURL))
+		ingressMyDrive.SetAnnotations(forge.IngressAuthenticationAnnotations(ingressMyDrive.GetAnnotations(), r.ServiceUrls.InstancesAuthURL))
 		return ctrl.SetControllerReference(instance, &ingressMyDrive, r.Scheme)
 	})
 

--- a/operators/pkg/instance-controller/exposition_test.go
+++ b/operators/pkg/instance-controller/exposition_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Generation of the exposition environment", func() {
 
 	JustBeforeEach(func() {
 		client := FakeClientWrapped{Client: clientBuilder.Build(), serviceClusterIP: clusterIP}
-		reconciler = instance_controller.InstanceReconciler{Client: client, Scheme: scheme.Scheme, WebsiteBaseURL: host}
+		reconciler = instance_controller.InstanceReconciler{Client: client, Scheme: scheme.Scheme, ServiceUrls: instance_controller.ServiceUrls{WebsiteBaseURL: host}}
 
 		ctx, _ = clctx.InstanceInto(ctx, &instance)
 		ctx, _ = clctx.EnvironmentInto(ctx, &environment)

--- a/operators/pkg/instance-controller/suite_test.go
+++ b/operators/pkg/instance-controller/suite_test.go
@@ -88,10 +88,12 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme:             k8sManager.GetScheme(),
 		EventsRecorder:     k8sManager.GetEventRecorderFor("Instance"),
 		NamespaceWhitelist: metav1.LabelSelector{MatchLabels: whiteListMap, MatchExpressions: []metav1.LabelSelectorRequirement{}},
-		NextcloudBaseURL:   "fake.com",
-		WebsiteBaseURL:     "fakesite.com",
+		ServiceUrls: ServiceUrls{
+			NextcloudBaseURL: "fake.com",
+			WebsiteBaseURL:   "fakesite.com",
+			InstancesAuthURL: "fake.com/auth",
+		},
 		WebdavSecretName:   "webdav-secret",
-		InstancesAuthURL:   "fake.com/auth",
 		ReconcileDeferHook: GinkgoRecover,
 		ContainerEnvOpts: forge.ContainerEnvOpts{
 			ImagesTag:            "v0.1.2",

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
@@ -35,10 +35,12 @@ import (
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
-// ContainersSnapshotOpts contains image names and tags of the containers needed for the VM snapshot.
+// ContainersSnapshotOpts contains image names and tags of the containers needed for the VM snapshot, along with VM registry access data.
 type ContainersSnapshotOpts struct {
 	ContainerKaniko    string
 	ContainerImgExport string
+	VMRegistry         string
+	RegistrySecretName string
 }
 
 // InstanceSnapshotReconciler reconciles a InstanceSnapshot object.
@@ -47,8 +49,6 @@ type InstanceSnapshotReconciler struct {
 	EventsRecorder     record.EventRecorder
 	Scheme             *runtime.Scheme
 	NamespaceWhitelist metav1.LabelSelector
-	VMRegistry         string
-	RegistrySecretName string
 	ContainersSnapshot ContainersSnapshotOpts
 
 	// This function, if configured, is deferred at the beginning of the Reconcile.

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_suite_test.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_suite_test.go
@@ -79,9 +79,9 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme:             k8sManager.GetScheme(),
 		EventsRecorder:     k8sManager.GetEventRecorderFor("instance-snapshot"),
 		NamespaceWhitelist: metav1.LabelSelector{MatchLabels: whiteListMap, MatchExpressions: []metav1.LabelSelectorRequirement{}},
-		VMRegistry:         "my-registry",
-		RegistrySecretName: "kaniko-secret",
 		ContainersSnapshot: instancesnapshot_controller.ContainersSnapshotOpts{
+			VMRegistry:         "my-registry",
+			RegistrySecretName: "kaniko-secret",
 			ContainerKaniko:    "kaniko",
 			ContainerImgExport: "crownlabs/img-export",
 		},

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
@@ -151,7 +151,7 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context
 	// Define secret VolumeSource.
 	secretvol := corev1.VolumeSource{
 		Secret: &corev1.SecretVolumeSource{
-			SecretName: r.RegistrySecretName,
+			SecretName: r.ContainersSnapshot.RegistrySecretName,
 			Items: []corev1.KeyToPath{
 				{
 					Key:  ".dockerconfigjson",
@@ -183,7 +183,7 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context
 		Name:  "docker-pusher",
 		Image: r.ContainersSnapshot.ContainerKaniko,
 		Args: []string{"--dockerfile=/workspace/Dockerfile",
-			fmt.Sprintf("--destination=%s/%s/%s:%s", r.VMRegistry, imagedir, isnap.Spec.ImageName, imagetag)},
+			fmt.Sprintf("--destination=%s/%s/%s:%s", r.ContainersSnapshot.VMRegistry, imagedir, isnap.Spec.ImageName, imagetag)},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "tmp-vol",


### PR DESCRIPTION
# Description

This PR refactors the startup flags for the instance and instancesnapshot controllers, by removing initial variables declarations and wrapping some of them inside nested structs of the reconcilers.

