### PR TITLE
Standalone applications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,13 @@ jobs:
 
           # Trigger a failure in case the diff is not empty
           exit ${exit_code}
-
+      - name: Log the error if the diff is not empty (in case the comment cannot be generated)
+        run: |
+          echo "The generated artifacts appear to be out-of-date."
+          echo
+          echo "Here it is an excerpt of the diff:"
+          echo "${{ steps.git-diff.outputs.diff }}"
+        if: failure()
       - name: Issue a comment in case the diff is not empty
         uses: peter-evans/create-or-update-comment@v1
         with:

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -147,7 +147,8 @@ export type EnvironmentRefInput = {
 export enum EnvironmentType {
   VirtualMachine = 'VirtualMachine',
   Container = 'Container',
-  CloudVm = 'CloudVM'
+  CloudVm = 'CloudVM',
+  Standalone = 'Standalone'
 }
 
 /** ImageListItem describes a single VM image. */

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -5,6 +5,8 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+DOMAIN="crownlabs.polito.it"
+
 gen: generate fmt vet manifests
 
 #run all tests
@@ -84,9 +86,15 @@ run-instance: generate
 	go run cmd/instance-operator/main.go\
 				--webdav-secret-name=nextcloud-credentials\
 				--namespace-whitelist=crownlabs.polito.it/operator-selector=local\
-				--website-base-url=crownlabs.polito.it\
+				--website-base-url=${DOMAIN}\
 				--instances-auth-url=crownlabs.polito.it/app/instances/auth\
 				--nextcloud-base-url=crownlabs.polito.it/cloud
+
+#the double target below is used to set DOMAIN for local targets 
+#reference: https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html
+run-instance-local: DOMAIN="crownlabsfake.polito.it"
+run-instance-local: samples-local install-local run-instance
+	
 
 run-tenant: generate
 	go run cmd/tenant-operator/main.go\
@@ -100,9 +108,17 @@ run-tenant: generate
 				--nc-url=$(NEXTCLOUD_URL)\
 				--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)\
 				--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)
+				--enable-webhooks=false
 
-install-tenant: manifests
-	kubectl apply -f deploy/crds/crownlabs.polito.it_tenants.yaml -f deploy/crds/crownlabs.polito.it_workspaces.yaml
+install-local: manifests
+	kubectl apply -f deploy/crds
+	kubectl apply -f tests/crds
 
 python-dependencies:
 	pip3 install -r ./build/delete-stale-instances/requirements.txt
+
+samples-local:
+	kubectl apply -f ./samples/	
+
+clean-local:
+	kubectl delete -f ./samples/

--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum="VirtualMachine";"Container";"CloudVM"
+// +kubebuilder:validation:Enum="VirtualMachine";"Container";"CloudVM";"Standalone"
 
 // EnvironmentType is an enumeration of the different types of environments that
 // can be instantiated in CrownLabs.
