### PR TITLE
Instance controller: remove generation changed predicate

### DIFF
--- a/operators/pkg/instctrl/controller.go
+++ b/operators/pkg/instctrl/controller.go
@@ -33,10 +33,8 @@ import (
 	"k8s.io/utils/trace"
 	virtv1 "kubevirt.io/client-go/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/context"
@@ -246,7 +244,7 @@ func (r *InstanceReconciler) setInitialReadyTimeIfNecessary(ctx context.Context)
 func (r *InstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	mgr.GetLogger().Info("setup manager")
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&clv1alpha2.Instance{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&clv1alpha2.Instance{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&virtv1.VirtualMachine{}).
 		Owns(&virtv1.VirtualMachineInstance{}).


### PR DESCRIPTION
# Description

This PR removes the generation changed predicate from the instance controller, since it is the likely culprit for the status glitch observed during the exam simulation, as it might prevent the status from being correctly updated in case of race conditions. 

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automated tests
- [x] Staging environment
