### PR TITLE
Added operator-selector label to the sample tenant namespace

### DIFF
--- a/operators/samples/instance-snapshot.yaml
+++ b/operators/samples/instance-snapshot.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tenant-john-doe
+  labels:
+    crownlabs.polito.it/operator-selector: local
 ---
 apiVersion: crownlabs.polito.it/v1alpha2
 kind: InstanceSnapshot

--- a/operators/samples/instance.yaml
+++ b/operators/samples/instance.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tenant-john-doe
+  labels:
+    crownlabs.polito.it/operator-selector: local
 ---
 apiVersion: crownlabs.polito.it/v1alpha2
 kind: Instance


### PR DESCRIPTION
This PR adds the **crownlabs.polito.it/operator-selector** label in the tenant namespaces generated by the example files in samples, in order to allow the instance operator to start in a local cluster (e.g. kind, minikube...  )  
