### PR TITLE
Active Page [manager]: Templates group fix

### DIFF
--- a/frontend/src/components/activePage/TableInstance/RowInstanceHeader/RowInstanceHeader.tsx
+++ b/frontend/src/components/activePage/TableInstance/RowInstanceHeader/RowInstanceHeader.tsx
@@ -11,8 +11,7 @@ import {
 const { Text } = Typography;
 export interface IRowInstanceHeaderProps {
   viewMode: WorkspaceRole;
-  showGuiIcon?: boolean;
-  templatePrettyName: string;
+  templateKey: string;
   handleSorting: (sortingType: string, sorting: number) => void;
   handleManagerSorting: (
     sortingType: string,
@@ -26,7 +25,7 @@ const RowInstanceHeader: FC<IRowInstanceHeaderProps> = ({ ...props }) => {
     viewMode,
     handleSorting,
     handleManagerSorting,
-    templatePrettyName: tpn,
+    templateKey: tkey,
   } = props;
   const [prettyNameOrder, setPrettyNameOrder] = useState(0);
   const [templatePrettyNameOrder, setTemplatePrettyNameOrder] = useState(0);
@@ -55,7 +54,7 @@ const RowInstanceHeader: FC<IRowInstanceHeaderProps> = ({ ...props }) => {
   const selectOrder = (key: sortKey) => {
     setSort(key);
     viewMode === WorkspaceRole.manager
-      ? handleManagerSorting(key, varByKey[key], tpn)
+      ? handleManagerSorting(key, varByKey[key], tkey)
       : handleSorting(key, varByKey[key]);
   };
 

--- a/frontend/src/components/activePage/TableInstance/TableInstance.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstance.tsx
@@ -58,6 +58,8 @@ const TableInstance: FC<ITableInstanceProps> = ({ ...props }) => {
     });
   };
 
+  const [{ templateId }] = instances;
+
   return (
     <>
       <div
@@ -84,7 +86,7 @@ const TableInstance: FC<ITableInstanceProps> = ({ ...props }) => {
                   viewMode={viewMode}
                   handleSorting={handleSorting!}
                   handleManagerSorting={handleManagerSorting!}
-                  templatePrettyName={instances[0].templatePrettyName!}
+                  templateKey={templateId}
                 />
               )}
             />

--- a/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
@@ -118,7 +118,7 @@ const TableInstanceLogic: FC<ITableInstanceLogicProps> = ({ ...props }) => {
 
   const instances =
     dataInstances?.instanceList?.instances
-      ?.map((i, n) => makeGuiInstance(i ?? {}, tenantId, tenantNamespace))
+      ?.map((i, n) => makeGuiInstance(i, tenantId))
       .sort((a, b) =>
         sorter(
           a,

--- a/frontend/src/components/activePage/TableWorkspaceLogic/TableWorkspaceLogic.tsx
+++ b/frontend/src/components/activePage/TableWorkspaceLogic/TableWorkspaceLogic.tsx
@@ -81,7 +81,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
     setSortingData([...old, { sortingTemplate, sorting, sortingType }]);
   };
 
-  const label = `crownlabs.polito.it/workspace in (${workspaces
+  const labels = `crownlabs.polito.it/workspace in (${workspaces
     .map(({ id }) => id)
     .join(',')})`;
 
@@ -93,7 +93,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
     subscribeToMore: subscribeToMoreInstances,
   } = useInstancesLabelSelectorQuery({
     variables: {
-      labels: label,
+      labels,
     },
     onCompleted: setDataInstances,
     onError: apolloErrorCatcher,
@@ -105,9 +105,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
       const unsubscribe = subscribeToMoreInstances({
         onError: makeErrorCatcher(ErrorTypes.GenericError),
         document: UpdatedInstancesLabelSelectorDocument,
-        variables: {
-          tenantNamespace,
-        },
+        variables: { labels },
         updateQuery: (prev, { subscriptionData }) => {
           const { data } =
             subscriptionData as UpdatedInstancesLabelSelectorSubscriptionResult;

--- a/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
@@ -55,7 +55,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
     onCompleted: data =>
       setDataInstances(
         data.instanceList?.instances
-          ?.map(i => makeGuiInstance(i, userId, tenantNamespace))
+          ?.map(i => makeGuiInstance(i, userId))
           .sort((a, b) =>
             (a.prettyName ?? '').localeCompare(b.prettyName ?? '')
           ) ?? []
@@ -148,15 +148,10 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
         !old.find(x => x.name === i.data?.createdInstance?.metadata?.name)
           ? [
               ...old,
-              makeGuiInstance(
-                i.data?.createdInstance ?? {},
-                userId ?? '',
-                tenantNamespace,
-                {
-                  templateName: templateId,
-                  workspaceName: workspaceName,
-                }
-              ),
+              makeGuiInstance(i.data?.createdInstance, userId, {
+                templateName: templateId,
+                workspaceName: workspaceName,
+              }),
             ]
           : old
       );

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -42,23 +42,23 @@ export type VmStatus =
   | 'CreationLoopBackoff'; //the environment has encountered a temporary error during creation.
 export type Instance = {
   id: number;
-  gui?: boolean;
+  gui: boolean;
   templateId: string;
-  templateName?: string;
-  templatePrettyName?: string;
-  persistent?: boolean;
-  tenantId?: string;
-  tenantDisplayName?: string;
-  tenantNamespace?: string;
-  environmentType?: EnvironmentType;
+  templateName: string;
+  templatePrettyName: string;
+  persistent: boolean;
+  tenantId: string;
+  tenantDisplayName: string;
+  tenantNamespace: string;
+  environmentType: EnvironmentType;
   name: string;
-  prettyName?: string;
+  prettyName: string;
   ip: string;
   status: VmStatus;
   url: string | null;
-  timeStamp?: string;
+  timeStamp: string;
   workspaceId: string;
-  running?: boolean;
+  running: boolean;
 };
 
 export enum LinkPosition {


### PR DESCRIPTION
### HOTFIX

[BUG] Active Page (manager): instances are now grouped by its template prettyName (not unique).

## SOLUTION

Now instances are grouped by a unique KEY generated from Template ID + Workspace ID