### PR TITLE
Frontend: New modal for Instance group deletion

### DIFF
--- a/frontend/src/components/activePage/ActiveView/ActiveView.tsx
+++ b/frontend/src/components/activePage/ActiveView/ActiveView.tsx
@@ -1,11 +1,9 @@
-import { DeleteOutlined } from '@ant-design/icons';
 import { Col, Space } from 'antd';
-import Button from 'antd-button-color';
 import { FC, useEffect, useState } from 'react';
-import { User, WorkspaceRole } from '../../../utils';
+import { User, Workspace, WorkspaceRole } from '../../../utils';
 import { SessionValue, StorageKeys } from '../../../utilsStorage';
 import Box from '../../common/Box';
-import { ModalAlert } from '../../common/ModalAlert';
+import ModalGroupDeletion from '../ModalGroupDeletion/ModalGroupDeletion';
 import TableInstanceLogic from '../TableInstance/TableInstanceLogic';
 import TableWorkspaceLogic from '../TableWorkspaceLogic/TableWorkspaceLogic';
 import Toolbox from '../Toolbox/Toolbox';
@@ -16,12 +14,7 @@ const advanced = new SessionValue(StorageKeys.Active_Headers, 'true');
 
 export interface IActiveViewProps {
   user: User;
-  workspaces: Array<{
-    prettyName: string;
-    role: WorkspaceRole;
-    namespace: string;
-    id: string;
-  }>;
+  workspaces: Array<Workspace>;
   managerView: boolean;
 }
 
@@ -40,6 +33,7 @@ const ActiveView: FC<IActiveViewProps> = ({ ...props }) => {
   );
   const [showCheckbox, setShowCheckbox] = useState(false);
   const [selectiveDestroy, setSelectiveDestroy] = useState<string[]>([]);
