### PR TITLE
Add back PyCharm license window

### DIFF
--- a/provisioning/containers/pycharm/Dockerfile
+++ b/provisioning/containers/pycharm/Dockerfile
@@ -37,7 +37,6 @@ RUN useradd -ms /bin/bash -u ${UID} $USER
 
 # Copy PyCharm pre-configuration (PyCharm configuration and consent options on license and usage stats)
 COPY config $HOME/.config/JetBrains/PyCharmCE${PYCHARM_VERSION}
-COPY java "$HOME/.java/.userPrefs/jetbrains/_!(!!cg\"p!(}!}@\"j!(k!|w\"w!'8!b!\"p!':!e@=="
 COPY local $HOME/.local/share/JetBrains/consentOptions
 
 # Set permissions on user home

--- a/provisioning/containers/pycharm/README.md
+++ b/provisioning/containers/pycharm/README.md
@@ -12,7 +12,6 @@ This allows the software to work out-of-the-box, without any splash screen (e.g.
 The required files are located in the following directories:
 
 - [config](config/): it contains three files for the (1) IDE theme, (2) window size, and (3) '_show tips on startup_' settings, which are copied in the container `~/.config` directory.
-- [java](java/): it contains one file for the license agreement consent, which is copied in the container `~/.java` directory
 - [local](local/): it contains one file for the IDE usage statistics consent, which is copied in the container `~/.local` directory
 
 Once this preparation is done, the `pycharm.sh` script is executed with an optional `PROJECT_DIR` parameter that, if set, points to a Python project root directory to further simplify the user experience.

--- a/provisioning/containers/pycharm/java/prefs.xml
+++ b/provisioning/containers/pycharm/java/prefs.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE map SYSTEM "http://java.sun.com/dtd/preferences.dtd">
-<map MAP_XML_VERSION="1.0">
-  <entry key="euacommunity_accepted_version" value="1.0"/>
-</map>


### PR DESCRIPTION
# Description

This PR removes the programmatic acceptance of pycharm license, in order to allow proper full-screen setting of the window on startup.
