### PR TITLE
Fix HTTPGet go util

### DIFF
--- a/operators/pkg/utils/network.go
+++ b/operators/pkg/utils/network.go
@@ -47,7 +47,7 @@ func HTTPGet(ctx context.Context, url string, timeout time.Duration) (statusCode
 	log.Info("performing request")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return resp.StatusCode, nil, err
+		return -1, nil, err
 	}
 
 	log.Info("reading response")


### PR DESCRIPTION
# Description

This PR addresses an issue discovered within the Instance Termination Automation Controller. The HTTPGet method returned the statusCode of the response on error, however in almost all the cases, the response is nil on error. This fix corrects this behavior by returning a -1 statusCode when err is not nil.