### PR TITLE
Frontend: configure caching policy in nginx.conf

### DIFF
--- a/frontend/nginx.conf.tmpl
+++ b/frontend/nginx.conf.tmpl
@@ -6,11 +6,32 @@ server {
         root   /usr/share/nginx/html;
         index  index.html;
         try_files $uri ${SUBROUTE}/index.html;
+
+        # Ensure that non-versioned resources are checked
+        # with upstream before using the cached version.
+        add_header Cache-Control 'no-cache must-revalidate';
+        expires 0;
+    }
+
+    location ~ ${SUBROUTE}/favicon.* {
+        root   /usr/share/nginx/html;
+
+        # Allow favicons to be cached, although for shorter periods.
+        add_header Cache-Control 'public';
+        expires 1M;
+    }
+
+    location ${SUBROUTE}/static {
+        root   /usr/share/nginx/html;
+
+        # Allow versioned resources to be cached freely, since a modification
+        # would also change the file name (i.e. they are immutable).
+        add_header Cache-Control 'immutable';
+        expires 1y;
     }
 
     location /healthz {
         access_log off;
         return 200 "healthy\n";
     }
-
 }


### PR DESCRIPTION
# Description

This PR enhances the nginx configuration file of the frontend, to introduce directives concerning the caching policy of the different resources. In particular, it enforces non versioned resources are always revalidated with the upstream, while static assets can be freely cached as versioned.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Locally, checking that resources are correctly cached
- [x] Through the deploy staging environment
