### PR TITLE
Ingress controller: increase default backend limits

### DIFF
--- a/infrastructure/ingress-controller/configurations/ingress-nginx-external.yaml
+++ b/infrastructure/ingress-controller/configurations/ingress-nginx-external.yaml
@@ -826,10 +826,10 @@ defaultBackend:
 
   resources: # {}
     limits:
-      cpu: 100m
+      cpu: 500m
       memory: 20Mi
     requests:
-      cpu: 10m
+      cpu: 50m
       memory: 20Mi
 
   extraVolumeMounts: []


### PR DESCRIPTION
# Description

This PR increases the ingress controller default backend limits, to reduce throttling.