### PR TITLE
Tenant webhook

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -123,6 +123,10 @@ tenant-operator:
       user: username
       pass: password
     maxConcurrentReconciles: 1
+  webhook:
+    deployment:
+      webhookBypassGroups: system:masters,system:serviceaccounts,kubernetes:admin
+    enableMutating: true
 
 bastion-operator:
   replicaCount: 1

--- a/operators/api/v1alpha1/tenant_types.go
+++ b/operators/api/v1alpha1/tenant_types.go
@@ -34,6 +34,9 @@ const (
 	// User -> a Tenant with User role can only interact with his/her own
 	// environments (e.g. VMs) within that Workspace.
 	User WorkspaceUserRole = "user"
+
+	// SVCTenantName -> name of a system/service tenant to which other resources might belong.
+	SVCTenantName string = "service-tenant"
 )
 
 // TenantWorkspaceEntry contains the information regarding one of the Workspaces

--- a/operators/deploy/tenant-operator/templates/_helpers.tpl
+++ b/operators/deploy/tenant-operator/templates/_helpers.tpl
@@ -66,3 +66,10 @@ Metrics selector additional labels
 {{- define "tenant-operator.metricsAdditionalLabels" -}}
 app.kubernetes.io/component: metrics
 {{- end }}
+
+{{/*
+Create a qualified app name for the webhook components.
+*/}}
+{{- define "tenant-operator.webhookname" -}}
+{{ .Values.rbacResourcesName }}
+{{- end }}

--- a/operators/deploy/tenant-operator/templates/deployment.yaml
+++ b/operators/deploy/tenant-operator/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             - "--nc-url={{ .Values.configurations.nextcloud.url }}"
             - "--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)"
             - "--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)"
+            - "--webhook-bypass-groups={{ .Values.webhook.deployment.webhookBypassGroups }}"
             - "--max-concurrent-reconciles={{ .Values.configurations.maxConcurrentReconciles }}"
           ports:
             - name: metrics
@@ -51,6 +52,9 @@ spec:
               protocol: TCP
             - name: probes
               containerPort: 8081
+              protocol: TCP
+            - name: webhook
+              containerPort: 9443
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -87,6 +91,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "tenant-operator.fullname" . }}
                   key: nextcloud-pass
+          volumeMounts:
+          - mountPath: {{ .Values.webhook.deployment.certsMount | default "/tmp/k8s-webhook-server/serving-certs/" }}
+            name: webhook-certs
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: {{ include "tenant-operator.webhookname" . }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/operators/deploy/tenant-operator/templates/webhook-cert.yaml
+++ b/operators/deploy/tenant-operator/templates/webhook-cert.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "tenant-operator.webhookname" . }}
+spec:
+  secretName: {{ include "tenant-operator.webhookname" . }}
+  dnsNames:
+  - {{ include "tenant-operator.webhookname" . }}.{{ .Release.Namespace }}.svc
+  issuerRef:
+    kind: ClusterIssuer
+    name: {{ .Values.webhook.clusterIssuer | default "self-signed" }}

