### PR TITLE
Remove cpu maximum constraint from Template crd

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -123,10 +123,9 @@ type Environment struct {
 // (i.e. CPU, RAM, ...) assigned to a certain environment.
 type EnvironmentResources struct {
 	// +kubebuilder:validation:Minimum:=1
-	// +kubebuilder:validation:Maximum:=8
 
 	// The maximum number of CPU cores made available to the environment
-	// (ranging between 1 and 8 cores). This maps to the 'limits' specified
+	// (at least 1 core). This maps to the 'limits' specified
 	// for the actual pod representing the environment.
 	CPU uint32 `json:"cpu"`
 

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -145,11 +145,10 @@ spec:
                       properties:
                         cpu:
                           description: The maximum number of CPU cores made available
-                            to the environment (ranging between 1 and 8 cores). This
-                            maps to the 'limits' specified for the actual pod representing
-                            the environment.
+                            to the environment (at least 1 core). This maps to the
+                            'limits' specified for the actual pod representing the
+                            environment.
                           format: int32
-                          maximum: 8
                           minimum: 1
                           type: integer
                         disk:


### PR DESCRIPTION
# Description

This removes the CPU maximum constraint in the Environment spec of the Template CRD since now limits are better handled by the Tenant.