### PR TITLE
Content uploader, force 200 <= http_code < 300

### DIFF
--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -50,6 +50,8 @@ const (
 	HealthzEndpoint = "/healthz"
 	// CrownLabsUserID -> used as UID and GID for containers security context.
 	CrownLabsUserID = int64(1010)
+	// SubmissionJobMaxRetries -> max number of retries for submission jobs.
+	SubmissionJobMaxRetries = 10
 
 	containersTerminationGracePeriod = 10
 )
@@ -151,6 +153,7 @@ func PodSpec(instance *clv1alpha2.Instance, environment *clv1alpha2.Environment,
 // SubmissionJobSpec returns the job spec for the submission job.
 func SubmissionJobSpec(instance *clv1alpha2.Instance, environment *clv1alpha2.Environment, opts *ContainerEnvOpts) batchv1.JobSpec {
 	return batchv1.JobSpec{
+		BackoffLimit: pointer.Int32(SubmissionJobMaxRetries),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -573,6 +573,7 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 
 		It("should return the correct podSpecification", func() {
 			Expect(actual).To(Equal(batchv1.JobSpec{
+				BackoffLimit: pointer.Int32Ptr(forge.SubmissionJobMaxRetries),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{

--- a/provisioning/containers/utils/content-uploader/entrypoint.sh
+++ b/provisioning/containers/utils/content-uploader/entrypoint.sh
@@ -20,4 +20,10 @@ cd "$SOURCE_PATH"
 zip "/tmp/$FILENAME.zip" -r .
 
 echo "Uploading archive..."
-curl -v --fail --request POST --form "binfile=@\"/tmp/$FILENAME.zip\"" --form "filename=$FILENAME.zip" "$DESTINATION_URL"
+HTTP_CODE=$(curl -v --request --fail POST --form "binfile=@\"/tmp/$FILENAME.zip\"" --form "filename=$FILENAME.zip" "$DESTINATION_URL" --write-out "%{http_code}")
+
+# return non zero if HTTP_CODE is less than 200 or greater equal than 300
+if [ "$HTTP_CODE" -lt "200" ] || [ "$HTTP_CODE" -ge "300" ]; then
+  echo "Upload failed with HTTP code $HTTP_CODE"
+  exit 1
+fi


### PR DESCRIPTION
# Description

This PR changes the failure detection mode of the content uploader, so that only http response codes between 200 and 299 are accepted. 
It also increases the backoff limit for submission jobs.