### PR TITLE
Update noVNC and add viewonly settings

### DIFF
--- a/provisioning/containers/gui-common/novnc/Dockerfile
+++ b/provisioning/containers/gui-common/novnc/Dockerfile
@@ -1,9 +1,9 @@
-FROM nginx:1.19.5-alpine
+FROM nginx:1.21.6-alpine
 
 ENV HTML_DATA=/usr/share/nginx/html
 
 # Get noVNC & cleanup
-RUN wget -qO- https://github.com/novnc/noVNC/archive/v1.2.0.tar.gz | \
+RUN wget -qO- https://github.com/novnc/noVNC/archive/v1.3.0.tar.gz | \
     tar xz -C ${HTML_DATA} --strip 1 && \
     rm -rf ${HTML_DATA}/docs && \
     rm -rf ${HTML_DATA}/snap && \
@@ -16,17 +16,28 @@ getConfigVar = (a,b) => {\
     return ogcv(a,b);\
 }" >> ${HTML_DATA}/app/webutil.js
 
-RUN echo "const ois = UI.initSettings;\
+RUN echo "window.onhashchange=()=>{ \
+const { hash } = window.location; \
+UI.forceSetting('resize', hash.includes('noresize') ? 'scale' : 'remote');\
+UI.forceSetting('view_only', hash.includes('readonly')); \
+UI.updateViewOnly(); \
+UI.applyResizeMode(); \
+}; \
+const ois = UI.initSettings;\
 UI.initSettings = () => {\
 ois();\
 let {pathname} = window.location;\
 pathname = pathname.split('/').filter(e=>e).join('/');\
 if (pathname) UI.forceSetting('path', pathname+'/vnc');\
-UI.forceSetting('resize', 'remote');\
 UI.forceSetting('show_dot', true);\
 UI.forceSetting('reconnect', true);\
-UI.forceSetting('reconnect_delay', 100);\
+UI.forceSetting('reconnect_delay', Math.floor(Math.random()*2000));\
+window.onhashchange();\
 }" >> ${HTML_DATA}/app/ui.js
+
+RUN echo #noVNC_container
+RUN echo "#noVNC_container {border-bottom-right-radius: 0 !important;}" \
+    >> ${HTML_DATA}/app/styles/base.css
 
 # Copy config template and entrypoint
 COPY nginx.conf.template /etc/nginx/nginx.conf.template

--- a/provisioning/containers/gui-common/novnc/nginx.conf.template
+++ b/provisioning/containers/gui-common/novnc/nginx.conf.template
@@ -2,9 +2,8 @@
 
 worker_processes  auto;
 
-# Logging & pid location
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
+# Save pid into /tmp to fix errors when running as non-root
+pid        /tmp/nginx.pid;
 
 # Workers configuration
 events {


### PR DESCRIPTION
# Description

This PR updates novnc to [v1.3.0](https://github.com/novnc/noVNC/releases/tag/v1.3.0) and adds `readonly` and `noresize` hash flags.