### PR TITLE
Change Faveo ingress url

### DIFF
--- a/infrastructure/ticketing/README.md
+++ b/infrastructure/ticketing/README.md
@@ -12,7 +12,7 @@ Here we assume that exists a namespace in K8S cluster called **crownlabs-ticketi
 Now we can proceed by installing Faveo helpdesk by applying the following manifests:
 * [mysql-secret.yaml](manifests/mysql-secret.yaml), it will create the `faveo-db-auth` secret, which contains custom encoded values for `DB_DATABASE`, `DB_USERNAME` and `DB_PASSWORD`;
 * [faveo-mysql-cluster-manifest.yaml](manifests/faveo-mysql-cluster-manifest.yaml), to expose a mysql instance for the database, this needs the `faveo-db-auth` secret to be already applied in the namespace;
-* [faveo-ingress.yaml](manifests/faveo-ingress.yaml), to expose faveo on Internet, it will be available [here](https://ticketing.crownlabs.polito.it);
+* [faveo-ingress.yaml](manifests/faveo-ingress.yaml), to expose faveo on Internet, it will be available [here](https://support.crownlabs.polito.it);
 * [faveo-php-configmap.yaml](manifests/faveo-php-configmap.yaml), which contains environment variables for faveo, the following parameters have to be configured
     * `DB_DATABASE` insert here the database name, it can be retrieved from the `faveo-db-auth` secret
     * `DB_USERNAME` insert here the username of the database owner, it can be retrieved from the `faveo-db-auth` secret

--- a/infrastructure/ticketing/manifests/faveo-ingress.yaml
+++ b/infrastructure/ticketing/manifests/faveo-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ingressClassName: nginx-external
   rules:
-  - host: ticketing.crownlabs.polito.it
+  - host: support.crownlabs.polito.it
     http:
       paths:
       - path: /
@@ -20,5 +20,5 @@ spec:
               number: 80
   tls:
   - hosts:
-    - ticketing.crownlabs.polito.it
+    - support.crownlabs.polito.it
     secretName: crownlabs-ingress-secret

--- a/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
+++ b/infrastructure/ticketing/manifests/faveo-php-configmap.yaml
@@ -3,7 +3,7 @@ data:
   .env: |
     APP_DEBUG=false
     APP_BUGSNAG=true
-    APP_URL=https://ticketing.crownlabs.polito.it
+    APP_URL=https://support.crownlabs.polito.it
     APP_KEY=base64:edcbeW2vK8rIuavnG7lF4OM1qAUfOoG6vin5ZucJUug=
     DB_TYPE=mysql
     DB_HOST="faveo-db-mysql-master"


### PR DESCRIPTION
This PR changes the ingress url of Faveo from http://ticketing.crownlabs.polito.it/ to http://support.crownlabs.polito.it/