### PR TITLE
Revert "slash-command-dispatch: use temp version to fix permissions issue"

### DIFF
--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Dispatch Slash Commands
-        uses: peter-evans/slash-command-dispatch@permissions
+        uses: peter-evans/slash-command-dispatch@v2
         with:
           token: ${{ secrets.CI_TOKEN }}
           reaction-token: ${{ secrets.CI_TOKEN }}


### PR DESCRIPTION
# Description

This PR restores the stable slash-command-dispatch version. 
