### PR TITLE
Tenant operator roles and binding for managing other tenants

### DIFF
--- a/deploy/crownlabs/templates/clusterroles.yaml
+++ b/deploy/crownlabs/templates/clusterroles.yaml
@@ -155,8 +155,6 @@ rules:
       - create
       - update
       - patch
-      - delete
-      - deletecollection
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operators/pkg/tenant-controller/tenant_controller_test.go
+++ b/operators/pkg/tenant-controller/tenant_controller_test.go
@@ -332,7 +332,7 @@ func checkTnClusterResourceCreation(ctx context.Context, tnName, nsName string, 
 	Expect(createdCr.Rules[0].APIGroups).Should(ContainElement(Equal("crownlabs.polito.it")))
 	Expect(createdCr.Rules[0].Resources).Should(ContainElement(Equal("tenants")))
 	Expect(createdCr.Rules[0].ResourceNames).Should(ContainElement(Equal(tnName)))
-	Expect(createdCr.Rules[0].Verbs).Should(Equal([]string{"get", "list", "watch"}))
+	Expect(createdCr.Rules[0].Verbs).Should(Equal([]string{"get", "list", "watch", "patch", "update"}))
 
 	By("By checking that the cluster role binding of the tenant has been created")
 	crbName := fmt.Sprintf("crownlabs-manage-%s", nsName)


### PR DESCRIPTION
# Description
This PR adds and fixes roles and rolebinding to achieve the following:
- self tenant edit (behind webhook)
- edit tenants within managed workspaces
- bonus: label for tenants without workspaces

# How Has This Been Tested?
- [x] Integrated tests (insufficient)
- [x] Staging
