### PR TITLE
Implementation of functions for ensuring Sandbox Namespace presence and absence

### DIFF
--- a/deploy/crownlabs/Chart.lock
+++ b/deploy/crownlabs/Chart.lock
@@ -29,5 +29,5 @@ dependencies:
 - name: policies
   repository: file://../../policies/
   version: 0.1.0
-digest: sha256:2e3f930d3126953bb8c7ed7d61270a8850dee55716ffca26defae21600d2bd24
-generated: "2021-07-06T19:01:31.090144215+02:00"
+digest: sha256:86459acf438793fc1f9ec34dfd8d32263c6996f02e8b7712eee73c12be6f4d4b
+generated: "2022-03-23T10:17:15.785619631+01:00"

--- a/deploy/crownlabs/templates/clusterroles.yaml
+++ b/deploy/crownlabs/templates/clusterroles.yaml
@@ -38,7 +38,7 @@ rules:
       - patch
       - delete
       - deletecollection
-      
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -233,4 +233,173 @@ rules:
     - patch
     - delete
     - deletecollection
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-sandbox
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - pods/log
+  - pods/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  - replicasets/status
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs/status
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}

--- a/operators/cmd/tenant-operator/main.go
+++ b/operators/cmd/tenant-operator/main.go
@@ -89,6 +89,7 @@ func main() {
 	flag.StringVar(&ncTnOpPsw, "nc-tenant-operator-psw", "", "The password of the acting account for nextcloud.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "The maximum number of concurrent Reconciles which can be run")
 	flag.StringVar(&webhookBypassGroups, "webhook-bypass-groups", "system:masters", "The list of groups which can skip webhooks checks, comma separated values")
+	sandboxClusterRole := flag.String("sandbox-cluster-role", "crownlabs-sandbox", "The cluster role defining the permissions for the sandbox namespace.")
 	enableWH := flag.Bool("enable-webhooks", true, "Enable webhooks server")
 
 	klog.InitFlags(nil)
@@ -168,13 +169,14 @@ func main() {
 		NcA = &controllers.NcActor{TnOpUser: ncTnOpUser, TnOpPsw: ncTnOpPsw, Client: httpClient, BaseURL: ncURL}
 	}
 	if err = (&controllers.TenantReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		KcA:              kcA,
-		NcA:              NcA,
-		TargetLabelKey:   targetLabelKey,
-		TargetLabelValue: targetLabelValue,
-		Concurrency:      maxConcurrentReconciles,
+		Client:             mgr.GetClient(),
+		Scheme:             mgr.GetScheme(),
+		KcA:                kcA,
+		NcA:                NcA,
+		TargetLabelKey:     targetLabelKey,
+		TargetLabelValue:   targetLabelValue,
+		SandboxClusterRole: *sandboxClusterRole,
+		Concurrency:        maxConcurrentReconciles,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "Unable to create controller", "controller", "tenant")
 		os.Exit(1)

--- a/operators/deploy/tenant-operator/templates/clusterrolebinding.yaml
+++ b/operators/deploy/tenant-operator/templates/clusterrolebinding.yaml
@@ -12,3 +12,22 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "tenant-operator.fullname" . }}
     namespace: {{ .Release.Namespace }}
+
+---
+
+# The tenant operator needs to be granted the CrownLabs sandbox permissions,
+# in order to be able of creating the corresponding rolebindings for the tenants.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.rbacResourcesName }}-sandbox
+  labels:
+    {{- include "tenant-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.configurations.sandboxClusterRole }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tenant-operator.fullname" . }}
+    namespace: {{ .Release.Namespace }}

--- a/operators/deploy/tenant-operator/templates/deployment.yaml
+++ b/operators/deploy/tenant-operator/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
             - "--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)"
             - "--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)"
             - "--webhook-bypass-groups={{ .Values.webhook.deployment.webhookBypassGroups }}"
+            - "--sandbox-cluster-role={{ .Values.configurations.sandboxClusterRole }}"
             - "--max-concurrent-reconciles={{ .Values.configurations.maxConcurrentReconciles }}"
           ports:
             - name: metrics

--- a/operators/deploy/tenant-operator/values.yaml
+++ b/operators/deploy/tenant-operator/values.yaml
@@ -18,6 +18,7 @@ configurations:
     user: username
     pass: password
   maxConcurrentReconciles: 1
+  sandboxClusterRole: crownlabs-sandbox
 
 image:
   repository: crownlabs/tenant-operator

