### PR TITLE
Adding configuration of crownlabs user in cloud-init

### DIFF
--- a/operators/pkg/forge/cloudinit.go
+++ b/operators/pkg/forge/cloudinit.go
@@ -22,10 +22,21 @@ import (
 
 // userdata is a helper structure to marshal the userdata configuration.
 type userdata struct {
+	Users             []user      `yaml:"users"`
 	Network           network     `yaml:"network"`
 	Mounts            [][]string  `yaml:"mounts"`
 	WriteFiles        []writefile `yaml:"write_files"`
 	SSHAuthorizedKeys []string    `yaml:"ssh_authorized_keys,omitempty"`
+}
+
+// user is a helper structure to marshal the userdata configuration to configure users.
+type user struct {
+	Name              string   `yaml:"name"`
+	LockPasswd        bool     `yaml:"lock_passwd"`
+	Passwd            string   `yaml:"passwd"`
+	Sudo              string   `yaml:"sudo"`
+	SSHAuthorizedKeys []string `yaml:"ssh_authorized_keys,omitempty"`
+	Shell             string   `yaml:"shell"`
 }
 
 // network is a helper structure to marshal the userdata configuration to configure the network subsystem.
@@ -49,6 +60,16 @@ type writefile struct {
 // CloudInitUserData forges the yaml manifest representing the cloud-init userdata configuration.
 func CloudInitUserData(nextcloudBaseURL, webdavUsername, webdavPassword string, publicKeys []string) ([]byte, error) {
 	config := userdata{
+		Users: []user{{
+			Name:       "crownlabs",
+			LockPasswd: false,
+			// The hash of the password ("crownlabs").
+			// You can generate this hash via: "mkpasswd --method=SHA-512 --rounds=4096".
+			Passwd:            "$6$rounds=4096$tBS1sNBpnw6feehB$lS9b7VKH6WMAFOB0SrHCgjD2BKs9CegDe51EiMRWbxQeCVnoGL4u0jNaRsYhvVoBFaRlXZkNsxfFhXvCBaNeQ.",
+			Sudo:              "ALL=(ALL) NOPASSWD:ALL",
+			SSHAuthorizedKeys: publicKeys,
+			Shell:             "/bin/bash",
+		}},
 		Network: network{
 			Version: 2,
 			ID0:     interf{DHCP4: true},

--- a/operators/pkg/forge/cloudinit_test.go
+++ b/operators/pkg/forge/cloudinit_test.go
@@ -32,6 +32,15 @@ var _ = Describe("CloudInit userdata generation", func() {
 
 			expected = `
 #cloud-config
+users:
+    - name: crownlabs
+      lock_passwd: false
+      passwd: $6$rounds=4096$tBS1sNBpnw6feehB$lS9b7VKH6WMAFOB0SrHCgjD2BKs9CegDe51EiMRWbxQeCVnoGL4u0jNaRsYhvVoBFaRlXZkNsxfFhXvCBaNeQ.
+      sudo: ALL=(ALL) NOPASSWD:ALL
+      ssh_authorized_keys:
+        - tenant-key-1
+        - tenant-key-2
+      shell: /bin/bash
 network:
     version: 2
     id0:


### PR DESCRIPTION
# Description
---
This PR adds directives to cloud-init in order to create in every VM an user with username "crownlabs" and password "crownlabs".