--- a/operators/deploy/tenant-operator/templates/webhook-config-mutating.yaml
+++ b/operators/deploy/tenant-operator/templates/webhook-config-mutating.yaml
@@ -1,0 +1,26 @@
+{{ if .Values.webhook.enableMutating }}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "tenant-operator.webhookname" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "tenant-operator.webhookname" . }}
+webhooks:
+- name: mutate.tenant.crownlabs.polito.it
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  rules:
+  - apiGroups:   ["crownlabs.polito.it"]
+    apiVersions: ["v1alpha1"]
+    operations:  ["CREATE","UPDATE"]
+    resources:   ["tenants"]
+    scope:       "Cluster"
+  clientConfig:
+    service:
+      name: {{ include "tenant-operator.webhookname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1alpha1-tenant
+      port: 443
+  sideEffects: None
+{{ end }}

--- a/operators/deploy/tenant-operator/templates/webhook-config-validating.yaml
+++ b/operators/deploy/tenant-operator/templates/webhook-config-validating.yaml
@@ -1,0 +1,27 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "tenant-operator.webhookname" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "tenant-operator.webhookname" . }}
+webhooks:
+- name: validate.tenant.crownlabs.polito.it
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - v1
+  objectSelector:
+    matchLabels:
+      {{ (split "=" .Values.configurations.targetLabel)._0 }}: {{ (split "=" .Values.configurations.targetLabel)._1 }}
+  rules:
+  - apiGroups:   ["crownlabs.polito.it"]
+    apiVersions: ["v1alpha1"]
+    operations:  ["CREATE","UPDATE"]
+    resources:   ["tenants"]
+    scope:       "Cluster"
+  clientConfig:
+    service:
+      name: {{ include "tenant-operator.webhookname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-v1alpha1-tenant
+      port: 443
+  sideEffects: None

--- a/operators/deploy/tenant-operator/templates/webhook-service.yaml
+++ b/operators/deploy/tenant-operator/templates/webhook-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tenant-operator.webhookname" . }}
+spec:
+  selector:
+    {{- include "tenant-operator.selectorLabels" . | nindent 6 }}
+  ports:
+  - name: https
+    port: 443
+    targetPort: webhook

--- a/operators/deploy/tenant-operator/values.yaml
+++ b/operators/deploy/tenant-operator/values.yaml
@@ -54,4 +54,11 @@ resources:
     memory: 100Mi
     cpu: 100m
 
+webhook:
+  deployment:
+    certsMount: /tmp/k8s-webhook-server/serving-certs/
+    webhookBypassGroups: system:masters,system:serviceaccounts,kubernetes:admin
+  enableMutating: true
+  clusterIssuer: self-signed
+
 rbacResourcesName: crownlabs-tenant-operator

--- a/operators/go.mod
+++ b/operators/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0 // indirect
-	github.com/go-resty/resty/v2 v2.5.0
+	github.com/go-resty/resty/v2 v2.6.0
 	github.com/golang/mock v1.5.0
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.4 // indirect

--- a/operators/go.sum
+++ b/operators/go.sum
@@ -287,8 +287,8 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
-github.com/go-resty/resty/v2 v2.5.0 h1:WFb5bD49/85PO7WgAjZ+/TJQ+Ty1XOcWEfD1zIFCM1c=
-github.com/go-resty/resty/v2 v2.5.0/go.mod h1:B88+xCTEwvfD94NOuE6GS1wMlnoKNY8eEiNizfNwOwA=
+github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKYS4=
+github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
@@ -902,8 +902,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201224014010-6772e930b67b h1:iFwSg7t5GZmB/Q5TjiEAsdoLDrdJRC1RiF2WhuV29Qw=
-golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -977,8 +977,9 @@ golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/operators/pkg/instanceset-landing/creation.go
+++ b/operators/pkg/instanceset-landing/creation.go
@@ -21,10 +21,9 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
-
-const serviceTenantName = "service-tenant"
 
 func generateInstanceName(userID, courseID string) string {
 	return "ex-" + courseID + "-" + userID + "-crownlabs"
@@ -45,7 +44,7 @@ func enforceOnDemandInstance(ctx context.Context, instanceName string) error {
 				Running:  true,
 				Template: Options.Template,
 				Tenant: clv1alpha2.GenericRef{
-					Name: serviceTenantName,
+					Name: clv1alpha1.SVCTenantName,
 				},
 			}
 		}

--- a/operators/pkg/tenantwh/common.go
+++ b/operators/pkg/tenantwh/common.go
@@ -1,0 +1,59 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantwh
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
+)
+
+// TenantWebhook holds data needed by webhooks.
+type TenantWebhook struct {
+	Client       client.Client
+	decoder      *admission.Decoder
+	BypassGroups []string // current ns SAs group: system:serviceaccounts:NAMESPACE
+}
+
+// CheckWebhookOverride verifies the subject who triggered the request can override the webhooks behavior.
+func (twh *TenantWebhook) CheckWebhookOverride(req *admission.Request) bool {
+	return utils.MatchOneInStringSlices(twh.BypassGroups, req.UserInfo.Groups)
+}
+
+// InjectDecoder injects the decoder - this method is used by controller runtime.
+func (twh *TenantWebhook) InjectDecoder(d *admission.Decoder) error {
+	twh.decoder = d
+	return nil
+}
+
+// DecodeTenant decodes the tenant from the incoming request.
+func (twh *TenantWebhook) DecodeTenant(obj runtime.RawExtension) (tenant *clv1alpha1.Tenant, err error) {
+	tenant = &clv1alpha1.Tenant{}
+	err = twh.decoder.DecodeRaw(obj, tenant)
+	return
+}
+
+// GetClusterTenant retrieves the tenant from the cluster given the name.
+func (twh *TenantWebhook) GetClusterTenant(ctx context.Context, name string) (tenant *clv1alpha1.Tenant, err error) {
+	tenant = &clv1alpha1.Tenant{}
+	err = twh.Client.Get(ctx, types.NamespacedName{Name: name}, tenant)
+	return
+}

--- a/operators/pkg/tenantwh/mutating.go
+++ b/operators/pkg/tenantwh/mutating.go
@@ -1,0 +1,141 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantwh
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
+)
+
+// TenantLabeler labels Tenants.
+type TenantLabeler struct {
+	opSelectorKey, opSelectorValue string
+	TenantWebhook
+}
+
+// MakeTenantLabeler creates a new webhook handler suitable for controller runtime based on TenantLabeler.
+func MakeTenantLabeler(c client.Client, webhookBypassGroups []string, opSelectorKey, opSelectorValue string) *webhook.Admission {
+	return &webhook.Admission{Handler: &TenantLabeler{
+		opSelectorKey, opSelectorValue,
+		TenantWebhook{Client: c, BypassGroups: webhookBypassGroups},
+	}}
+}
+
+// Handle on TenantLabeler adds operator selector labels to new tenants and prevents possible changes - this method is used by controller runtime.
+func (tl *TenantLabeler) Handle(ctx context.Context, req admission.Request) admission.Response { //nolint:gocritic,hugeParam // the signature of this method is imposed by controller runtime.
+	log := ctrl.LoggerFrom(ctx).WithName("labeler").WithValues("username", req.UserInfo.Username, "tenant", req.Name)
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	log.V(utils.LogDebugLevel).Info("processing mutation request", "groups", strings.Join(req.UserInfo.Groups, ","))
+
+	tenant, err := tl.DecodeTenant(req.Object)
+	if err != nil {
+		log.Error(err, "tenant decode from request failed")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	labels, warnings, err := tl.EnforceTenantLabels(ctx, &req, tenant.GetLabels())
+	if err != nil {
+		log.Error(err, "label enforcement failed")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	tenant.SetLabels(labels)
+
+	return tl.CreatePatchResponse(ctx, &req, tenant).WithWarnings(warnings...)
+}
+
+// EnforceTenantLabels sets operator selector labels.
+func (tl *TenantLabeler) EnforceTenantLabels(ctx context.Context, req *admission.Request, oldLabels map[string]string) (labels map[string]string, warnings []string, err error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	labels = oldLabels
+
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	// enforce empty operator on svc tenant
+	if req.Name == clv1alpha1.SVCTenantName {
+		if labels[tl.opSelectorKey] != "" {
+			labels[tl.opSelectorKey] = ""
+			log.Info("attempted adding operator selector labels to svc tenant")
+			return labels, []string{"operator selector label must not be present on service tenant and has been removed"}, nil
+		}
+		log.Info("service tenant processed")
+		return labels, nil, nil
+	}
+
+	// skip enforcement in case of override user and non-empty selector
+	if labels[tl.opSelectorKey] != "" && tl.CheckWebhookOverride(req) {
+		log.Info("webhook override: not changing labels")
+		return labels, nil, nil
+	}
+
+	// enforce labels on create
+	if req.Operation == admissionv1.Create {
+		log.Info("enforcing operator selection labels", "operation", "create")
+		labels[tl.opSelectorKey] = tl.opSelectorValue
+		return labels, nil, nil
+	}
+
+	oldTenant, err := tl.DecodeTenant(req.OldObject)
+	if err != nil {
+		// if we get an error here it's not because we're on create
+		log.Error(err, "previous tenant decode from request failed")
+		return nil, nil, err
+	}
+
+	oldTenantLabels := oldTenant.GetLabels()
+
+	oldLabel, oldLabelExisted := oldTenantLabels[tl.opSelectorKey]
+	newLabel := labels[tl.opSelectorKey]
+
+	if newLabel != oldLabel {
+		if oldLabelExisted {
+			labels[tl.opSelectorKey] = oldLabel
+		} else {
+			delete(labels, tl.opSelectorKey)
+		}
+		warnings = []string{"operator selector label change is prohibited and has been reverted"}
+		log.Info("operator selector label change prevented", "operation", "update", "requested", oldLabel, "applied", newLabel)
+	} else {
+		log.Info("correct operator selector label already present", "operation", "update")
+	}
+
+	return labels, warnings, nil
+}
+
+// CreatePatchResponse creates and admission response with the given tenant.
+func (tl *TenantLabeler) CreatePatchResponse(ctx context.Context, req *admission.Request, tenant *clv1alpha1.Tenant) admission.Response {
+	marshaledTenant, err := json.Marshal(tenant)
+	if err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "patch response creation failed")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledTenant)
+}

