### PR TITLE
Change MySQL operator for faveo

### DIFF
--- a/infrastructure/ticketing/README.md
+++ b/infrastructure/ticketing/README.md
@@ -10,11 +10,13 @@ Here we assume that exists a namespace in K8S cluster called **crownlabs-ticketi
 
 ### Install Procedure
 Now we can proceed by installing Faveo helpdesk by applying the following manifests:
-* [faveo-mysql-cluster-manifest.yaml](manifests/faveo-mysql-cluster-manifest.yaml), to expose a mysql instance for the database, it will create the `faveo-db-auth` secret with encrypted db username and db password;
+* [mysql-secret.yaml](manifests/mysql-secret.yaml), it will create the `faveo-db-auth` secret, which contains custom encoded values for `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD`;
+* [faveo-mysql-cluster-manifest.yaml](manifests/faveo-mysql-cluster-manifest.yaml), to expose a mysql instance for the database, this needs the `faveo-db-auth` secret to be already applied in the namespace;
 * [faveo-ingress.yaml](manifests/faveo-ingress.yaml), to expose faveo on Internet, it will be available [here](https://ticketing.crownlabs.polito.it);
 * [faveo-php-configmap.yaml](manifests/faveo-php-configmap.yaml), which contains environment variables for faveo, the following parameters have to be configured
-    * `DB_USERNAME` insert here the database name, it can be retrieved from the `faveo-db-auth` secret
-    * `DB_PASSWORD` insert here the database password, it can be retrieved from the `faveo-db-auth` secret
+    * `DB_DATABASE` insert here the database name, it can be retrieved from the `faveo-db-auth` secret
+    * `DB_USERNAME` insert here the username of the database owner, it can be retrieved from the `faveo-db-auth` secret
+    * `DB_PASSWORD` insert here the password of the database owner, it can be retrieved from the `faveo-db-auth` secret
     * `ADMIN_USERNAME` insert here username for the first admin user created
     * `ADMIN_PASSWORD` insert here password for the first admin user created
     * `JWT_SECRET` generate a 32-character string, or launch the `php artisan jwt:secret` command
@@ -22,6 +24,7 @@ Now we can proceed by installing Faveo helpdesk by applying the following manife
 * [faveo-deployment.yaml](manifests/faveo-deployment.yaml), for create and start a container with faveo.
 
 ```bash
+kubectl apply -f mysql-secret.yaml
 kubectl apply -f faveo-mysql-cluster-manifest.yaml
 kubectl apply -f faveo-ingress.yaml
 kubectl apply -f faveo-php-configmap.yaml

--- a/infrastructure/ticketing/manifests/faveo-mysql-cluster-manifest.yaml
+++ b/infrastructure/ticketing/manifests/faveo-mysql-cluster-manifest.yaml
@@ -1,28 +1,18 @@
-apiVersion: kubedb.com/v1alpha2
-kind: MySQL
+apiVersion: mysql.presslabs.org/v1alpha1
+kind: MysqlCluster
 metadata:
   name: faveo-db
   namespace: crownlabs-ticketing
 spec:
   replicas: 3
-  topology:
-    mode: GroupReplication
-    group:
-      name: "c82b2207-b254-43b4-b7a7-215aaf16ade0"
-  version: "8.0.23-v1"
-  storageType: Durable
-  storage:
-    storageClassName: "rook-ceph-block"
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 10Gi
-  podTemplate:
-    spec:
-      env:
-      - name: MYSQL_DATABASE
-        value: faveo
-    metadata:
-      annotations:
-        backup.velero.io/backup-volumes: data
+  secretName: faveo-db-auth
+  volumeSpec:
+    persistentVolumeClaim:
+      storageClassName: "rook-ceph-block"
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
+  podSpec:
+    annotations:
+      backup.velero.io/backup-volumes: data

--- a/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
+++ b/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
@@ -6,9 +6,9 @@ data:
     APP_URL=https://ticketing.crownlabs.polito.it
     APP_KEY=base64:edcbeW2vK8rIuavnG7lF4OM1qAUfOoG6vin5ZucJUug=
     DB_TYPE=mysql
-    DB_HOST="faveo-db"
+    DB_HOST="faveo-db-mysql-master"
     DB_PORT="3306"
-    DB_DATABASE="faveo"
+    DB_DATABASE=<insert db name here>
     DB_USERNAME=<insert db username here>
     DB_PASSWORD=<insert db password here>
     ADMIN_USERNAME=<insert admin username here>

--- a/infrastructure/ticketing/manifests/mysql-secret.yaml
+++ b/infrastructure/ticketing/manifests/mysql-secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: faveo-db-auth
+  namespace: crownlabs-ticketing
+type: Opaque
+data:
+  # root password is required to be specified
+  ROOT_PASSWORD: 
+  # a user name to be created, not required
+  USER: 
+  # a name for database that will be created, not required
+  DATABASE: 


### PR DESCRIPTION
This PR updates mysql manifests for Faveo.
They are now adapted to this [operator](https://github.com/bitpoke/mysql-operator) which has already been installed in the cluster.
The goal is to provide a more highly available database, the PR contains also updates for the documentation