### PR TITLE
Added Infinite icon file

### DIFF
--- a/frontend/src/assets/infinite.svg
+++ b/frontend/src/assets/infinite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" ><path d="M256 256s-48-96-126-96c-54.12 0-98 43-98 96s43.88 96 98 96c30 0 56.45-13.18 78-32m48-64s48 96 126 96c54.12 0 98-43 98-96s-43.88-96-98-96c-29.37 0-56.66 13.75-78 32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-miterlimit="10" stroke-width="48"/></svg>

--- a/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
@@ -13,6 +13,7 @@ import { CreateInstanceMutation } from '../../../../generated-types';
 import { FetchResult } from 'apollo-link';
 import { ModalAlert } from '../../../common/ModalAlert';
 import { useInstancesLabelSelectorQuery } from '../../../../generated-types';
+import { ReactComponent as SvgInfinite } from '../../../../assets/infinite.svg';
 
 export interface ITemplatesTableRowProps {
   id: string;
@@ -35,19 +36,6 @@ export interface ITemplatesTableRowProps {
   >;
   expandRow: (activeInstances: number, rowId: string, create: boolean) => void;
 }
-
-const infiniteIcon = (
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="20px">
-    <path
-      d="M256 256s-48-96-126-96c-54.12 0-98 43-98 96s43.88 96 98 96c30 0 56.45-13.18 78-32m48-64s48 96 126 96c54.12 0 98-43 98-96s-43.88-96-98-96c-29.37 0-56.66 13.75-78 32"
-      fill="none"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-miterlimit="10"
-      stroke-width="48"
-    />
-  </svg>
-);
 
 const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({ ...props }) => {
   const {
@@ -122,7 +110,7 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({ ...props }) => {
                   }
                 >
                   <div className="text-green-500 ml-3 flex items-center">
-                    {infiniteIcon}
+                    <SvgInfinite width="22px" />
                   </div>
                 </Tooltip>
               )}


### PR DESCRIPTION
Updated components

- TemplatesTabeRow

This PR isolates the svg used in TemplatesTable for the infinite symbol in a separated file, so it can be reused easily.