### PR TITLE
Build-push action: disable push to harbor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,8 +249,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           tags: |
-            ${{ steps.parameters.outputs.harbor-registry }}/${{ matrix.harbor-project }}/${{ steps.parameters.outputs.repo-name }}:${{ needs.configure.outputs.ref }}
             ${{ steps.parameters.outputs.repo-owner }}/${{ steps.parameters.outputs.repo-name }}:${{ needs.configure.outputs.ref }}
+          # ${{ steps.parameters.outputs.harbor-registry }}/${{ matrix.harbor-project }}/${{ steps.parameters.outputs.repo-name }}:${{ needs.configure.outputs.ref }}
           push: ${{ needs.configure.outputs.repo-push }}
           file: ${{ steps.parameters.outputs.dockerfile }}
           context: ${{ matrix.context }}
@@ -260,7 +260,7 @@ jobs:
           # https://github.com/moby/buildkit/issues/1896
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
-          
+
   trigger-events-master:
     name: Trigger events upon successful push to master
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

This PR (temporarily) disables the push of Docker images to harbor, since for some reasons (still unknown) the process fails in a certain number of cases. Hopefully, this will be re-enabled once we succeed in making it work consistently.