--- a/operators/pkg/tenantwh/mutating_test.go
+++ b/operators/pkg/tenantwh/mutating_test.go
@@ -1,0 +1,225 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantwh_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/tenantwh"
+)
+
+var _ = Describe("Mutating webhook", func() {
+	var (
+		mutatingWH *tenantwh.TenantLabeler
+		request    admission.Request
+
+		opSelectorKey   = "crownlabs.polito.it/op-sel"
+		opSelectorValue = "prod"
+	)
+
+	forgeOpSelectorMap := func(opSel string) map[string]string {
+		return map[string]string{opSelectorKey: opSel}
+	}
+
+	forgeTenantWithLabels := func(name string, labels map[string]string) *clv1alpha1.Tenant {
+		return &clv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	}
+
+	BeforeEach(func() {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		mutatingWH = tenantwh.MakeTenantLabeler(fakeClient, bypassGroups, opSelectorKey, opSelectorValue).Handler.(*tenantwh.TenantLabeler)
+		Expect(mutatingWH.InjectDecoder(decoder)).To(Succeed())
+	})
+
+	Describe("The TenantLabeler.Handle method", func() {
+		var response, expectedResponse admission.Response
+
+		JustBeforeEach(func() {
+			response = mutatingWH.Handle(ctx, request)
+		})
+
+		When("the request is invalid", func() {
+			BeforeEach(func() {
+				request = admission.Request{}
+			})
+
+			It("Should return an error response", func() {
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusBadRequest))
+				Expect(response.Result.Message).NotTo(BeEmpty())
+				Expect(response.Allowed).To(BeFalse())
+			})
+		})
+
+		When("the request is valid", func() {
+			BeforeEach(func() {
+				testTenant := clv1alpha1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "test-tenant"}}
+				request = forgeRequest(admissionv1.Create, &testTenant, nil)
+				labels, _, _ := mutatingWH.EnforceTenantLabels(ctx, &request, nil)
+				testTenant.SetLabels(labels)
+				expectedResponse = mutatingWH.CreatePatchResponse(ctx, &request, &testTenant)
+			})
+
+			It("Should return a valid response", func() {
+				Expect(response).To(Equal(expectedResponse))
+			})
+		})
+	})
+
+	Describe("The TenantLabeler.EnforceTenantLabels method", func() {
+		type EnforceLabelsCase struct {
+			newTenant, oldTenant *clv1alpha1.Tenant
+			operation            admissionv1.Operation
+			expectedLabels       map[string]string
+			expectedWarnings     []string
+			expectedError        error
+			beforeEach           func(*EnforceLabelsCase)
+		}
+
+		var (
+			actualLabels   map[string]string
+			actualWarnings []string
+			actualError    error
+		)
+
+		WhenBody := func(elc EnforceLabelsCase) {
+			BeforeEach(func() {
+				request = forgeRequest(elc.operation, elc.newTenant, elc.oldTenant)
+				if elc.beforeEach != nil {
+					elc.beforeEach(&elc)
+				}
+			})
+			JustBeforeEach(func() {
+				actualLabels, actualWarnings, actualError = mutatingWH.EnforceTenantLabels(ctx, &request, elc.newTenant.Labels)
+			})
+			It("Should return the expected resutls", func() {
+				if elc.expectedError != nil {
+					Expect(actualError).To(MatchError(elc.expectedError))
+				} else {
+					Expect(actualError).To(BeNil())
+				}
+				Expect(actualWarnings).To(Equal(elc.expectedWarnings))
+				Expect(actualLabels).To(Equal(elc.expectedLabels))
+			})
+		}
+
+		Context("Operation is create", func() {
+			When("operation is issued against the service tenant", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:        admissionv1.Create,
+					newTenant:        forgeTenantWithLabels(clv1alpha1.SVCTenantName, map[string]string{opSelectorKey: "something-not-nil"}),
+					expectedLabels:   map[string]string{opSelectorKey: ""},
+					expectedWarnings: []string{"operator selector label must not be present on service tenant and has been removed"},
+				})
+			})
+
+			When("operation is issued by an admin/operator", func() {
+				testLabels := map[string]string{"test1": "test", opSelectorKey: opSelectorValue}
+				WhenBody(EnforceLabelsCase{
+					operation:      admissionv1.Create,
+					newTenant:      forgeTenantWithLabels(testTenantName, testLabels),
+					expectedLabels: testLabels,
+					beforeEach:     func(_ *EnforceLabelsCase) { request.UserInfo.Groups = bypassGroups },
+				})
+			})
+
+			When("no operator selector label is set", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:      admissionv1.Create,
+					newTenant:      forgeTenantWithLabels(testTenantName, nil),
+					expectedLabels: forgeOpSelectorMap(opSelectorValue),
+				})
+			})
+
+			When("operator selector label is present and invalid", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:      admissionv1.Create,
+					newTenant:      forgeTenantWithLabels(testTenantName, map[string]string{opSelectorKey: "something-not-nil"}),
+					expectedLabels: forgeOpSelectorMap(opSelectorValue),
+				})
+			})
+
+			When("operator selector label is present and valid", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:      admissionv1.Create,
+					newTenant:      forgeTenantWithLabels(testTenantName, map[string]string{opSelectorKey: opSelectorValue}),
+					expectedLabels: forgeOpSelectorMap(opSelectorValue),
+				})
+			})
+		})
+
+		Context("Operation is update", func() {
+			When("old tenant is invalid", func() {
+				var expectedErr error
+				WhenBody(EnforceLabelsCase{
+					operation:     admissionv1.Update,
+					newTenant:     &clv1alpha1.Tenant{},
+					oldTenant:     nil,
+					expectedError: expectedErr,
+					beforeEach:    func(elc *EnforceLabelsCase) { _, elc.expectedError = mutatingWH.DecodeTenant(runtime.RawExtension{}) },
+				})
+			})
+
+			When("operator selector label change is attempted", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:        admissionv1.Update,
+					newTenant:        forgeTenantWithLabels(testTenantName, forgeOpSelectorMap("invalid")),
+					oldTenant:        forgeTenantWithLabels(testTenantName, forgeOpSelectorMap("some")),
+					expectedLabels:   forgeOpSelectorMap("some"),
+					expectedWarnings: []string{"operator selector label change is prohibited and has been reverted"},
+				})
+			})
+
+			When("operator selector label was not present and is added", func() {
+				WhenBody(EnforceLabelsCase{
+					operation:        admissionv1.Update,
+					newTenant:        forgeTenantWithLabels(testTenantName, forgeOpSelectorMap(opSelectorValue)),
+					oldTenant:        forgeTenantWithLabels(testTenantName, nil),
+					expectedLabels:   map[string]string{},
+					expectedWarnings: []string{"operator selector label change is prohibited and has been reverted"},
+				})
+			})
+
+			When("operator selector label is already present, custom and new val is correct", func() {
+				customVal := "custom" + opSelectorValue
+				WhenBody(EnforceLabelsCase{
+					operation:      admissionv1.Update,
+					newTenant:      forgeTenantWithLabels(testTenantName, forgeOpSelectorMap(customVal)),
+					oldTenant:      forgeTenantWithLabels(testTenantName, forgeOpSelectorMap(customVal)),
+					expectedLabels: forgeOpSelectorMap(customVal),
+				})
+			})
+
+			When("operator selector label is already present, custom and new val differs", func() {
+				customVal := "custom" + opSelectorValue
+				WhenBody(EnforceLabelsCase{
+					operation:        admissionv1.Update,
+					newTenant:        forgeTenantWithLabels(testTenantName, forgeOpSelectorMap(opSelectorValue)),
+					oldTenant:        forgeTenantWithLabels(testTenantName, forgeOpSelectorMap(customVal)),
+					expectedLabels:   forgeOpSelectorMap(customVal),
+					expectedWarnings: []string{"operator selector label change is prohibited and has been reverted"},
+				})
+			})
+		})
+	})
+})