@@ -32,12 +32,14 @@ type EnvironmentType string
 type EnvironmentMode string
 
 const (
-	// ClassContainer -> the environment is constituted by a Docker container.
+	// ClassContainer -> the environment is constituted by a Docker container exposing a service through a VNC server.
 	ClassContainer EnvironmentType = "Container"
 	// ClassVM -> the environment is constituted by a Virtual Machine.
 	ClassVM EnvironmentType = "VirtualMachine"
 	// ClassCloudVM -> the environment is constituited by a Virtual Machine started from cloud images downloaded from HTTP URL.
 	ClassCloudVM EnvironmentType = "CloudVM"
+	// ClassStandalone -> the environment is constituted by a Docker Container exposing a web service through an http interface.
+	ClassStandalone EnvironmentType = "Standalone"
 
 	// ModeStandard -> Normal operation (authentication, ssh, files access).
 	ModeStandard EnvironmentMode = "Standard"
@@ -84,7 +86,7 @@ type Environment struct {
 	Image string `json:"image"`
 
 	// The type of environment to be instantiated, among VirtualMachine,
-	// Container and CloudVM.
+	// Container, CloudVM and Standalone.
 	EnvironmentType EnvironmentType `json:"environmentType"`
 
 	// +kubebuilder:default=true
@@ -105,6 +107,10 @@ type Environment struct {
 
 	// The mode associated with the environment (Standard, Exam, Exercise)
 	Mode EnvironmentMode `json:"mode,omitempty"`
+
+	// +kubebuilder:default=false
+	// Whether the environment needs the URL Rewrite or not.
+	RewriteURL bool `json:"rewriteURL,omitempty"`
 
 	// Options to customize container startup
 	ContainerStartupOptions *ContainerStartupOpts `json:"containerStartupOptions,omitempty"`

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -105,11 +105,12 @@ spec:
                       type: object
                     environmentType:
                       description: The type of environment to be instantiated, among
-                        VirtualMachine, Container and CloudVM.
+                        VirtualMachine, Container, CloudVM and Standalone.
                       enum:
                       - VirtualMachine
                       - Container
                       - CloudVM
+                      - Standalone
                       type: string
                     guiEnabled:
                       default: true
@@ -187,6 +188,11 @@ spec:
                       - memory
                       - reservedCPUPercentage
                       type: object
+                    rewriteURL:
+                      default: false
+                      description: Whether the environment needs the URL Rewrite or
+                        not.
+                      type: boolean
                     storageClassName:
                       description: Name of the storage class to be used for the persistent
                         volume (when needed)

--- a/operators/pkg/forge/services.go
+++ b/operators/pkg/forge/services.go
@@ -36,7 +36,7 @@ const (
 	// SSHPortName -> the name of the port the SSH daemon is exposed to.
 	SSHPortName = "ssh"
 	// GUIPortName -> the name of the port the NoVNC service is exposed to.
-	GUIPortName = "vnc"
+	GUIPortName = "gui"
 	// MyDrivePortName -> the name of the port the "MyDrive" service is exposed to.
 	MyDrivePortName = "mydrive"
 	// XVncPortName -> the name of the port through which the X server is accessible through VNC.
@@ -55,19 +55,19 @@ func ServiceSpec(instance *clv1alpha2.Instance, environment *clv1alpha2.Environm
 		ports = append(ports, serviceSpecTCPPort(SSHPortName, SSHPortNumber))
 	}
 
-	// Add the desktop port only if enabled.
+	// Add the GUI port only if enabled.
 	if environment.GuiEnabled {
 		ports = append(ports, serviceSpecTCPPort(GUIPortName, GUIPortNumber))
 	}
 
-	// Additional container ports
+	// Add the "MyDrive" port only if the environment is a container or standalone.
+	if (environment.EnvironmentType == clv1alpha2.ClassStandalone || environment.EnvironmentType == clv1alpha2.ClassContainer) && environment.Mode == clv1alpha2.ModeStandard {
+		ports = append(ports, serviceSpecTCPPort(MyDrivePortName, MyDrivePortNumber))
+	}
+
+	// Add the Metrics port only for container
 	if environment.EnvironmentType == clv1alpha2.ClassContainer {
 		ports = append(ports, serviceSpecTCPPort(MetricsPortName, MetricsPortNumber))
-
-		// Add the "MyDrive" port for standard instances.
-		if environment.Mode == clv1alpha2.ModeStandard {
-			ports = append(ports, serviceSpecTCPPort(MyDrivePortName, MyDrivePortNumber))
-		}
 	}
 
 	spec := corev1.ServiceSpec{

--- a/operators/pkg/forge/services_test.go
+++ b/operators/pkg/forge/services_test.go
@@ -129,8 +129,8 @@ var _ = Describe("Services forging", func() {
 				},
 				Expected: []corev1.ServicePort{
 					{Name: forge.GUIPortName, Protocol: corev1.ProtocolTCP, Port: forge.GUIPortNumber, TargetPort: intstr.FromInt(forge.GUIPortNumber)},
-					{Name: forge.MetricsPortName, Protocol: corev1.ProtocolTCP, Port: forge.MetricsPortNumber, TargetPort: intstr.FromInt(forge.MetricsPortNumber)},
 					{Name: forge.MyDrivePortName, Protocol: corev1.ProtocolTCP, Port: forge.MyDrivePortNumber, TargetPort: intstr.FromInt(forge.MyDrivePortNumber)},
+					{Name: forge.MetricsPortName, Protocol: corev1.ProtocolTCP, Port: forge.MetricsPortNumber, TargetPort: intstr.FromInt(forge.MetricsPortNumber)},
 				},
 			}),
 			Entry("When the Environment is a Container", ServiceSpecCase{

--- a/operators/pkg/instctrl/controller.go
+++ b/operators/pkg/instctrl/controller.go
@@ -202,7 +202,7 @@ func (r *InstanceReconciler) enforceEnvironments(ctx context.Context) error {
 				r.EventsRecorder.Eventf(instance, v1.EventTypeWarning, EvEnvironmentErr, EvEnvironmentErrMsg, environment.Name)
 				return err
 			}
-		case clv1alpha2.ClassContainer:
+		case clv1alpha2.ClassContainer, clv1alpha2.ClassStandalone:
 			if err := r.EnforceContainerEnvironment(ctx); err != nil {
 				r.EventsRecorder.Eventf(instance, v1.EventTypeWarning, EvEnvironmentErr, EvEnvironmentErrMsg, environment.Name)
 				return err

--- a/operators/pkg/instctrl/exposition_test.go
+++ b/operators/pkg/instctrl/exposition_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Generation of the exposition environment", func() {
 				Tenant:   clv1alpha2.GenericRef{Name: tenantName},
 			},
 		}
-		environment = clv1alpha2.Environment{Name: environmentName, Mode: clv1alpha2.ModeStandard}
+		environment = clv1alpha2.Environment{Name: environmentName, Mode: clv1alpha2.ModeStandard, EnvironmentType: clv1alpha2.ClassContainer}
 
 		serviceName = forge.NamespacedName(&instance)
 		ingressGUIName = forge.NamespacedNameWithSuffix(&instance, forge.IngressGUINameSuffix)
@@ -153,12 +153,12 @@ var _ = Describe("Generation of the exposition environment", func() {
 	DescribeBodyParametersIngressGUI := DescribeBodyParameters{
 		NamespacedName: &ingressGUIName, Object: &ingress, GroupResource: netv1.Resource("ingresses"),
 		ExpectedSpecForger: func(inst *clv1alpha2.Instance, _ *clv1alpha2.Environment) interface{} {
-			return forge.IngressSpec(host, forge.IngressVNCGUIPath(inst),
+			return forge.IngressSpec(host, forge.IngressGUIPath(inst, &environment),
 				forge.IngressDefaultCertificateName, serviceName.Name, forge.GUIPortName)
 		},
 		EmptySpec:              netv1.IngressSpec{},
 		InstanceStatusGetter:   func(inst *clv1alpha2.Instance) string { return inst.Status.URL },
-		InstanceStatusExpected: fmt.Sprintf("https://%v/instance/%v", host, instanceUID),
+		InstanceStatusExpected: fmt.Sprintf("https://%v/instance/%v/", host, instanceUID),
 	}
 
 	DescribeBodyParametersIngressMD := DescribeBodyParameters{

--- a/operators/samples/instance.yaml
+++ b/operators/samples/instance.yaml
@@ -16,3 +16,39 @@ spec:
     namespace: workspace-tea
   tenant.crownlabs.polito.it/TenantRef:
     name: john.doe
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Instance
+metadata:
+  name: instance-vscode-python-proxyenabled
+  namespace: tenant-john-doe
+spec:
+  template.crownlabs.polito.it/TemplateRef:
+    name: vscode-python-proxyenabled
+    namespace: workspace-standalone
+  tenant.crownlabs.polito.it/TenantRef:
+    name: john.doe
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Instance
+metadata:
+  name: instance-jupyterlab
+  namespace: tenant-john-doe
+spec:
+  template.crownlabs.polito.it/TemplateRef:
+    name: jupyterlab
+    namespace: workspace-standalone
+  tenant.crownlabs.polito.it/TenantRef:
+    name: john.doe
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Instance
+metadata:
+  name: instance-vscode-c-cpp-persistent
+  namespace: tenant-john-doe
+spec:
+  template.crownlabs.polito.it/TemplateRef:
+    name: vscode-c-cpp-persistent
+    namespace: workspace-standalone
+  tenant.crownlabs.polito.it/TenantRef:
+    name: john.doe

--- a/operators/samples/templates.yaml
+++ b/operators/samples/templates.yaml
@@ -8,6 +8,11 @@ kind: Namespace
 metadata:
   name: workspace-coffee
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workspace-standalone
+---
 apiVersion: crownlabs.polito.it/v1alpha2
 kind: Template
 metadata:
@@ -51,3 +56,79 @@ spec:
   workspace.crownlabs.polito.it/WorkspaceRef:
     name: coffee
   deleteAfter: 1h
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Template
+metadata:
+  name: vscode-python-proxyenabled
+  namespace: workspace-standalone
+spec:
+  prettyName: Visual Studio Code - Python (proxy enabled)
+  description: A template about vscode
+  environmentList:
+    - name: vscode-environment
+      environmentType: Standalone
+      mode: Standard
+      image: harbor.crownlabs.polito.it/crownlabs-standalone/vscode-python:1.0.0
+      containerStartupOptions:
+        contentPath: /config/workspace
+        startupArgs:
+          - "false"
+          - "proxy"
+      resources:
+        cpu: 2
+        memory: 2G
+        reservedCPUPercentage: 25
+      rewriteURL: true
+  workspace.crownlabs.polito.it/WorkspaceRef:
+    name: standalone
+  deleteAfter: 30d
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Template
+metadata:
+  name: vscode-c-cpp-persistent
+  namespace: workspace-standalone
+spec:
+  prettyName: vscode c-cpp persistent
+  description: A template about vscode
+  environmentList:
+    - name: vscode-environment
+      environmentType: Standalone
+      mode: Standard
+      image: harbor.crownlabs.polito.it/crownlabs-standalone/vscode-c-cpp:1.0.0
+      containerStartupOptions:
+        contentPath: /config/workspace
+      resources:
+        cpu: 2
+        memory: 2G
+        disk: 4G
+        reservedCPUPercentage: 25
+      rewriteURL: true
+      persistent: true
+  workspace.crownlabs.polito.it/WorkspaceRef:
+    name: standalone
+  deleteAfter: 30d
+---
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Template
+metadata:
+  name: jupyterlab
+  namespace: workspace-standalone
+spec:
+  prettyName: jupyterlab
+  description: A template about vscode
+  environmentList:
+    - name: jupyterlab-environment
+      environmentType: Standalone
+      mode: Standard
+      image: harbor.crownlabs.polito.it/crownlabs-standalone/jupyterlab:1.0.0
+      containerStartupOptions:
+        contentPath: /home/crownlabs
+      resources:
+        cpu: 2
+        memory: 2G
+        reservedCPUPercentage: 25
+  workspace.crownlabs.polito.it/WorkspaceRef:
+    name: standalone
+  deleteAfter: 30d


### PR DESCRIPTION
This PR introduces the possibility to deploy a generic web-based application on CrownLabs using templates and instances.

Roadmap:

- [x] Add Standalone EnvironmentType to the CRD
- [x] Implement the creation of a standalone application's Ingress in the instance controller
- [x] Add the Rewrite annotation to the ingress to allow the deploying of applications with a generic subpath
- [x] Implement the creation of a standalone application's Service in the instance controller
- [x] Implement a new Pod creation function for standalone applications in the instance controller
- [x] Clean the code