--- a/operators/pkg/forge/labels.go
+++ b/operators/pkg/forge/labels.go
@@ -29,6 +29,7 @@ const (
 	labelPersistentKey  = "crownlabs.polito.it/persistent"
 	labelComponentKey   = "crownlabs.polito.it/component"
 	labelMetricsEnabled = "crownlabs.polito.it/metrics-enabled"
+	labelTypeKey        = "crownlabs.polito.it/type"
 
 	// InstanceTerminationSelectorLabel -> label for Instances which have to be be checked for termination.
 	InstanceTerminationSelectorLabel = "crownlabs.polito.it/watch-for-instance-termination"
@@ -37,7 +38,9 @@ const (
 	// InstanceSubmissionCompletedLabel -> label for Instances that have been submitted.
 	InstanceSubmissionCompletedLabel = "crownlabs.polito.it/instance-submission-completed"
 
-	labelManagedByValue = "instance"
+	labelManagedByInstanceValue = "instance"
+	labelManagedByTenantValue   = "tenant"
+	labelTypeSandboxValue       = "sandbox"
 )
 
 // InstanceLabels receives in input a set of labels and returns the updated set depending on the specified template,
@@ -46,7 +49,7 @@ func InstanceLabels(labels map[string]string, template *clv1alpha2.Template, ins
 	labels = deepCopyLabels(labels)
 	update := false
 
-	update = updateLabel(labels, labelManagedByKey, labelManagedByValue) || update
+	update = updateLabel(labels, labelManagedByKey, labelManagedByInstanceValue) || update
 	update = updateLabel(labels, labelWorkspaceKey, template.Spec.WorkspaceRef.Name) || update
 	update = updateLabel(labels, labelTemplateKey, template.Name) || update
 	update = updateLabel(labels, labelPersistentKey, persistentLabelValue(template.Spec.EnvironmentList)) || update
@@ -62,10 +65,21 @@ func InstanceLabels(labels map[string]string, template *clv1alpha2.Template, ins
 func InstanceObjectLabels(labels map[string]string, instance *clv1alpha2.Instance) map[string]string {
 	labels = deepCopyLabels(labels)
 
-	labels[labelManagedByKey] = labelManagedByValue
+	labels[labelManagedByKey] = labelManagedByInstanceValue
 	labels[labelInstanceKey] = instance.Name
 	labels[labelTemplateKey] = instance.Spec.Template.Name
 	labels[labelTenantKey] = instance.Spec.Tenant.Name
+
+	return labels
+}
+
+// SandboxObjectLabels receives in input a set of labels and the tenant name, returns the updated set.
+func SandboxObjectLabels(labels map[string]string, name string) map[string]string {
+	labels = deepCopyLabels(labels)
+
+	labels[labelManagedByKey] = labelManagedByTenantValue
+	labels[labelTypeKey] = labelTypeSandboxValue
+	labels[labelTenantKey] = name
 
 	return labels
 }

--- a/operators/pkg/forge/resourcequota.go
+++ b/operators/pkg/forge/resourcequota.go
@@ -36,6 +36,15 @@ var (
 
 	// CapMemory -> The cap amount of RAM memory that can be requested by a Tenant.
 	CapMemory = *resource.NewScaledQuantity(50, resource.Giga)
+
+	// SandboxCPUQuota -> The maximum amount of CPU cores that can be used by a sandbox namespace.
+	SandboxCPUQuota = *resource.NewQuantity(4, resource.DecimalSI)
+
+	// SandboxRequestCPUQuota -> The maximum amount of CPU cores that can be requested by a sandbox namespace.
+	SandboxRequestCPUQuota = *resource.NewQuantity(2, resource.DecimalSI)
+
+	// SandboxMemoryQuota -> The maximum amount of RAM memory that can be used by a sandbox namespace.
+	SandboxMemoryQuota = *resource.NewScaledQuantity(8, resource.Giga)
 )
 
 // TenantResourceList forges the Tenant Resource Quota as the value defined in TenantSpec, if any, otherwise it keeps the sum of all quota for each workspace.
@@ -68,5 +77,15 @@ func TenantResourceQuotaSpec(quota *clv1alpha2.TenantResourceQuota) corev1.Resou
 		corev1.ResourceRequestsCPU:    quota.CPU,
 		corev1.ResourceRequestsMemory: quota.Memory,
 		InstancesCountKey:             *resource.NewQuantity(int64(quota.Instances), resource.DecimalSI),
+	}
+}
+
+// SandboxResourceQuotaSpec forges the Resource Quota spec for sandbox namespaces.
+func SandboxResourceQuotaSpec() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceLimitsCPU:      SandboxCPUQuota,
+		corev1.ResourceLimitsMemory:   SandboxMemoryQuota,
+		corev1.ResourceRequestsCPU:    SandboxRequestCPUQuota,
+		corev1.ResourceRequestsMemory: SandboxMemoryQuota,
 	}
 }