--- a/operators/pkg/tenantwh/tenantwh_suite_test.go
+++ b/operators/pkg/tenantwh/tenantwh_suite_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantwh_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+)
+
+var (
+	scheme  *runtime.Scheme
+	decoder *admission.Decoder
+	ctx     = context.Background()
+
+	bypassGroups   = []string{"admins"}
+	testTenantName = "test-tenant"
+	testWorkspace  = "test-workspace"
+)
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	Expect(clv1alpha1.AddToScheme(scheme)).To(Succeed())
+	var err error
+	decoder, err = admission.NewDecoder(scheme)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+func TestTenantWebHooks(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Forge Suite")
+}
+
+func serializeTenant(t *clv1alpha1.Tenant) runtime.RawExtension {
+	data, err := json.Marshal(t)
+	Expect(err).ToNot(HaveOccurred())
+	return runtime.RawExtension{Raw: data}
+}
+
+func forgeRequest(op admissionv1.Operation, newTenant, oldTenant *clv1alpha1.Tenant) admission.Request {
+	req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: op}}
+	if newTenant != nil {
+		req.Object = serializeTenant(newTenant)
+		req.Name = newTenant.Name
+	}
+	if oldTenant != nil {
+		req.OldObject = serializeTenant(oldTenant)
+	}
+	return req
+}

