### PR TITLE
Dashboard added persistent view

### DIFF
--- a/frontend/src/components/workspaces/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/workspaces/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { Col } from 'antd';
 import { WorkspaceContainer } from '../WorkspaceContainer';
 import { WorkspaceWelcome } from '../WorkspaceWelcome';
@@ -15,8 +15,14 @@ export interface IDashboardProps {
 }
 
 const Dashboard: FC<IDashboardProps> = ({ ...props }) => {
-  const [selectedWsId, setSelectedWs] = useState(-1);
+  const [selectedWsId, setSelectedWs] = useState(
+    parseInt(window.sessionStorage.getItem('prevWs') ?? '-1')
+  );
   const { tenantNamespace, workspaces } = props;
+
+  useEffect(() => {
+    window.sessionStorage.setItem('prevWs', `${selectedWsId}`);
+  }, [selectedWsId]);
 
   return (
     <>

--- a/frontend/src/components/workspaces/Grid/WorkspaceGridItem/WorkspaceGridItem.tsx
+++ b/frontend/src/components/workspaces/Grid/WorkspaceGridItem/WorkspaceGridItem.tsx
@@ -11,6 +11,7 @@ export interface IWorkspaceGridItemProps {
 
 const WorkspaceGridItem: FC<IWorkspaceGridItemProps> = ({ ...props }) => {
   const { id, title, isActive, onClick } = props;
+
   return (
     <Row className="sm:px-0 md:px-4">
       <Col span={24} className="flex justify-center pb-2">

--- a/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { Table } from 'antd';
 import { TemplatesTableRow } from '../TemplatesTableRow';
 import { RightOutlined } from '@ant-design/icons';
@@ -91,7 +91,9 @@ const TemplatesTable: FC<ITemplatesTableProps> = ({ ...props }) => {
           });
     };
    */
-  const [expandedId, setExpandedId] = useState(['']);
+  const [expandedId, setExpandedId] = useState([
+    window.sessionStorage.getItem('prevExpandedIdDashboard') ?? '',
+  ]);
 
   const expandRow = (
     activeInstances: number,
@@ -99,11 +101,19 @@ const TemplatesTable: FC<ITemplatesTableProps> = ({ ...props }) => {
     create: boolean
   ) => {
     if (activeInstances) {
+      let expandedIdTmp: string;
       if (!create)
-        expandedId[0] === rowId ? setExpandedId(['']) : setExpandedId([rowId]);
-      else setExpandedId([rowId]);
+        expandedId[0] === rowId
+          ? (expandedIdTmp = '')
+          : (expandedIdTmp = `${rowId}`);
+      else expandedIdTmp = `${rowId}`;
+      setExpandedId([expandedIdTmp]);
     }
   };
+
+  useEffect(() => {
+    window.sessionStorage.setItem('prevExpandedIdDashboard', `${expandedId}`);
+  }, [expandedId]);
 
   const handleAccordion = (expanded: boolean, record: Template) => {
     expanded ? setExpandedId([record.id]) : setExpandedId(['']);


### PR DESCRIPTION
Components updated:

- Dashboard
- WorkspaceGridItem
- TemplatesTable

This PR initialize and save the status of the shown workspace and template (in the main page) inside the session storage.
So when a user change page and come back to the main page, will be able to see the previous opened workspace and template.