--- a/operators/pkg/forge/resourcequota_test.go
+++ b/operators/pkg/forge/resourcequota_test.go
@@ -139,4 +139,27 @@ var _ = Describe("Resource quota spec forging", func() {
 			})
 		})
 	})
+
+	Describe("The forge.SandboxResourceQuotaSpec function", func() {
+		var (
+			spec corev1.ResourceList
+		)
+
+		JustBeforeEach(func() {
+			spec = forge.SandboxResourceQuotaSpec()
+		})
+
+		When("Forging the resource quota specifications", func() {
+			It("Should configure the correct amount of CPU requests and limits", func() {
+				Expect(spec[corev1.ResourceLimitsCPU]).To(Equal(*resource.NewQuantity(4, resource.DecimalSI)))
+				Expect(spec[corev1.ResourceRequestsCPU]).To(Equal(*resource.NewQuantity(2, resource.DecimalSI)))
+			})
+
+			It("Should configure the correct amount of memory requests and limits", func() {
+				Expect(spec[corev1.ResourceLimitsMemory]).To(Equal(*resource.NewScaledQuantity(8, resource.Giga)))
+				Expect(spec[corev1.ResourceRequestsMemory]).To(Equal(*resource.NewScaledQuantity(8, resource.Giga)))
+			})
+
+		})
+	})
 })

