### PR TITLE
Sandbox environment: add limit range creation

### DIFF
--- a/infrastructure/docker-registry/README.md
+++ b/infrastructure/docker-registry/README.md
@@ -12,7 +12,7 @@
 
 
 ## What is it
-From the [Docker Registry](https://docs.docker.com/registry/) official documentation: A Registry is a stateless, highly scalable server-side application that stores and lets you distribute Docker images. 
+From the [Docker Registry](https://docs.docker.com/registry/) official documentation: A Registry is a stateless, highly scalable server-side application that stores and lets you distribute Docker images.
 [Harbor](https://goharbor.io/) is an open source registry having a lot of features, such as an advanced UI, a vulnerability scanner, robot accounts and so on. For more information visit the official web page.
 
 ## Why do we need it?
@@ -40,9 +40,9 @@ To install Harbor, it is possible to leverage the [official Helm Chart](https://
   6. PVC that can be shared across nodes (i.e., with `ReadWriteMany` access mode) or external object storage
 
 ### Redis Configuration
-In our architecture we have a [Redis-Sentinel](https://redis.io/topics/sentinel) service, instead of [Redis Cluster](https://redis.io/topics/cluster-tutorial), because with this architecture Sentinel manages automatically the failover of the master.
+In our architecture we have a [Redis-Sentinel](https://redis.io/docs/manual/sentinel/) service, instead of [Redis Cluster](https://redis.io/docs/manual/scaling/), because with this architecture Sentinel manages automatically the failover of the master.
 To enable the `Redis-Sentinel ` architecture it is necessary to configure the following parameter in the redis file values (`redis-service-values.yaml`):
-```yaml 
+```yaml
   sentinel.enabled=true
 ```
 
@@ -83,4 +83,3 @@ helm upgrade harbor harbor/harbor --namespace harbor \
 ```
 Warning: credentials and secret parameters have been redacted from the values file stored in this repository.
 Look [here](https://github.com/goharbor/harbor-helm) for a complete configuration guide.
-

--- a/operators/deploy/tenant-operator/templates/clusterrole.yaml
+++ b/operators/deploy/tenant-operator/templates/clusterrole.yaml
@@ -10,7 +10,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
 
 - apiGroups: [""]
-  resources: ["namespaces", "resourcequotas", "secrets"]
+  resources: ["namespaces", "resourcequotas", "limitranges", "secrets"]
   verbs: ["get", "list", "watch", "create", "update", "delete", "deletecollection"]
 
 - apiGroups: ["rbac.authorization.k8s.io"]

--- a/operators/pkg/forge/limitrange.go
+++ b/operators/pkg/forge/limitrange.go
@@ -1,0 +1,37 @@
+// Copyright 2020-2022 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// SandboxLimitRangeSpec forges the Limit Range spec for sandbox namespaces.
+func SandboxLimitRangeSpec() corev1.LimitRangeSpec {
+	return corev1.LimitRangeSpec{
+		Limits: []corev1.LimitRangeItem{{
+			Type: corev1.LimitTypeContainer,
+			DefaultRequest: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(10, resource.Milli),
+				corev1.ResourceMemory: *resource.NewScaledQuantity(50, resource.Mega),
+			},
+			Default: corev1.ResourceList{
+				corev1.ResourceCPU:    *resource.NewScaledQuantity(100, resource.Milli),
+				corev1.ResourceMemory: *resource.NewScaledQuantity(250, resource.Mega),
+			},
+		}},
+	}
+}

--- a/operators/pkg/forge/limitrange_test.go
+++ b/operators/pkg/forge/limitrange_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020-2022 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forge_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+)
+
+var _ = Describe("Limit range spec forging", func() {
+	Describe("The forge.SandboxLimitRangeSpec function", func() {
+		var spec corev1.LimitRangeSpec
+
+		JustBeforeEach(func() { spec = forge.SandboxLimitRangeSpec() })
+
+		It("Should have a single limit entry of type container", func() {
+			Expect(spec.Limits).To(HaveLen(1))
+			Expect(spec.Limits[0].Type).To(BeIdenticalTo(corev1.LimitTypeContainer))
+		})
+
+		It("Should set the correct default requests", func() {
+			Expect(spec.Limits[0].DefaultRequest[corev1.ResourceCPU]).To(WithTransform(
+				func(q resource.Quantity) string { return q.String() }, Equal("10m")))
+			Expect(spec.Limits[0].DefaultRequest[corev1.ResourceMemory]).To(WithTransform(
+				func(q resource.Quantity) string { return q.String() }, Equal("50M")))
+		})
+
+		It("Should set the correct default limits", func() {
+			Expect(spec.Limits[0].Default[corev1.ResourceCPU]).To(WithTransform(
+				func(q resource.Quantity) string { return q.String() }, Equal("100m")))
+			Expect(spec.Limits[0].Default[corev1.ResourceMemory]).To(WithTransform(
+				func(q resource.Quantity) string { return q.String() }, Equal("250M")))
+		})
+	})
+})


### PR DESCRIPTION
# Description

This PR enhances the management of the sandbox environment, introducing the creation of a limit range object. It sets default request/limit values, preventing the need for explicit configuration in each deployment.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Automated tests
- [x] Staging environment
