### PR TITLE
Move StorageClass definition into Template (env)

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -108,6 +108,9 @@ type Environment struct {
 
 	// Options to customize container startup
 	ContainerStartupOptions *ContainerStartupOpts `json:"containerStartupOptions,omitempty"`
+
+	// Name of the storage class to be used for the persistent volume (when needed)
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // EnvironmentResources is the specification of the amount of resources

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -86,7 +86,6 @@ func main() {
 	flag.StringVar(&containerEnvOpts.ContentDownloaderImg, "container-env-content-downloader-img", "latest", "The image name for the init-container to download and unarchive initial content to the instance volume.")
 	flag.StringVar(&containerEnvOpts.ContentUploaderImg, "container-env-content-uploader-img", "latest", "The image name for the job to compress and upload instance content from a persistent instance.")
 	flag.StringVar(&containerEnvOpts.MyDriveImgAndTag, "container-env-mydrive-img-and-tag", "filebrowser/filebrowser:latest", "The image name and tag for the filebrowser image (sidecar for gui-based file manager)")
-	flag.StringVar(&containerEnvOpts.StorageClassName, "container-storage-class-name", "", "The storage class name for persistent container environments (empty = default)")
 
 	flag.StringVar(&instSnapOpts.VMRegistry, "vm-registry", "", "The registry where VMs should be uploaded")
 	flag.StringVar(&instSnapOpts.RegistrySecretName, "vm-registry-secret", "", "The name of the secret for the VM registry")

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -187,6 +187,10 @@ spec:
                       - memory
                       - reservedCPUPercentage
                       type: object
+                    storageClassName:
+                      description: Name of the storage class to be used for the persistent
+                        volume (when needed)
+                      type: string
                   required:
                   - environmentType
                   - image

--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -62,17 +62,16 @@ type ContainerEnvOpts struct {
 	MyDriveImgAndTag     string
 	ContentDownloaderImg string
 	ContentUploaderImg   string
-	StorageClassName     string
 }
 
 // PVCSpec forges a ReadWriteOnce PersistentVolumeClaimSpec
 // with requests set as in environment.Resources.Disk.
-func PVCSpec(environment *clv1alpha2.Environment, opts *ContainerEnvOpts) corev1.PersistentVolumeClaimSpec {
+func PVCSpec(environment *clv1alpha2.Environment) corev1.PersistentVolumeClaimSpec {
 	return corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{
 			corev1.ReadWriteOnce,
 		},
-		StorageClassName: PVCStorageClassName(opts),
+		StorageClassName: PVCStorageClassName(environment),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: environment.Resources.Disk,
@@ -82,9 +81,9 @@ func PVCSpec(environment *clv1alpha2.Environment, opts *ContainerEnvOpts) corev1
 }
 
 // PVCStorageClassName returns the storage class configured as option, or nil if empty.
-func PVCStorageClassName(opts *ContainerEnvOpts) *string {
-	if opts.StorageClassName != "" {
-		return pointer.String(opts.StorageClassName)
+func PVCStorageClassName(environment *clv1alpha2.Environment) *string {
+	if environment.StorageClassName != "" {
+		return pointer.String(environment.StorageClassName)
 	}
 	return nil
 }

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -97,15 +97,10 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 	})
 
 	Describe("The forge.PVCSpec function", func() {
-		var (
-			spec         corev1.PersistentVolumeClaimSpec
-			storageClass string
-		)
-
-		BeforeEach(func() { storageClass = "" })
+		var spec corev1.PersistentVolumeClaimSpec
 
 		JustBeforeEach(func() {
-			spec = forge.PVCSpec(&environment, &forge.ContainerEnvOpts{StorageClassName: storageClass})
+			spec = forge.PVCSpec(&environment)
 		})
 
 		It("Should set the correct access mode", func() {
@@ -119,7 +114,7 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 		})
 
 		When("A custom storage class is specified", func() {
-			BeforeEach(func() { storageClass = "foo" })
+			BeforeEach(func() { environment.StorageClassName = "foo" })
 			It("Should set the storage class name", func() {
 				Expect(spec.StorageClassName).To(PointTo(Equal("foo")))
 			})

--- a/operators/pkg/instctrl/containers.go
+++ b/operators/pkg/instctrl/containers.go
@@ -62,7 +62,7 @@ func (r *InstanceReconciler) enforcePVC(ctx context.Context) error {
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
 		// PVC's spec is immutable, it has to be set at creation
 		if pvc.ObjectMeta.CreationTimestamp.IsZero() {
-			pvc.Spec = forge.PVCSpec(environment, &r.ContainerEnvOpts)
+			pvc.Spec = forge.PVCSpec(environment)
 		}
 		pvc.SetLabels(forge.InstanceObjectLabels(pvc.GetLabels(), instance))
 		return ctrl.SetControllerReference(instance, &pvc, r.Scheme)

--- a/operators/pkg/instctrl/containers_test.go
+++ b/operators/pkg/instctrl/containers_test.go
@@ -285,7 +285,7 @@ var _ = Describe("Generation of the container based instances", func() {
 
 			It("The PVC should be present and have the expected specs", func() {
 				Expect(reconciler.Get(ctx, objectName, &pvc)).To(Succeed())
-				Expect(pvc.Spec).To(Equal(forge.PVCSpec(&environment, &forge.ContainerEnvOpts{})))
+				Expect(pvc.Spec).To(Equal(forge.PVCSpec(&environment)))
 			})
 		})
 


### PR DESCRIPTION
# Description

This PR moves the StorageClassName definition into the Template Spec (inside the Environment specification), removing it from the startup flags.
