### PR TITLE
SSH keys: re-fetch keys on component re-render

### DIFF
--- a/frontend/src/components/accountPage/UserPanelLogic/UserPanelLogic.tsx
+++ b/frontend/src/components/accountPage/UserPanelLogic/UserPanelLogic.tsx
@@ -34,6 +34,7 @@ function UserPanelLogic() {
   const { data, loading, error } = useSshKeysQuery({
     variables: { tenantId: userId ?? '' },
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
   });
 
   useEffect(() => {

--- a/frontend/src/components/activePage/TableInstance/RowInstanceActions/RowInstanceActions.tsx
+++ b/frontend/src/components/activePage/TableInstance/RowInstanceActions/RowInstanceActions.tsx
@@ -110,6 +110,7 @@ const RowInstanceActions: FC<IRowInstanceActionsProps> = ({ ...props }) => {
       </div>
       <Modal
         title="SSH Connection"
+        bodyStyle={{ padding: '12px' }}
         visible={sshModal}
         onOk={() => setSshModal(false)}
         onCancel={() => setSshModal(false)}

--- a/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
@@ -45,6 +45,7 @@ const TableInstanceLogic: FC<ITableInstanceLogicProps> = ({ ...props }) => {
   const { data: sshKeysResult } = useSshKeysQuery({
     variables: { tenantId: tenantId ?? '' },
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
   });
 
   const hasSSHKeys = !!sshKeysResult?.tenant?.spec?.publicKeys?.length;

--- a/frontend/src/components/activePage/TableTemplate/TableTemplate.tsx
+++ b/frontend/src/components/activePage/TableTemplate/TableTemplate.tsx
@@ -24,6 +24,7 @@ const TableTemplate: FC<ITableTemplateProps> = ({ ...props }) => {
   const { data: sshKeysResult } = useSshKeysQuery({
     variables: { tenantId: tenantId ?? '' },
     notifyOnNetworkStatusChange: true,
+    fetchPolicy: 'network-only',
   });
 
   const hasSSHKeys = !!sshKeysResult?.tenant?.spec?.publicKeys?.length;


### PR DESCRIPTION
# Description

This PR fixes 2 issues:
- SSH keys modifications (add/remove) not detected until page reload 
- Line break in Connect via SSH command

Co-authored by: Alessandro Bacci ale.bacci142@gmail.com 