### PR TITLE
oauth2-proxy: bump version and switch to keycloak-oidc as provider

### DIFF
--- a/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
+++ b/infrastructure/identity-provider/manifests/oauth2-proxy-values.yaml
@@ -1,5 +1,7 @@
 # Oauth client configuration specifics
 config:
+  # Add config annotations
+  annotations: {}
   # OAuth client ID
   clientID: "user-instances"
   # OAuth client secret
@@ -27,7 +29,8 @@ config:
     cookie_refresh = "45m0s"
     email_domains = [ "*" ]
     oidc_issuer_url = "https://auth.crownlabs.polito.it/auth/realms/crownlabs"
-    provider = "oidc"
+    provider = "keycloak-oidc"
+    redirect_url = "https://crownlabs.polito.it"
     proxy_prefix = "/app/instances/oauth2"
     reverse_proxy = true
     skip_provider_button = true
@@ -45,7 +48,7 @@ config:
 
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
-  tag: "v7.1.3"
+  tag: "v7.2.0"
   pullPolicy: "IfNotPresent"
 
 # Optionally specify an array of imagePullSecrets.
@@ -62,6 +65,9 @@ extraEnv:
         name:  crownlabs-instances-auth-redis
         key: redis-password
 
+# -- Custom labels to add into metadata
+customLabels: {}
+
 # To authorize individual email addresses
 # That is part of extraArgs but since this needs special treatment we need to do a separate section
 authenticatedEmailsFile:
@@ -70,8 +76,12 @@ authenticatedEmailsFile:
   persistence: configmap
   # template is the name of the configmap what contains the email user list but has been configured without this chart.
   # It's a simpler way to maintain only one configmap (user list) instead changing it for each oauth2-proxy service.
-  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access".
+  # Be aware the value name in the extern config map in data needs to be named to "restricted_user_access" or to the
+  # provided value in restrictedUserAccessKey field.
   template: ""
+  # The configmap/secret key under which the list of email access is stored
+  # Defaults to "restricted_user_access" if not filled-in, but can be overridden to allow flexibility
+  restrictedUserAccessKey: ""
   # One email per line
   # example:
   # restricted_access: |-
@@ -105,6 +115,7 @@ serviceAccount:
 
 ingress:
   enabled: true
+  className: nginx-external
   path: /app/instances/oauth2/
   # Only used if API capabilities (networking.k8s.io/v1) allow it
   pathType: Prefix
@@ -303,3 +314,22 @@ redis:
 
 # Enables apiVersion deprecation checks
 checkDeprecation: true
+
+metrics:
+  # Enable Prometheus metrics endpoint
+  enabled: true
+  # Serve Prometheus metrics on this port
+  port: 44180
+  servicemonitor:
+    # Enable Prometheus Operator ServiceMonitor
+    enabled: false
+    # Define the namespace where to deploy the ServiceMonitor resource
+    namespace: ""
+    # Prometheus Instance definition
+    prometheusInstance: default
+    # Prometheus scrape interval
+    interval: 60s
+    # Prometheus scrape timeout
+    scrapeTimeout: 30s
+    # Add custom labels to the ServiceMonitor resource
+    labels: {}


### PR DESCRIPTION
# Description

This PR bumps the crownlabs-instances-auth oauth2-proxy version and switches to keycloak-oidc as provider.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Updating the deployed release.
