### PR TITLE
Add improvements to the filter of the subscription

### DIFF
--- a/qlkube/src/pubsub.js
+++ b/qlkube/src/pubsub.js
@@ -1,6 +1,8 @@
 const { PubSub } = require('apollo-server');
 
+const maxListeners = parseInt(process.env.MAX_LISTENERS) || 100;
 const pubsub = new PubSub();
+pubsub.ee.setMaxListeners(maxListeners);
 
 function publishEvent(label, value) {
   pubsub.publish(label, value);

--- a/qlkube/src/utils.js
+++ b/qlkube/src/utils.js
@@ -24,9 +24,9 @@ const graphqlQueryRegistry = {
   async requestDidStart(requestContext) {
     if (requestContext.request.operationName !== 'IntrospectionQuery')
       graphqlLogger(
-        `[i]Request started:\n[+] Variables: ${JSON.stringify(
+        `[i] Request started (Variables: ${JSON.stringify(
           requestContext.request.variables
-        )}\n[+] Query: ${requestContext.request.operationName}`
+        )}, Query: ${requestContext.request.operationName})`
       );
   },
 };


### PR DESCRIPTION
# Description

The pr adds improvements to the filter of the subscription and reduces the request at the Kubernetes API server.

- [x] No pubsubAsyncIterator on the sub-labels.
- [x] Check on namespace at the beginning.
- [x] Change resolve from a list type query to a query of a single resource based on the metadata of the payload.