--- a/operators/pkg/tenantwh/validating.go
+++ b/operators/pkg/tenantwh/validating.go
@@ -1,0 +1,148 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tenantwh groups the functionalities related to the Tenant webhook.
+package tenantwh
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
+)
+
+// TenantValidator validates Tenants.
+type TenantValidator struct{ TenantWebhook }
+
+// MakeTenantValidator creates a new webhook handler suitable for controller runtime based on TenantValidator.
+func MakeTenantValidator(c client.Client, webhookBypassGroups []string) *webhook.Admission {
+	return &webhook.Admission{Handler: &TenantValidator{TenantWebhook{
+		Client:       c,
+		BypassGroups: webhookBypassGroups,
+	}}}
+}
+
+// Handle admits a tenant if user is editing its own tenant or a user is adding/removing workspaces
+// they own to/from another user - this method is used by controller runtime.
+func (tv *TenantValidator) Handle(ctx context.Context, req admission.Request) admission.Response { //nolint:gocritic,hugeParam // the signature of this method is imposed by controller runtime.
+	log := ctrl.LoggerFrom(ctx).WithName("validator").WithValues("username", req.UserInfo.Username, "tenant", req.Name)
+
+	log.V(utils.LogDebugLevel).Info("processing admission request", "groups", strings.Join(req.UserInfo.Groups, ","))
+
+	if tv.CheckWebhookOverride(&req) {
+		log.Info("admitted: successful override")
+		return admission.Allowed("")
+	}
+
+	tenant, err := tv.DecodeTenant(req.Object)
+	if err != nil {
+		log.Error(err, "new tenant decode from request failed")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	oldTenant, err := tv.DecodeTenant(req.OldObject)
+	if err != nil && req.Operation != admissionv1.Create {
+		log.Error(err, "previous tenant decode from request failed")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if req.UserInfo.Username == req.Name {
+		ctx = ctrl.LoggerInto(ctx, log.WithValues("operation", "self-edit"))
+		return tv.HandleSelfEdit(ctx, tenant, oldTenant)
+	}
+
+	manager, err := tv.GetClusterTenant(ctx, req.UserInfo.Username)
+	if err != nil {
+		log.Error(err, "failed fetching a (manager) tenant associated to the current actor")
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("could not fetch a tenant for the current user: %w", err))
+	}
+
+	ctx = ctrl.LoggerInto(ctx, log.WithValues("operation", "workspaces-edit"))
+	return tv.HandleWorkspaceEdit(ctx, tenant, oldTenant, manager)
+}
+
+// HandleSelfEdit checks every field but public keys for changes through DeepEqual.
+func (tv *TenantValidator) HandleSelfEdit(ctx context.Context, newTenant, oldTenant *clv1alpha1.Tenant) admission.Response {
+	log := ctrl.LoggerFrom(ctx)
+	newTenant.Spec.PublicKeys = nil
+	oldTenant.Spec.PublicKeys = nil
+	if !reflect.DeepEqual(newTenant.Spec, oldTenant.Spec) {
+		log.Info("denied: unexpected tenant spec change")
+		return admission.Denied("only changes to public keys are allowed in the owned tenant")
+	}
+
+	log.Info("allowed")
+	return admission.Allowed("")
+}
+
+// HandleWorkspaceEdit checks that changes made to the workspaces have been made by a valid manager, then checks other fields not to have been modified through DeepEqual.
+func (tv *TenantValidator) HandleWorkspaceEdit(ctx context.Context, newTenant, oldTenant, manager *clv1alpha1.Tenant) admission.Response {
+	log := ctrl.LoggerFrom(ctx)
+
+	workspacesDiff := CalculateWorkspacesDiff(newTenant, oldTenant)
+	managerWorkspaces := mapFromWorkspacesList(manager)
+
+	for ws, changed := range workspacesDiff {
+		if changed && managerWorkspaces[ws] != clv1alpha1.Manager {
+			log.Info("denied: unexpected tenant spec change", "not-a-manager-for", ws)
+			return admission.Denied("you are not a manager for workspace <" + ws + ">")
+		}
+	}
+
+	newTenant.Spec.Workspaces = nil
+	oldTenant.Spec.Workspaces = nil
+	if !reflect.DeepEqual(newTenant.Spec, oldTenant.Spec) {
+		log.Info("denied: unexpected tenant spec change")
+		return admission.Denied("only changes to workspaces are allowed to workspace managers")
+	}
+
+	log.Info("allowed")
+	return admission.Allowed("")
+}
+
+func calculateWorkspacesOneWayDiff(a, b *clv1alpha1.Tenant, changes map[string]bool) map[string]bool {
+	aAsMap := mapFromWorkspacesList(a)
+	for _, v := range b.Spec.Workspaces {
+		if aAsMap[v.WorkspaceRef.Name] != v.Role {
+			changes[v.WorkspaceRef.Name] = true
+		}
+	}
+	return changes
+}
+
+// CalculateWorkspacesDiff returns the list of workspaces that are different between two tenants.
+func CalculateWorkspacesDiff(a, b *clv1alpha1.Tenant) map[string]bool {
+	changes := calculateWorkspacesOneWayDiff(a, b, map[string]bool{})
+
+	return calculateWorkspacesOneWayDiff(b, a, changes)
+}
+
+func mapFromWorkspacesList(tenant *clv1alpha1.Tenant) map[string]clv1alpha1.WorkspaceUserRole {
+	wss := make(map[string]clv1alpha1.WorkspaceUserRole, len(tenant.Spec.Workspaces))
+
+	for _, v := range tenant.Spec.Workspaces {
+		wss[v.WorkspaceRef.Name] = v.Role
+	}
+
+	return wss
+}

--- a/operators/pkg/tenantwh/validating_test.go
+++ b/operators/pkg/tenantwh/validating_test.go
@@ -1,0 +1,261 @@
+// Copyright 2020-2021 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantwh_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/tenantwh"
+)
+
+var _ = Describe("Validating webhook", func() {
+	forgeTenantWithWorkspaceUser := func(wsName string) *clv1alpha1.Tenant {
+		return &clv1alpha1.Tenant{
+			Spec: clv1alpha1.TenantSpec{
+				Workspaces: []clv1alpha1.TenantWorkspaceEntry{{
+					WorkspaceRef: clv1alpha1.GenericRef{Name: wsName},
+					Role:         clv1alpha1.User,
+				}},
+			},
+		}
+	}
+
+	var (
+		validatingWH *tenantwh.TenantValidator
+		request      admission.Request
+		response     admission.Response
+		manager      *clv1alpha1.Tenant
+	)
+
+	BeforeEach(func() {
+
+		manager = &clv1alpha1.Tenant{
+			ObjectMeta: metav1.ObjectMeta{Name: "some-manager"},
+			Spec: clv1alpha1.TenantSpec{
+				Workspaces: []clv1alpha1.TenantWorkspaceEntry{{
+					WorkspaceRef: clv1alpha1.GenericRef{Name: testWorkspace},
+					Role:         clv1alpha1.Manager,
+				}},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(manager).Build()
+
+		validatingWH = tenantwh.MakeTenantValidator(fakeClient, bypassGroups).Handler.(*tenantwh.TenantValidator)
+		Expect(validatingWH.InjectDecoder(decoder)).To(Succeed())
+	})
+
+	Describe("The TenantValidator.Handle method", func() {
+		JustBeforeEach(func() {
+			response = validatingWH.Handle(ctx, request)
+		})
+
+		When("the user is an admin/operator", func() {
+			BeforeEach(func() {
+				request = forgeRequest(admissionv1.Create, nil, nil)
+				request.UserInfo.Groups = bypassGroups
+			})
+			It("Should admit the request", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("the new tenant is invalid", func() {
+			BeforeEach(func() {
+				request = forgeRequest(admissionv1.Create, nil, nil)
+			})
+			It("Should return an error response", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusBadRequest))
+				Expect(response.Result.Message).ToNot(BeEmpty())
+			})
+		})
+
+		When("the old tenant is invalid", func() {
+			BeforeEach(func() {
+				request = forgeRequest(admissionv1.Update, &clv1alpha1.Tenant{}, nil)
+			})
+			It("Should return an error response", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusBadRequest))
+				Expect(response.Result.Message).ToNot(BeEmpty())
+			})
+		})
+
+		When("Tenant is being edited by an invalid external user", func() {
+			BeforeEach(func() {
+				request = forgeRequest(admissionv1.Update, &clv1alpha1.Tenant{}, &clv1alpha1.Tenant{})
+				request.UserInfo.Username = "invalid-manager"
+			})
+			It("Should return an error response", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusBadRequest))
+				Expect(response.Result.Message).ToNot(BeEmpty())
+			})
+		})
+	})
+
+	Describe("The TenantValidator.HandleSelfEdit method", func() {
+		var newTenant, oldTenant *clv1alpha1.Tenant
+		JustBeforeEach(func() {
+			response = validatingWH.HandleSelfEdit(ctx, newTenant, oldTenant)
+		})
+
+		When("only public keys are changed", func() {
+			BeforeEach(func() {
+				oldTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{PublicKeys: []string{"some-key"}}}
+				newTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{PublicKeys: []string{"other-key"}}}
+			})
+			It("should allow the change", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("other fields are changed", func() {
+			BeforeEach(func() {
+				oldTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{LastName: "test"}}
+				newTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{Email: "other"}}
+			})
+			It("should deny the change", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusForbidden))
+				Expect(response.Result.Reason).NotTo(BeEmpty())
+			})
+		})
+	})
+
+	Describe("The TenantValidator.HandleWorkspaceEdit", func() {
+		var newTenant, oldTenant *clv1alpha1.Tenant
+		JustBeforeEach(func() {
+			response = validatingWH.HandleWorkspaceEdit(ctx, newTenant, oldTenant, manager)
+		})
+
+		When("manager adds a workspace he manages", func() {
+			BeforeEach(func() {
+				oldTenant = &clv1alpha1.Tenant{}
+				newTenant = forgeTenantWithWorkspaceUser(testWorkspace)
+			})
+			It("Should allow the change", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("manager removes a workspace he manages", func() {
+			BeforeEach(func() {
+				newTenant = &clv1alpha1.Tenant{}
+				oldTenant = forgeTenantWithWorkspaceUser(testWorkspace)
+			})
+			It("Should allow the change", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("manager adds a workspace he doesn't manage", func() {
+			BeforeEach(func() {
+				oldTenant = &clv1alpha1.Tenant{}
+				newTenant = forgeTenantWithWorkspaceUser("invalid-workspace")
+			})
+			It("Should allow the change", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusForbidden))
+				Expect(response.Result.Reason).NotTo(BeEmpty())
+			})
+		})
+
+		When("manager remvoes a workspace he doesn't manage", func() {
+			BeforeEach(func() {
+				newTenant = &clv1alpha1.Tenant{}
+				oldTenant = forgeTenantWithWorkspaceUser("invalid-workspace")
+			})
+			It("Should allow the change", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusForbidden))
+				Expect(response.Result.Reason).NotTo(BeEmpty())
+			})
+		})
+
+		When("other fields are changed", func() {
+			BeforeEach(func() {
+				oldTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{LastName: "test"}}
+				newTenant = &clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{Email: "other"}}
+			})
+			It("should deny the change", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusForbidden))
+				Expect(response.Result.Reason).NotTo(BeEmpty())
+			})
+		})
+	})
+
+	Describe("The CalculateWorkspacesDiff function", func() {
+		type CalcWsDiffCase struct {
+			a, b            []clv1alpha1.TenantWorkspaceEntry
+			expectedChanges []string
+		}
+		WhenBody := func(cwdc CalcWsDiffCase) func() {
+			return func() {
+				var actuals []string
+				result := tenantwh.CalculateWorkspacesDiff(
+					&clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{Workspaces: cwdc.a}},
+					&clv1alpha1.Tenant{Spec: clv1alpha1.TenantSpec{Workspaces: cwdc.b}},
+				)
+				for k, v := range result {
+					if v {
+						actuals = append(actuals, k)
+					}
+				}
+				It("Should calculate the correct diffs", func() {
+					Expect(actuals).To(BeEquivalentTo(cwdc.expectedChanges))
+				})
+			}
+		}
+		makeWs := func(name string, role clv1alpha1.WorkspaceUserRole) clv1alpha1.TenantWorkspaceEntry {
+			return clv1alpha1.TenantWorkspaceEntry{WorkspaceRef: clv1alpha1.GenericRef{Name: name}, Role: role}
+		}
+
+		When("The two tenants have no different workspaces", WhenBody(CalcWsDiffCase{
+			a:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager)},
+			b:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager)},
+			expectedChanges: nil,
+		}))
+
+		When("The first tenant has one more workspace", WhenBody(CalcWsDiffCase{
+			a:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager)},
+			b:               []clv1alpha1.TenantWorkspaceEntry{},
+			expectedChanges: []string{"test-a"},
+		}))
+
+		When("The second tenant has one more workspace", WhenBody(CalcWsDiffCase{
+			a:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager)},
+			b:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager), makeWs("test-b", clv1alpha1.User)},
+			expectedChanges: []string{"test-b"},
+		}))
+
+		When("There is a difference in roles", WhenBody(CalcWsDiffCase{
+			a:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.User)},
+			b:               []clv1alpha1.TenantWorkspaceEntry{makeWs("test-a", clv1alpha1.Manager)},
+			expectedChanges: []string{"test-a"},
+		}))
+
+	})
+})

