### PR TITLE
Bug Fix: Instances notification

### DIFF
--- a/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
@@ -84,16 +84,11 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
                   ?.templateWrapper?.itPolitoCrownlabsV1alpha2Template?.spec
                   ?.templateName,
               description: `Instance started`,
-              btn: (
+              btn: instance.status?.url && (
                 <Button
                   type="success"
                   size="small"
-                  onClick={() =>
-                    window.open(
-                      data?.updateInstance?.instance?.status?.url!,
-                      '_blank'
-                    )
-                  }
+                  onClick={() => window.open(instance.status?.url!, '_blank')}
                 >
                   Connect
                 </Button>


### PR DESCRIPTION
Components updated:

- TemplatesTableLogic

This PR add a control in the Instances notifications, which doesn't render the button "connect" if there is no GUI in the instance.