--- a/operators/pkg/forge/utils.go
+++ b/operators/pkg/forge/utils.go
@@ -15,6 +15,7 @@
 package forge
 
 import (
+	"fmt"
 	"strings"
 
 	petname "github.com/dustinkirkland/golang-petname"
@@ -78,6 +79,11 @@ func NamespacedNameToObjectMeta(namespacedName types.NamespacedName) metav1.Obje
 // prevent issues with DNS style requirements.
 func canonicalName(name string) string {
 	return strings.ReplaceAll(name, ".", StringSeparator)
+}
+
+// CanonicalSandboxName returns a name given a tenant name.
+func CanonicalSandboxName(name string) string {
+	return fmt.Sprintf("sandbox-%s", canonicalName(name))
 }
 
 // RandomInstancePrettyName generates a random name of 2 capitalized words.

--- a/operators/pkg/tenant-controller/sandbox.go
+++ b/operators/pkg/tenant-controller/sandbox.go
@@ -1,0 +1,106 @@
+// Copyright 2020-2022 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tenant_controller groups the functionalities related to the Tenant controller.
+package tenant_controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
+)
+
+// EnforceSandboxResources ensures the presence/absence of a sandbox.
+func (r *TenantReconciler) EnforceSandboxResources(ctx context.Context, tenant *clv1alpha2.Tenant) error {
+	if tenant.Spec.CreateSandbox {
+		return r.enforceSandboxResourcesPresence(ctx, tenant)
+	}
+	return r.enforceSandboxResourcesAbsence(ctx, tenant)
+}
+
+// enforceSandboxResourcesPresence ensures the presence of a sandbox.
+func (r *TenantReconciler) enforceSandboxResourcesPresence(ctx context.Context, tenant *clv1alpha2.Tenant) error {
+	sandboxnsName := forge.CanonicalSandboxName(tenant.Name)
+	log := ctrl.LoggerFrom(ctx, "environment", "sandbox")
+
+	// Enforce the namespace presence
+	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: sandboxnsName}}
+	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &namespace, func() error {
+		namespace.SetLabels(forge.SandboxObjectLabels(namespace.GetLabels(), tenant.Name))
+		return ctrl.SetControllerReference(tenant, &namespace, r.Scheme)
+	})
+
+	if err != nil {
+		log.Error(err, "failed to enforce resource", "namespace", klog.KObj(&namespace))
+		return err
+	}
+	log.V(utils.FromResult(res)).Info("sandbox namespace correctly enforced", "sandbox namespace", klog.KObj(&namespace), "result", res)
+	tenant.Status.SandboxNamespace.Name = sandboxnsName
+
+	// Enforce role binding precence
+	roleBind := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "sandbox-editor", Namespace: sandboxnsName}}
+	res, err = ctrl.CreateOrUpdate(ctx, r.Client, &roleBind, func() error {
+		roleBind.SetLabels(forge.SandboxObjectLabels(roleBind.GetLabels(), tenant.Name))
+		roleBind.RoleRef = rbacv1.RoleRef{Kind: "ClusterRole", Name: r.SandboxClusterRole, APIGroup: rbacv1.GroupName}
+		roleBind.Subjects = []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: tenant.Name, APIGroup: rbacv1.GroupName}}
+		return ctrl.SetControllerReference(tenant, &roleBind, r.Scheme)
+	})
+	if err != nil {
+		log.Error(err, "failed to enforce resource", "role binding", klog.KObj(&roleBind))
+		return err
+	}
+	log.V(utils.FromResult(res)).Info("sandbox role binding correctly enforced", "role binding", klog.KObj(&roleBind), "result", res)
+
+	// Enforce resource quota presence
+	resourceQuota := corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: "sandbox-resource-quota", Namespace: sandboxnsName},
+	}
+	res, err = ctrl.CreateOrUpdate(ctx, r.Client, &resourceQuota, func() error {
+		resourceQuota.SetLabels(forge.SandboxObjectLabels(resourceQuota.GetLabels(), tenant.Name))
+		resourceQuota.Spec.Hard = forge.SandboxResourceQuotaSpec()
+		return ctrl.SetControllerReference(tenant, &resourceQuota, r.Scheme)
+	})
+	if err != nil {
+		log.Error(err, "failed to enforce resource", "resource quota", klog.KObj(&resourceQuota))
+		return err
+	}
+	log.V(utils.FromResult(res)).Info("sandbox resource quota correctly enforced", "resource quota", klog.KObj(&resourceQuota), "result", res)
+	tenant.Status.SandboxNamespace.Created = true
+
+	return err
+}
+
+// enforceInstanceExpositionAbsence ensures the sandbox's absence.
+func (r *TenantReconciler) enforceSandboxResourcesAbsence(ctx context.Context, tenant *clv1alpha2.Tenant) error {
+	sandboxnsName := forge.CanonicalSandboxName(tenant.Name)
+
+	// Enforce namespace absence
+	namespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: sandboxnsName}}
+	if err := utils.EnforceObjectAbsence(ctx, r.Client, &namespace, "sandbox namespace"); err != nil {
+		return err
+	}
+
+	tenant.Status.SandboxNamespace.Created = false
+	tenant.Status.SandboxNamespace.Name = ""
+
+	return nil
+}

