### PR TITLE
Add FsGroup in podSecurityContext

### DIFF
--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -91,6 +91,7 @@ func PodSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
 		RunAsUser:    pointer.Int64(CrownLabsUserID),
 		RunAsGroup:   pointer.Int64(CrownLabsUserID),
+		FSGroup:      pointer.Int64(CrownLabsUserID),
 		RunAsNonRoot: pointer.Bool(true),
 	}
 }

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -135,6 +135,9 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 		It("Should set the correct RunAsUser", func() {
 			Expect(psc.RunAsUser).To(PointTo(BeNumerically("==", 1010)))
 		})
+		It("Should set the correct FsGroup", func() {
+			Expect(psc.FSGroup).To(PointTo(BeNumerically("==", 1010)))
+		})
 		It("Should set the correct RunAsNonRoot", func() {
 			Expect(psc.RunAsNonRoot).To(PointTo(BeTrue()))
 		})


### PR DESCRIPTION
# Description

This PR adds FsGroup setting in PodSecurityContext for container based instances (for example cinder volumes begin with root user write access only).
