### PR TITLE
Instance operator: make containers storage class configurable

### DIFF
--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -77,6 +77,7 @@ func main() {
 	flag.StringVar(&containerEnvOpts.WebsockifyImg, "container-env-websockify-img", "crownlabs/websockify", "The image name for the websockify image (sidecar for graphical container environment)")
 	flag.StringVar(&containerEnvOpts.ContentDownloaderImg, "container-env-content-downloader-img", "latest", "The image name for the init-container to download and unarchive initial content to the instance volume.")
 	flag.StringVar(&containerEnvOpts.MyDriveImgAndTag, "container-env-mydrive-img-and-tag", "filebrowser/filebrowser:latest", "The image name and tag for the filebrowser image (sidecar for gui-based file manager)")
+	flag.StringVar(&containerEnvOpts.StorageClassName, "container-storage-class-name", "", "The storage class name for persistent container environments (empty = default)")
 
 	flag.StringVar(&instSnapOpts.VMRegistry, "vm-registry", "", "The registry where VMs should be uploaded")
 	flag.StringVar(&instSnapOpts.RegistrySecretName, "vm-registry-secret", "", "The name of the secret for the VM registry")

--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -58,21 +58,31 @@ type ContainerEnvOpts struct {
 	WebsockifyImg        string
 	MyDriveImgAndTag     string
 	ContentDownloaderImg string
+	StorageClassName     string
 }
 
 // PVCSpec forges a ReadWriteOnce PersistentVolumeClaimSpec
 // with requests set as in environment.Resources.Disk.
-func PVCSpec(environment *clv1alpha2.Environment) corev1.PersistentVolumeClaimSpec {
+func PVCSpec(environment *clv1alpha2.Environment, opts *ContainerEnvOpts) corev1.PersistentVolumeClaimSpec {
 	return corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
 		},
+		StorageClassName: PVCStorageClassName(opts),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: environment.Resources.Disk,
 			},
 		},
 	}
+}
+
+// PVCStorageClassName returns the storage class configured as option, or nil if empty.
+func PVCStorageClassName(opts *ContainerEnvOpts) *string {
+	if opts.StorageClassName != "" {
+		return pointer.String(opts.StorageClassName)
+	}
+	return nil
 }
 
 // PodSecurityContext forges a PodSecurityContext

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -93,10 +93,15 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 	})
 
 	Describe("The forge.PVCSpec function", func() {
-		var spec corev1.PersistentVolumeClaimSpec
+		var (
+			spec         corev1.PersistentVolumeClaimSpec
+			storageClass string
+		)
+
+		BeforeEach(func() { storageClass = "" })
 
 		JustBeforeEach(func() {
-			spec = forge.PVCSpec(&environment)
+			spec = forge.PVCSpec(&environment, &forge.ContainerEnvOpts{StorageClassName: storageClass})
 		})
 
 		It("Should set the correct access mode", func() {
@@ -104,6 +109,16 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 		})
 		It("Should set the correct resources", func() {
 			Expect(spec.Resources.Requests.Storage()).To(PointTo(Equal(environment.Resources.Disk)))
+		})
+		It("Should leave the storage class name unset", func() {
+			Expect(spec.StorageClassName).To(BeNil())
+		})
+
+		When("A custom storage class is specified", func() {
+			BeforeEach(func() { storageClass = "foo" })
+			It("Should set the storage class name", func() {
+				Expect(spec.StorageClassName).To(PointTo(Equal("foo")))
+			})
 		})
 	})
 

--- a/operators/pkg/instctrl/containers.go
+++ b/operators/pkg/instctrl/containers.go
@@ -62,7 +62,7 @@ func (r *InstanceReconciler) enforcePVC(ctx context.Context) error {
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
 		// PVC's spec is immutable, it has to be set at creation
 		if pvc.ObjectMeta.CreationTimestamp.IsZero() {
-			pvc.Spec = forge.PVCSpec(environment)
+			pvc.Spec = forge.PVCSpec(environment, &r.ContainerEnvOpts)
 		}
 		pvc.SetLabels(forge.InstanceObjectLabels(pvc.GetLabels(), instance))
 		return ctrl.SetControllerReference(instance, &pvc, r.Scheme)

--- a/operators/pkg/instctrl/containers_test.go
+++ b/operators/pkg/instctrl/containers_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Generation of the container based instances", func() {
 
 			It("The PVC should be present and have the expected specs", func() {
 				Expect(reconciler.Get(ctx, objectName, &pvc)).To(Succeed())
-				Expect(pvc.Spec).To(Equal(forge.PVCSpec(&environment)))
+				Expect(pvc.Spec).To(Equal(forge.PVCSpec(&environment, &forge.ContainerEnvOpts{})))
 			})
 		})
 


### PR DESCRIPTION
# Description

This PR introduces a flag to configure the storage class name used for the persistent container environments.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Existing