--- a/operators/pkg/tenant-controller/sandbox_test.go
+++ b/operators/pkg/tenant-controller/sandbox_test.go
@@ -1,0 +1,223 @@
+// Copyright 2020-2022 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tenant_controller_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+	tntctrl "github.com/netgroup-polito/CrownLabs/operators/pkg/tenant-controller"
+	. "github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
+)
+
+var _ = Describe("Sandbox", func() {
+	var (
+		ctx           context.Context
+		clientBuilder fake.ClientBuilder
+		reconciler    tntctrl.TenantReconciler
+		tenant        clv1alpha2.Tenant
+
+		sandboxNSname types.NamespacedName
+		sbNamespace   corev1.Namespace
+
+		roleBindingNSname types.NamespacedName
+		sbRoleBinding     rbacv1.RoleBinding
+
+		resQuotaNSname types.NamespacedName
+		sbResQuota     corev1.ResourceQuota
+
+		ownerRef metav1.OwnerReference
+		err      error
+	)
+
+	const (
+		tenantName = "tester"
+	)
+
+	CreateSandboxObjects := func() {
+		sbNamespace = corev1.Namespace{
+			ObjectMeta: forge.NamespacedNameToObjectMeta(sandboxNSname),
+		}
+		sbRoleBinding = rbacv1.RoleBinding{
+			ObjectMeta: forge.NamespacedNameToObjectMeta(roleBindingNSname),
+		}
+		sbResQuota = corev1.ResourceQuota{
+			ObjectMeta: forge.NamespacedNameToObjectMeta(resQuotaNSname),
+		}
+
+		sbNamespace.SetCreationTimestamp(metav1.NewTime(time.Now()))
+		sbRoleBinding.SetCreationTimestamp(metav1.NewTime(time.Now()))
+		sbResQuota.SetCreationTimestamp(metav1.NewTime(time.Now()))
+		clientBuilder.WithObjects(&sbNamespace, &sbRoleBinding, &sbResQuota)
+	}
+
+	DescribeBodySandboxNamespacePresence := func() {
+		It("Namespace should be present and have the expected labels", func() {
+			Expect(reconciler.Get(ctx, sandboxNSname, &sbNamespace)).To(Succeed())
+			for k, v := range forge.SandboxObjectLabels(nil, tenantName) {
+				Expect(sbNamespace.GetLabels()).To(HaveKeyWithValue(k, v))
+			}
+			Expect(sbNamespace.GetOwnerReferences()).To(ContainElement(ownerRef))
+		})
+
+		It("Should fill the correct sandbox status value", func() {
+			Expect(tenant.Status.SandboxNamespace).To(BeIdenticalTo(clv1alpha2.NameCreated{Name: sandboxNSname.Name, Created: true}))
+		})
+	}
+	DescribeBodySandboxResourceQuotaPresence := func() {
+		It("Resource quota should be present and have the expected labels", func() {
+			Expect(reconciler.Get(ctx, resQuotaNSname, &sbResQuota)).To(Succeed())
+			for k, v := range forge.SandboxObjectLabels(nil, tenantName) {
+				Expect(sbResQuota.GetLabels()).To(HaveKeyWithValue(k, v))
+			}
+			Expect(sbResQuota.GetOwnerReferences()).To(ContainElement(ownerRef))
+		})
+
+		It("Resource quota should be present and have the expected spec", func() {
+			Expect(reconciler.Get(ctx, resQuotaNSname, &sbResQuota)).To(Succeed())
+			for k, v := range forge.SandboxResourceQuotaSpec() {
+				Expect(sbResQuota.Spec.Hard).To(HaveKeyWithValue(k, WithTransform(
+					func(q resource.Quantity) string { return q.String() }, Equal(v.String()))))
+			}
+		})
+	}
+	DescribeBodySandboxRoleBindingPresence := func() {
+		It("Role binding should be present and have the expected labels", func() {
+			Expect(reconciler.Get(ctx, roleBindingNSname, &sbRoleBinding)).To(Succeed())
+			for k, v := range forge.SandboxObjectLabels(nil, tenantName) {
+				Expect(sbRoleBinding.GetLabels()).To(HaveKeyWithValue(k, v))
+			}
+			Expect(sbRoleBinding.GetOwnerReferences()).To(ContainElement(ownerRef))
+		})
+
+		It("Role binding should be present and have the expected roleref", func() {
+			Expect(reconciler.Get(ctx, roleBindingNSname, &sbRoleBinding)).To(Succeed())
+			Expect(sbRoleBinding.RoleRef).To(BeIdenticalTo(rbacv1.RoleRef{Kind: "ClusterRole", Name: "crownlabs-sandbox", APIGroup: rbacv1.GroupName}))
+		})
+
+		It("Role binding should be present and have the expected subjects", func() {
+			Expect(reconciler.Get(ctx, roleBindingNSname, &sbRoleBinding)).To(Succeed())
+			for i, subject := range []rbacv1.Subject{{Kind: rbacv1.UserKind, Name: tenant.Name, APIGroup: rbacv1.GroupName}} {
+				Expect(sbRoleBinding.Subjects[i]).To(BeIdenticalTo(subject))
+			}
+		})
+	}
+	DescribeBodySandboxNamespaceAbsence := func() {
+		It("Should set the sandbox status empty", func() {
+			Expect(tenant.Status.SandboxNamespace).To(BeIdenticalTo(clv1alpha2.NameCreated{Name: "", Created: false}))
+		})
+
+		It("Namespace should not be present", func() {
+			Expect(reconciler.Get(ctx, sandboxNSname, &sbNamespace)).To(FailBecauseNotFound())
+		})
+	}
+
+	BeforeEach(func() {
+		ctx = ctrl.LoggerInto(context.Background(), logr.Discard())
+		clientBuilder = *fake.NewClientBuilder().WithScheme(scheme.Scheme)
+		tenant = clv1alpha2.Tenant{
+			ObjectMeta: metav1.ObjectMeta{Name: tenantName},
+		}
+		ownerRef = metav1.OwnerReference{
+			APIVersion:         clv1alpha2.GroupVersion.String(),
+			Kind:               "Tenant",
+			Name:               tenant.Name,
+			UID:                tenant.GetUID(),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+			Controller:         pointer.BoolPtr(true),
+		}
+		sandboxNSname = types.NamespacedName{
+			Name: forge.CanonicalSandboxName(tenantName),
+		}
+		roleBindingNSname = types.NamespacedName{
+			Name:      "sandbox-editor",
+			Namespace: sandboxNSname.Name,
+		}
+		resQuotaNSname = types.NamespacedName{
+			Name:      "sandbox-resource-quota",
+			Namespace: sandboxNSname.Name,
+		}
+		sbNamespace = corev1.Namespace{}
+		sbRoleBinding = rbacv1.RoleBinding{}
+		sbResQuota = corev1.ResourceQuota{}
+	})
+
+	JustBeforeEach(func() {
+		client := clientBuilder.Build()
+		reconciler = tntctrl.TenantReconciler{Client: client, Scheme: scheme.Scheme, SandboxClusterRole: "crownlabs-sandbox"}
+		err = reconciler.EnforceSandboxResources(ctx, &tenant)
+	})
+
+	Context("CreateSandbox flag is true", func() {
+		BeforeEach(func() {
+			tenant.Spec.CreateSandbox = true
+		})
+
+		When("Sandbox resources are not yet present", func() {
+			It("Should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Describe("Assessing the namespace presence", func() { DescribeBodySandboxNamespacePresence() })
+			Describe("Assessing the resource quota presence", func() { DescribeBodySandboxResourceQuotaPresence() })
+			Describe("Assessing the role binding presence", func() { DescribeBodySandboxRoleBindingPresence() })
+		})
+
+		When("Sandbox resources are already present", func() {
+			BeforeEach(func() { CreateSandboxObjects() })
+
+			It("Should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Describe("Assessing the namespace presence", func() { DescribeBodySandboxNamespacePresence() })
+			Describe("Assessing the resource quota presence", func() { DescribeBodySandboxResourceQuotaPresence() })
+			Describe("Assessing the role binding presence", func() { DescribeBodySandboxRoleBindingPresence() })
+		})
+	})
+
+	Context("CreateSandbox flag is false", func() {
+		BeforeEach(func() {
+			tenant.Spec.CreateSandbox = false
+		})
+		When("Sandbox Resources have not yet been deleted", func() {
+			BeforeEach(func() {
+				CreateSandboxObjects()
+			})
+			It("Should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Describe("Assessing the namespace absence", func() { DescribeBodySandboxNamespaceAbsence() })
+		})
+		When("Sandbox Resources have already been deleted", func() {
+			It("Should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+			Describe("Assessing the namespace absence", func() { DescribeBodySandboxNamespaceAbsence() })
+		})
+	})
+})

--- a/operators/pkg/utils/client.go
+++ b/operators/pkg/utils/client.go
@@ -1,0 +1,39 @@
+// Copyright 2020-2022 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnforceObjectAbsence deletes a Kubernetes object and prints the appropriate log messages, without failing if it does not exist.
+func EnforceObjectAbsence(ctx context.Context, c client.Client, obj client.Object, kind string) error {
+	if err := c.Delete(ctx, obj); err != nil {
+		if !kerrors.IsNotFound(err) {
+			ctrl.LoggerFrom(ctx).Error(err, "failed to delete object", kind, klog.KObj(obj))
+			return err
+		}
+		ctrl.LoggerFrom(ctx).V(LogDebugLevel).Info("the object was already removed", kind, klog.KObj(obj))
+	} else {
+		ctrl.LoggerFrom(ctx).V(LogInfoLevel).Info("object correctly removed", kind, klog.KObj(obj))
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description

This PR aims to implement functions for sandbox namespace. Following the instance model, the following functions have been added:
1)  SandboxObjectLabels  (in pkg/forge/labels.go), retrieves the updated set of labels for a given sandbox namespace of a given tenant
2)  SandboxResourceQuotaSpec  (in pkg/forge/resourcequota.go) forges the resource quota spec for a given sandbox namespace
3)  EnforceSandboxResources  (in pkg/tenant-controller/sandbox.go) enforces the sandbox presence or absence depending on the value of CreateSandbox flag inside TenantStatus, therefore it creates (or deletes) sandbox namespace, resource quota and role binding.
All the previous functions have been tested using Ginkgo framework in pkg/tenant-controller/sandbox_test.go, pkg/forge/resourcequota_test.go and pkg/forge/labels_test.go