--- a/operators/pkg/utils/common.go
+++ b/operators/pkg/utils/common.go
@@ -65,3 +65,15 @@ func CheckSelectorLabel(ctx context.Context, k8sClient client.Client, namespaceN
 	ctrl.LoggerFrom(ctx).V(LogDebugLevel).Info("selector labels met")
 	return true, nil
 }
+
+// MatchOneInStringSlices checks if there's at least one common string between two string slices.
+func MatchOneInStringSlices(a, b []string) bool {
+	for _, valA := range a {
+		for _, valB := range b {
+			if valA == valB {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Description

This PR adds two webhooks (one validating and one mutating) inside the tenant controller through controller-runtime apis.
Webhook deployment is acheived thanks to certmanager which handles certificates creation and signing. This enables the webhook to be deployed just through helm.

### Mutating webhook
The mutating webhook is supposed to work in production only, since it has to work on any tenant. It is responsible for: 
- [x] adding the operator selector to every created tenant. 
- [x] rejecting/enforcing any non-valid operator selection label if the tenant has not been created by a cluster admin.

### Validating webhook
The validating webhook can be deployed also in pre-production and staging as it will operate based on the operator selection label. It handles creation, updates and deletion of templates. It is responsible for:
- [x] prohibiting operator selector label 
- [x] enabling tenant update on ssh keys only by the user corresponding to such tenant
- [x] enabing tenant update on workspaces only by workspace managers, who can add/remove only the workspaces they are manager for

# How Has This Been Tested?
- [x] locally
- [x] unit tests
- [x] staging