+  const [selectedPersistent, setSelectedPersistent] = useState<boolean>(false);
 
   const selectToDestroy = (instanceId: string) => {
     selectiveDestroy.includes(instanceId)
@@ -70,28 +64,14 @@ const ActiveView: FC<IActiveViewProps> = ({ ...props }) => {
 
   return (
     <Col span={24} lg={22} xxl={20}>
-      <ModalAlert
-        headTitle="Destroy Selected"
+      <ModalGroupDeletion
+        view={WorkspaceRole.manager}
+        persistent={selectedPersistent}
+        selective={true}
+        instanceList={selectiveDestroy}
         show={showAlert}
-        message="ATTENTION"
-        description={`Are you sure do you want to destroy the ${selectiveDestroy.length} selected instances. This operation is dangerous and irreversible!`}
-        type="error"
-        buttons={[
-          <Button
-            type="danger"
-            shape="round"
-            size="middle"
-            icon={<DeleteOutlined />}
-            className="border-0"
-            onClick={() => {
-              setDestroySelectedTrigger(true);
-              setShowAlert(false);
-            }}
-          >
-            Destroy Selected
-          </Button>,
-        ]}
         setShow={setShowAlert}
+        destroy={() => setDestroySelectedTrigger(true)}
       />
       <Box
         header={{
@@ -149,6 +129,7 @@ const ActiveView: FC<IActiveViewProps> = ({ ...props }) => {
               setDestroySelectedTrigger={setDestroySelectedTrigger}
               selectiveDestroy={selectiveDestroy}
               selectToDestroy={selectToDestroy}
+              setSelectedPersistent={setSelectedPersistent}
             />
           </div>
         ) : (

--- a/frontend/src/components/activePage/ActiveViewLogic/ActiveViewLogic.tsx
+++ b/frontend/src/components/activePage/ActiveViewLogic/ActiveViewLogic.tsx
@@ -3,6 +3,7 @@ import { Spin } from 'antd';
 import ActiveView from '../ActiveView/ActiveView';
 import { WorkspaceRole } from '../../../utils';
 import { TenantContext } from '../../../graphql-components/tenantContext/TenantContext';
+import { makeWorkspace } from '../../../utilsLogic';
 
 const ActiveViewLogic: FC<{}> = ({ ...props }) => {
   const {
@@ -12,17 +13,7 @@ const ActiveViewLogic: FC<{}> = ({ ...props }) => {
   } = useContext(TenantContext);
 
   const workspaces =
-    tenantData?.tenant?.spec?.workspaces?.map(workspace => {
-      const { workspaceWrapperTenantV1alpha2, name, role } = workspace!;
-      const { spec, status } =
-        workspaceWrapperTenantV1alpha2?.itPolitoCrownlabsV1alpha1Workspace!;
-      return {
-        prettyName: spec?.prettyName as string,
-        role: WorkspaceRole[role!],
-        namespace: status?.namespace?.name!,
-        id: name!,
-      };
-    }) || [];
+    tenantData?.tenant?.spec?.workspaces?.map(makeWorkspace) || [];
 
   const managerWorkspaces = workspaces?.filter(
     ws => ws.role === WorkspaceRole.manager

--- a/frontend/src/components/activePage/ModalGroupDeletion/ModalGroupDeletion.tsx
+++ b/frontend/src/components/activePage/ModalGroupDeletion/ModalGroupDeletion.tsx
@@ -1,0 +1,116 @@
+import { DeleteOutlined } from '@ant-design/icons';
+import { Divider } from 'antd';
+import Button from 'antd-button-color';
+import { Dispatch, FC, SetStateAction, useState } from 'react';
+import { ReactComponent as SvgInfinite } from '../../../assets/infinite.svg';
+import { WorkspaceRole } from '../../../utils';
+import { ModalAlert } from '../../common/ModalAlert';
+
+export interface IModalGroupDeletionProps {
+  view: WorkspaceRole;
+  persistent: boolean;
+  selective: boolean;
+  groupName?: string;
+  instanceList: Array<string>;
+  show: boolean;
+  setShow: Dispatch<SetStateAction<boolean>>;
+  destroy: () => void;
+}
+
+const ModalGroupDeletion: FC<IModalGroupDeletionProps> = ({ ...props }) => {
+  const {
+    view,
+    persistent,
+    selective,
+    groupName,
+    instanceList,
+    show,
+    setShow,
+    destroy,
+  } = props;
+  const [confirmDeletion, setConfirmDeletion] = useState(false);
+
+  const title = selective ? 'Destroy Selected' : 'Destroy All';
+  const message = <b>ATTENTION</b>;
+  const description = (
+    <>
+      <div>
+        Are you sure that you want to destroy
+        {selective ? (
+          <>{` the ${instanceList.length} selected instances`}</>
+        ) : groupName ? (
+          <>
+            {' all instances of '}
+            <b>
+              <i>{groupName}</i>
+            </b>
+          </>
+        ) : (
+          ' all instances'
+        )}
+        ? <br />
+        This operation is <u>dangerous and irreversible</u>!
+      </div>
+
+      {persistent ? (
+        <div className="text-center text-xs">
+          <Divider type="horizontal" className="my-3" />
+          <div className="flex items-end">
+            <i>
+              (Seems you are also trying to destroy one or more Persistent
+              instances
+              <SvgInfinite
+                width="16px"
+                className="ml-1.5 success-color-fg align-bottom"
+              />
+              .
+              {view === WorkspaceRole.manager
+                ? ' You need to confirm their deletion)'
+                : ' They will be skipped, you need to MANUALLY destroy them)'}
+            </i>
+          </div>
+        </div>
+      ) : (
+        ''
+      )}
+    </>
+  );
+  const buttons = [
+    <Button
+      key="destroy_all"
+      type="danger"
+      shape="round"
+      size="middle"
+      disabled={!confirmDeletion}
+      icon={<DeleteOutlined />}
+      className="border-0"
+      onClick={() => {
+        destroy();
+        setShow(false);
+      }}
+    >
+      {selective ? 'Destroy Selected' : 'Destroy All'}
+    </Button>,
+  ];
+
+  const checkbox = {
+    confirmCheckbox: confirmDeletion,
+    setConfirmCheckbox: setConfirmDeletion,
+    checkboxLabel: 'I understand the risk and I want to proceed',
+  };
+
+  return (
+    <ModalAlert
+      headTitle={title}
+      show={show}
+      message={message}
+      description={description}
+      type="error"
+      buttons={buttons}
+      setShow={setShow}
+      checkbox={checkbox}
+    />
+  );
+};
+
+export default ModalGroupDeletion;

--- a/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
@@ -15,7 +15,7 @@ import { TenantContext } from '../../../graphql-components/tenantContext/TenantC
 import { matchK8sObject, replaceK8sObject } from '../../../k8sUtils';
 import { Instance, User, WorkspaceRole } from '../../../utils';
 import {
-  getSubObjType,
+  getSubObjTypeK8s,
   makeGuiInstance,
   notifyStatus,
   sorter,
@@ -79,7 +79,7 @@ const TableInstanceLogic: FC<ITableInstanceLogicProps> = ({ ...props }) => {
           if (prev.instanceList?.instances) {
             let instances = [...prev.instanceList.instances];
             const found = instances.find(matchK8sObject(instance, false));
-            objType = getSubObjType(found, instance, updateType);
+            objType = getSubObjTypeK8s(found, instance, updateType);
             switch (objType) {
               case SubObjType.Deletion:
                 instances = instances.filter(matchK8sObject(instance, true));
@@ -131,7 +131,7 @@ const TableInstanceLogic: FC<ITableInstanceLogicProps> = ({ ...props }) => {
 
   const instances =
     dataInstances?.instanceList?.instances
-      ?.map((i, n) => makeGuiInstance(i, tenantId))
+      ?.map(i => makeGuiInstance(i, tenantId))
       .sort((a, b) =>
         sorter(
           a,

--- a/frontend/src/components/activePage/TableTemplate/TableTemplate.tsx
+++ b/frontend/src/components/activePage/TableTemplate/TableTemplate.tsx
@@ -50,7 +50,7 @@ const TableTemplate: FC<ITableTemplateProps> = ({ ...props }) => {
   } = props;
   const { hasSSHKeys } = useContext(TenantContext);
   const [expandedId, setExpandedId] = useState(
-    expandedT.get(templates[0].workspaceId).split(',')
+    expandedT.get(templates[0].workspaceName).split(',')
   );
   const { apolloErrorCatcher } = useContext(ErrorContext);
 
@@ -105,7 +105,7 @@ const TableTemplate: FC<ITableTemplateProps> = ({ ...props }) => {
   ];
 
   useEffect(() => {
-    expandedT.set(expandedId.join(','), templates[0].workspaceId);
+    expandedT.set(expandedId.join(','), templates[0].workspaceName);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedId]);
 

--- a/frontend/src/components/activePage/TableTemplate/TableTemplateRow.tsx
+++ b/frontend/src/components/activePage/TableTemplate/TableTemplateRow.tsx
@@ -1,17 +1,17 @@
-import { FC, useState } from 'react';
-import { Space, Menu, Dropdown, Typography, Tooltip } from 'antd';
-import Button from 'antd-button-color';
 import {
-  DeleteOutlined,
-  MoreOutlined,
-  DesktopOutlined,
   CodeOutlined,
+  DeleteOutlined,
+  DesktopOutlined,
+  MoreOutlined,
 } from '@ant-design/icons';
-import Badge from '../../common/Badge';
-import { ModalAlert } from '../../common/ModalAlert';
+import { Dropdown, Menu, Space, Tooltip, Typography } from 'antd';
+import Button from 'antd-button-color';
+import { FC, useState } from 'react';
 import { ReactComponent as SvgInfinite } from '../../../assets/infinite.svg';
-import { Template } from '../../../utils';
+import { Template, WorkspaceRole } from '../../../utils';
 import { DropDownAction } from '../../../utilsLogic';
+import Badge from '../../common/Badge';
+import ModalGroupDeletion from '../ModalGroupDeletion/ModalGroupDeletion';
 
 const { Text } = Typography;
 export interface ITableTemplateRowProps {
@@ -125,25 +125,17 @@ const TableTemplateRow: FC<ITableTemplateRowProps> = ({ ...props }) => {
           />
         </Dropdown>
       </div>
-      <ModalAlert
-        headTitle="Destroy All"
+      <ModalGroupDeletion
+        view={WorkspaceRole.manager}
+        persistent={
+          !!template.instances.filter(i => i.persistent === true).length
+        }
+        groupName={template.name}
+        selective={false}
+        instanceList={template.instances.map(i => i.id)}
         show={showAlert}
-        message="ATTENTION"
-        description={`Are you sure do you want to destroy all the instances in ${name}. This operation is dangerous and irreversible!`}
-        type="error"
-        buttons={[
-          <Button
-            type="danger"
-            shape="round"
-            size="middle"
-            icon={<DeleteOutlined />}
-            className="border-0"
-            onClick={() => destroyAll()}
-          >
-            Destroy All
-          </Button>,
-        ]}
         setShow={setShowAlert}
+        destroy={destroyAll}
       />
     </>
   );

--- a/frontend/src/components/activePage/TableWorkspace/TableWorkspace.tsx
+++ b/frontend/src/components/activePage/TableWorkspace/TableWorkspace.tsx
@@ -32,6 +32,7 @@ export interface ITableWorkspaceProps {
   ) => void;
   destroySelectedTrigger: boolean;
   setDestroySelectedTrigger: Dispatch<SetStateAction<boolean>>;
+  setSelectedPersistent: Dispatch<SetStateAction<boolean>>;
   selectiveDestroy: string[];
   selectToDestroy: (instanceId: string) => void;
 }
@@ -51,6 +52,7 @@ const TableWorkspace: FC<ITableWorkspaceProps> = ({ ...props }) => {
     setDestroySelectedTrigger,
     selectiveDestroy,
     selectToDestroy,
+    setSelectedPersistent,
   } = props;
   const [expandedId, setExpandedId] = useState(expandedWS.get().split(','));
   const { apolloErrorCatcher } = useContext(ErrorContext);
@@ -60,7 +62,7 @@ const TableWorkspace: FC<ITableWorkspaceProps> = ({ ...props }) => {
   });
 
   const expandWorkspace = () => {
-    setExpandedId(workspaces.map(ws => ws.id));
+    setExpandedId(workspaces.map(ws => ws.name));
   };
 
   const collapseWorkspace = () => {
@@ -98,16 +100,27 @@ const TableWorkspace: FC<ITableWorkspaceProps> = ({ ...props }) => {
       title: 'Template',
       key: 'template',
       // eslint-disable-next-line react/no-multi-comp
-      render: ({ title, templates, id }: Workspace) => (
+      render: ({ prettyName, templates, name }: Workspace) => (
         <TableWorkspaceRow
-          title={title}
-          id={id}
+          title={prettyName}
+          id={name}
           nActive={getActives(templates)}
           expandRow={expandRow}
         />
       ),
     },
   ];
+
+  useEffect(() => {
+    const persistent =
+      (instances &&
+        instances.filter(
+          i => selectiveDestroy.includes(i.id) && i.persistent
+        )) ||
+      [];
+    setSelectedPersistent(persistent.length > 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectiveDestroy]);
 
   useEffect(() => {
     expandedWS.set(expandedId.join(','));
@@ -132,13 +145,13 @@ const TableWorkspace: FC<ITableWorkspaceProps> = ({ ...props }) => {
       className={`rowInstance-bg-color cl-table flex-grow flex-wrap content-between py-0 overflow-auto scrollbar`}
     >
       <Table
-        rowKey={record => record.id}
+        rowKey={record => record.name}
         columns={columns}
         size="middle"
         dataSource={workspaces}
         pagination={false}
         showHeader={false}
-        onExpand={(expanded, ws) => expandRow(ws.id)}
+        onExpand={(expanded, ws) => expandRow(ws.name)}
         expandable={{
           expandedRowKeys: expandedId,
           // eslint-disable-next-line react/no-multi-comp

--- a/frontend/src/components/activePage/TableWorkspace/TableWorkspaceRow.tsx
+++ b/frontend/src/components/activePage/TableWorkspace/TableWorkspaceRow.tsx
@@ -1,7 +1,5 @@
-import { FC } from 'react';
 import { Space, Typography } from 'antd';
-import Button from 'antd-button-color';
-import { UserSwitchOutlined } from '@ant-design/icons';
+import { FC } from 'react';
 import Badge from '../../common/Badge';
 
 const { Text } = Typography;
@@ -24,14 +22,6 @@ const TableWorkspaceRow: FC<ITableWorkspaceRowProps> = ({ ...props }) => {
         <Text className="font-bold w-48 xs:w-56 sm:w-max" ellipsis>
           {title}
         </Text>
-        <Button
-          disabled={true}
-          type="ghost"
-          shape="circle"
-          size="middle"
-          className="mr-2"
-          icon={<UserSwitchOutlined />}
-        />
       </Space>
     </div>
   );

--- a/frontend/src/components/activePage/TableWorkspaceLogic/TableWorkspaceLogic.tsx
+++ b/frontend/src/components/activePage/TableWorkspaceLogic/TableWorkspaceLogic.tsx
@@ -17,10 +17,10 @@ import {
   useInstancesLabelSelectorQuery,
 } from '../../../generated-types';
 import { matchK8sObject, replaceK8sObject } from '../../../k8sUtils';
-import { multiStringIncludes, User, WorkspaceRole } from '../../../utils';
+import { multiStringIncludes, User, Workspace } from '../../../utils';
 import {
   getManagerInstances,
-  getSubObjType,
+  getSubObjTypeK8s,
   getTemplatesMapped,
   getWorkspacesMapped,
   notifyStatus,
@@ -32,12 +32,7 @@ const fetchPolicy_networkOnly: FetchPolicy = 'network-only';
 
 export interface ITableWorkspaceLogicProps {
   user: User;
-  workspaces: Array<{
-    prettyName: string;
-    role: WorkspaceRole;
-    namespace: string;
-    id: string;
-  }>;
+  workspaces: Array<Workspace>;
   filter: string;
   showAdvanced: boolean;
   showCheckbox: boolean;
@@ -47,6 +42,7 @@ export interface ITableWorkspaceLogicProps {
   setCollapseAll: Dispatch<SetStateAction<boolean>>;
   setExpandAll: Dispatch<SetStateAction<boolean>>;
   setDestroySelectedTrigger: Dispatch<SetStateAction<boolean>>;
+  setSelectedPersistent: Dispatch<SetStateAction<boolean>>;
   selectiveDestroy: string[];
   selectToDestroy: (instanceId: string) => void;
 }
@@ -66,6 +62,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
     setDestroySelectedTrigger,
     selectToDestroy,
     selectiveDestroy,
+    setSelectedPersistent,
   } = props;
 
   const { tenantId, tenantNamespace } = user;
@@ -89,7 +86,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
   };
 
   const labels = `crownlabs.polito.it/workspace in (${workspaces
-    .map(({ id }) => id)
+    .map(({ name }) => name)
     .join(',')})`;
 
   const { makeErrorCatcher, apolloErrorCatcher, errorsQueue } =
@@ -129,7 +126,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
           if (prev.instanceList?.instances) {
             let instances = [...prev.instanceList.instances];
             const found = instances.find(matchK8sObject(instance, false));
-            objType = getSubObjType(found, instance, updateType);
+            objType = getSubObjTypeK8s(found, instance, updateType);
 
             switch (objType) {
               case SubObjType.Deletion:
@@ -204,6 +201,7 @@ const TableWorkspaceLogic: FC<ITableWorkspaceLogicProps> = ({ ...props }) => {
       setDestroySelectedTrigger={setDestroySelectedTrigger}
       selectiveDestroy={selectiveDestroy}
       selectToDestroy={selectToDestroy}
+      setSelectedPersistent={setSelectedPersistent}
     />
   ) : (
     <div className="flex justify-center h-full items-center">

--- a/frontend/src/components/common/ModalAlert/ModalAlert.tsx
+++ b/frontend/src/components/common/ModalAlert/ModalAlert.tsx
@@ -1,16 +1,31 @@
-import React, { FC, ReactNode } from 'react';
-import { Modal, Alert, AlertProps } from 'antd';
+import React, { Dispatch, FC, ReactNode, SetStateAction } from 'react';
+import { Modal, Alert, AlertProps, Checkbox } from 'antd';
 
 export interface IModalAlertProps extends AlertProps {
   headTitle: ReactNode;
   show: boolean;
   buttons: Array<React.ReactNode>;
   setShow: (status: boolean) => void;
+  checkbox?: {
+    confirmCheckbox: boolean;
+    setConfirmCheckbox: Dispatch<SetStateAction<boolean>>;
+    checkboxLabel: string;
+  };
 }
 
 const ModalAlert: FC<IModalAlertProps> = ({ ...props }) => {
-  const { headTitle, show, type, message, description, buttons, setShow } =
-    props;
+  const {
+    headTitle,
+    show,
+    type,
+    message,
+    description,
+    buttons,
+    setShow,
+    checkbox,
+  } = props;
+
+  const { confirmCheckbox, setConfirmCheckbox, checkboxLabel } = checkbox || {};
 
   return (
     <Modal
@@ -21,7 +36,16 @@ const ModalAlert: FC<IModalAlertProps> = ({ ...props }) => {
       onCancel={() => setShow(false)}
     >
       <Alert message={message} description={description} type={type} showIcon />
-
+      {checkbox && (
+        <div className="flex justify-center mt-3">
+          <Checkbox
+            checked={confirmCheckbox}
+            onChange={() => setConfirmCheckbox!(old => !old)}
+          >
+            {checkboxLabel}
+          </Checkbox>
+        </div>
+      )}
       <div className="flex justify-center mt-6">{buttons}</div>
     </Modal>
   );

--- a/frontend/src/components/workspaces/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/workspaces/Dashboard/Dashboard.tsx
@@ -1,20 +1,15 @@
-import { FC, useEffect, useState } from 'react';
 import { Col } from 'antd';
+import { FC, useEffect, useState } from 'react';
+import { Workspace } from '../../../utils';
+import { SessionValue, StorageKeys } from '../../../utilsStorage';
+import { WorkspaceGrid } from '../Grid/WorkspaceGrid';
 import { WorkspaceContainer } from '../WorkspaceContainer';
 import { WorkspaceWelcome } from '../WorkspaceWelcome';
-import { WorkspaceGrid } from '../Grid/WorkspaceGrid';
-import { WorkspaceRole } from '../../../utils';
-import { SessionValue, StorageKeys } from '../../../utilsStorage';
 
 const dashboard = new SessionValue(StorageKeys.Dashboard_View, '-1');
 export interface IDashboardProps {
   tenantNamespace: string;
-  workspaces: Array<{
-    workspaceId: string;
-    role: WorkspaceRole;
-    workspaceNamespace: string;
-    workspaceName: string;
-  }>;
+  workspaces: Array<Workspace>;
 }
 
 const Dashboard: FC<IDashboardProps> = ({ ...props }) => {
@@ -31,9 +26,9 @@ const Dashboard: FC<IDashboardProps> = ({ ...props }) => {
         <div className="flex-auto lg:overflow-x-hidden overflow-auto scrollbar">
           <WorkspaceGrid
             selectedWs={selectedWsId}
-            workspaceItems={workspaces.map((wk, idx) => ({
+            workspaceItems={workspaces.map((ws, idx) => ({
               id: idx,
-              title: wk.workspaceId,
+              title: ws.prettyName,
             }))}
             onClick={setSelectedWs}
           />
@@ -48,13 +43,7 @@ const Dashboard: FC<IDashboardProps> = ({ ...props }) => {
         {selectedWsId !== -1 ? (
           <WorkspaceContainer
             tenantNamespace={tenantNamespace}
-            workspace={{
-              id: selectedWsId,
-              role: workspaces[selectedWsId].role,
-              title: workspaces[selectedWsId].workspaceId,
-              workspaceNamespace: workspaces[selectedWsId].workspaceNamespace,
-              workspaceName: workspaces[selectedWsId].workspaceName,
-            }}
+            workspace={workspaces[selectedWsId]}
           />
         ) : (
           <WorkspaceWelcome />

--- a/frontend/src/components/workspaces/DashboardLogic/DashboardLogic.tsx
+++ b/frontend/src/components/workspaces/DashboardLogic/DashboardLogic.tsx
@@ -1,7 +1,7 @@
 import { Spin } from 'antd';
 import { FC, useContext } from 'react';
 import { TenantContext } from '../../../graphql-components/tenantContext/TenantContext';
-import { WorkspaceRole } from '../../../utils';
+import { makeWorkspace } from '../../../utilsLogic';
 import Dashboard from '../Dashboard/Dashboard';
 
 const DashboardLogic: FC<{}> = () => {
@@ -16,19 +16,7 @@ const DashboardLogic: FC<{}> = () => {
       <Dashboard
         tenantNamespace={tenantData.tenant?.status?.personalNamespace?.name!}
         workspaces={
-          tenantData?.tenant?.spec?.workspaces?.map(workspace => {
-            return {
-              workspaceId: workspace?.workspaceWrapperTenantV1alpha2
-                ?.itPolitoCrownlabsV1alpha1Workspace?.spec
-                ?.prettyName as string,
-              role: WorkspaceRole[workspace?.role!],
-              workspaceNamespace:
-                workspace?.workspaceWrapperTenantV1alpha2
-                  ?.itPolitoCrownlabsV1alpha1Workspace?.status?.namespace
-                  ?.name!,
-              workspaceName: workspace?.name!,
-            };
-          }) ?? []
+          tenantData?.tenant?.spec?.workspaces?.map(makeWorkspace) ?? []
         }
       />
     </>

--- a/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
@@ -73,8 +73,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
         },
         updateQuery: updateQueryOwnedInstancesQuery(
           setDataInstances,
-          userId ?? '',
-          tenantNamespace
+          userId ?? ''
         ),
       });
       return unsubscribe;
@@ -113,7 +112,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
       const unsubscribe = subscribeToMoreTemplates({
         onError: makeErrorCatcher(ErrorTypes.GenericError),
         document: updatedWorkspaceTemplates,
-        variables: { workspaceNamespace: `${workspaceNamespace}` },
+        variables: { workspaceNamespace },
         updateQuery: updateQueryWorkspaceTemplatesQuery(setDataTemplate),
       });
       return unsubscribe;

--- a/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
@@ -70,7 +70,7 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({ ...props }) => {
     useInstancesLabelSelectorQuery({
       onError: apolloErrorCatcher,
       variables: {
-        labels: `crownlabs.polito.it/template=${template.id},crownlabs.polito.it/workspace=${template.workspaceId}`,
+        labels: `crownlabs.polito.it/template=${template.id},crownlabs.polito.it/workspace=${template.workspaceName}`,
       },
       skip: true,
       fetchPolicy: 'network-only',

--- a/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
+++ b/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
@@ -1,30 +1,24 @@
-import { FC, useContext, useState } from 'react';
-import { UserSwitchOutlined, PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined, UserSwitchOutlined } from '@ant-design/icons';
+import { Modal, Tooltip } from 'antd';
 import Button from 'antd-button-color';
-import Box from '../../common/Box';
-import { TemplatesTableLogic } from '../Templates/TemplatesTableLogic';
-import { WorkspaceRole } from '../../../utils';
+import { FC, useContext, useState } from 'react';
+import { ErrorContext } from '../../../errorHandling/ErrorContext';
 import {
   EnvironmentType,
   ImagesQuery,
   useCreateTemplateMutation,
   useImagesQuery,
 } from '../../../generated-types';
+import { Workspace } from '../../../utils';
+import UserListLogic from '../../accountPage/UserListLogic/UserListLogic';
+import Box from '../../common/Box';
 import ModalCreateTemplate from '../ModalCreateTemplate';
 import { Image, Template } from '../ModalCreateTemplate/ModalCreateTemplate';
-import { Tooltip, Modal } from 'antd';
-import { ErrorContext } from '../../../errorHandling/ErrorContext';
-import UserListLogic from '../../accountPage/UserListLogic/UserListLogic';
+import { TemplatesTableLogic } from '../Templates/TemplatesTableLogic';
 
 export interface IWorkspaceContainerProps {
   tenantNamespace: string;
-  workspace: {
-    id: number;
-    title: string;
-    role: WorkspaceRole;
-    workspaceNamespace: string;
-    workspaceName: string;
-  };
+  workspace: Workspace;
 }
 
 const getImages = (dataImages: ImagesQuery) => {
@@ -65,7 +59,12 @@ const WorkspaceContainer: FC<IWorkspaceContainerProps> = ({ ...props }) => {
 
   const {
     tenantNamespace,
-    workspace: { role, title, workspaceNamespace, workspaceName },
+    workspace: {
+      role,
+      name: workspaceName,
+      namespace: workspaceNamespace,
+      prettyName: workspacePrettyName,
+    },
   } = props;
 
   const { apolloErrorCatcher } = useContext(ErrorContext);
@@ -125,7 +124,7 @@ const WorkspaceContainer: FC<IWorkspaceContainerProps> = ({ ...props }) => {
           center: (
             <div className="h-full flex justify-center items-center px-5">
               <p className="md:text-4xl text-2xl text-center mb-0">
-                <b>{title}</b>
+                <b>{workspacePrettyName}</b>
               </p>
             </div>
           ),
@@ -168,7 +167,7 @@ const WorkspaceContainer: FC<IWorkspaceContainerProps> = ({ ...props }) => {
         />
         <Modal
           destroyOnClose={true}
-          title={`Users in ${title} `}
+          title={`Users in ${workspacePrettyName} `}
           width="800px"
           visible={showUserListModal}
           footer={null}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -10,8 +10,9 @@ export type BadgeSize = 'small' | 'middle' | 'large';
 export type User = { tenantId: string; tenantNamespace: string };
 export type BoxHeaderSize = 'small' | 'middle' | 'large';
 export type Workspace = {
-  id: string;
-  title: string;
+  name: string;
+  namespace: string;
+  prettyName: string;
   role: WorkspaceRole;
   templates?: Array<Template>;
 };
@@ -27,7 +28,8 @@ export type Template = {
   persistent: boolean;
   resources: Resources;
   instances: Array<Instance>;
-  workspaceId: string;
+  workspaceName: string;
+  workspaceNamespace: string;
 };
 
 export type Instance = {
@@ -48,7 +50,7 @@ export type Instance = {
   url: string | null;
   myDriveUrl: string;
   timeStamp: string;
-  workspaceId: string;
+  workspaceName: string;
   running: boolean;
 };
 


### PR DESCRIPTION
With this PR will be implement and improve the system and the modal to delete a certain group of instances:

- [x] Active Page [Manager]: Selective group deletion
- [x] Active Page [Manager]: Group deletion by "Template"
- [x] Active Page [Personal]: Delete all personal instances (Persistent ones won't be deleted anymore)
- [x] Simple deletion modal restyling