### PR TITLE
SSH: Timeout on idle connections

### DIFF
--- a/operators/build/ssh-bastion/sshd_config_custom
+++ b/operators/build/ssh-bastion/sshd_config_custom
@@ -4,6 +4,10 @@ port 2222
 PasswordAuthentication no
 PubkeyAuthentication yes
 
+# Close the connection if the client does not respond for 3 minutes (60s*3) 
+ClientAliveCountMax 3
+ClientAliveInterval 60
+
 # We need this otherwise sshd will raise ownership issues about the file updated from the sidecar
 StrictModes no
 


### PR DESCRIPTION
# Description

This PR enables the SSH bastion to close any SSH connection that does not respond after 3 minutes.