### PR TITLE
Add externalTrafficPolicy to bastion helm chart

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -135,6 +135,10 @@ bastion-operator:
     repositorySidecar: crownlabs/bastion-operator
   rbacResourcesName: crownlabs-bastion-operator
   serviceAnnotations: {}
+  service:
+    type: LoadBalancer
+    port: 22
+    externalTrafficPolicy: Cluster
 
 image-list:
   replicaCount: 1

--- a/operators/deploy/bastion-operator/templates/service.yaml
+++ b/operators/deploy/bastion-operator/templates/service.yaml
@@ -15,5 +15,6 @@ spec:
       targetPort: ssh-alt
       protocol: TCP
       name: ssh-alt
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   selector:
     {{- include "bastion-operator.selectorLabels" . | nindent 4 }}

--- a/operators/deploy/bastion-operator/values.yaml
+++ b/operators/deploy/bastion-operator/values.yaml
@@ -74,6 +74,7 @@ resources:
 service:
   type: LoadBalancer
   port: 22
+  externalTrafficPolicy: Cluster
 
 
 sshKeysSecret:


### PR DESCRIPTION
# Description

This PR adds `externalTrafficPolicy` field to the bastion controller helm chart. Setting this value to Local enables sources ip to be kept but might reduce traffic balance across nodes. 
