### PR TITLE
Popovers replaced by modals

### DIFF
--- a/frontend/src/components/activePage/TableInstance/TableInstance.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstance.tsx
@@ -156,9 +156,9 @@ const TableInstance: FC<ITableInstanceProps> = ({ ...props }) => {
           <ModalAlert
             headTitle="Destroy All"
             show={showAlert}
-            alertMessage="Warning"
-            alertDescription="This operation will delete all your instances and it is not reversible. Do you want to continue?"
-            alertType="warning"
+            message="Warning"
+            description="This operation will delete all your instances and it is not reversible. Do you want to continue?"
+            type="warning"
             buttons={[
               <Button
                 type="danger"

--- a/frontend/src/components/activePage/TableTemplate/TableTemplateRow.tsx
+++ b/frontend/src/components/activePage/TableTemplate/TableTemplateRow.tsx
@@ -128,9 +128,9 @@ const TableTemplateRow: FC<ITableTemplateRowProps> = ({ ...props }) => {
       <ModalAlert
         headTitle="Destroy All"
         show={showAlert}
-        alertMessage="ATTENTION"
-        alertDescription={`Are you sure do you want to destroy all the instances in ${name}. This operation is dangerous and irreversible!`}
-        alertType="error"
+        message="ATTENTION"
+        description={`Are you sure do you want to destroy all the instances in ${name}. This operation is dangerous and irreversible!`}
+        type="error"
         buttons={[
           <Button
             type="danger"

--- a/frontend/src/components/common/ModalAlert/ModalAlert.stories.tsx
+++ b/frontend/src/components/common/ModalAlert/ModalAlert.stories.tsx
@@ -20,9 +20,9 @@ const Template: Story<IModalAlertProps> = args => <ModalAlert {...args} />;
 export const Loading = Template.bind({});
 Loading.args = {
   headTitle: 'Loading modal',
-  alertType: 'warning',
-  alertMessage: 'CrownLabs is creating your vm ...',
-  alertDescription:
+  type: 'warning',
+  message: 'CrownLabs is creating your vm ...',
+  description:
     'Please remember to turn off your VM in the active section when you don’t need it anymore.',
   buttons: [
     <Button key={0} type="primary" shape="round" size={'middle'}>
@@ -41,9 +41,9 @@ Loading.args = {
 export const Ready = Template.bind({});
 Ready.args = {
   headTitle: 'Ready modal',
-  alertType: 'success',
-  alertMessage: 'your VM is ready',
-  alertDescription:
+  type: 'success',
+  message: 'your VM is ready',
+  description:
     'Please remember to turn off your VM in the active section when you don’t need it anymore.',
   buttons: [
     <Button key={0} type="success" shape="round" size={'middle'}>
@@ -55,9 +55,9 @@ Ready.args = {
 export const Exit = Template.bind({});
 Exit.args = {
   headTitle: 'Wait before going out',
-  alertType: 'error',
-  alertMessage: 'You have some VM still running',
-  alertDescription: 'Please turn off your VM if you don’t need it anymore',
+  type: 'error',
+  message: 'You have some VM still running',
+  description: 'Please turn off your VM if you don’t need it anymore',
   buttons: [
     <Button ghost type="primary" shape="round" size={'middle'}>
       Exit

--- a/frontend/src/components/common/ModalAlert/ModalAlert.tsx
+++ b/frontend/src/components/common/ModalAlert/ModalAlert.tsx
@@ -1,26 +1,16 @@
-import React, { FC } from 'react';
-import { Modal, Alert } from 'antd';
+import React, { FC, ReactNode } from 'react';
+import { Modal, Alert, AlertProps } from 'antd';
 
-export interface IModalAlertProps {
-  headTitle: string;
+export interface IModalAlertProps extends AlertProps {
+  headTitle: ReactNode;
   show: boolean;
-  alertMessage: string;
-  alertDescription: string;
-  alertType: 'info' | 'success' | 'error' | 'warning';
   buttons: Array<React.ReactNode>;
   setShow: (status: boolean) => void;
 }
 
 const ModalAlert: FC<IModalAlertProps> = ({ ...props }) => {
-  const {
-    headTitle,
-    show,
-    alertType,
-    alertMessage,
-    alertDescription,
-    buttons,
-    setShow,
-  } = props;
+  const { headTitle, show, type, message, description, buttons, setShow } =
+    props;
 
   return (
     <Modal
@@ -30,12 +20,7 @@ const ModalAlert: FC<IModalAlertProps> = ({ ...props }) => {
       visible={show}
       onCancel={() => setShow(false)}
     >
-      <Alert
-        message={alertMessage}
-        description={alertDescription}
-        type={alertType}
-        showIcon
-      />
+      <Alert message={message} description={description} type={type} showIcon />
 
       <div className="flex justify-center mt-6">{buttons}</div>
     </Modal>

--- a/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
@@ -100,9 +100,9 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({ ...props }) => {
     <>
       <ModalAlert
         headTitle={name}
-        alertMessage="Cannot delete this template"
-        alertDescription="A template with active instances cannot be deleted. Please delete al the instances associated with this template."
-        alertType="warning"
+        message="Cannot delete this template"
+        description="A template with active instances cannot be deleted. Please delete al the instances associated with this template."
+        type="warning"
         buttons={[
           <Button
             key={0}
@@ -119,9 +119,9 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({ ...props }) => {
       />
       <ModalAlert
         headTitle={name}
-        alertMessage="Delete template"
-        alertDescription="Do you really want to delete this template?"
-        alertType="warning"
+        message="Delete template"
+        description="Do you really want to delete this template?"
+        type="warning"
         buttons={[
           <Button
             key={0}


### PR DESCRIPTION
Updated Components:

- RowInstanceActions
- TableInstance
- ModalAlert

This PR removes the remaining popovers replacing them with modals. The modal alert component has been modified to allow ReactNode as props.