### PR TITLE
Include policies for securing sandbox namespace 

### DIFF
--- a/deploy/crownlabs/Chart.lock
+++ b/deploy/crownlabs/Chart.lock
@@ -26,5 +26,8 @@ dependencies:
 - name: instmetrics
   repository: file://../../operators/deploy/instmetrics
   version: 0.1.0
-digest: sha256:5e61e140806766e46aa2014b018ba66c40653756b213e3ff042782b0d662a6a8
-generated: "2022-04-02T18:37:42.140831116+02:00"
+- name: policies
+  repository: file://../../policies
+  version: 0.1.0
+digest: sha256:94f282fd3eb152d3693b5d98117d3cd48ca6570be13a48552de2b3b036696f46
+generated: "2022-07-08T12:10:33.942195264+02:00"

--- a/deploy/crownlabs/Chart.yaml
+++ b/deploy/crownlabs/Chart.yaml
@@ -64,3 +64,8 @@ dependencies:
   version: "0.1.0"
   repository: file://../../operators/deploy/instmetrics
   condition: instmetrics.enabled
+
+- name: policies
+  version: "0.1.0"
+  repository: file://../../policies
+  condition: policies.enabled

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -162,3 +162,12 @@ instmetrics:
     connectionTimeout:  10s
     updatePeriod: 4s
     grpcPort: 9090
+  
+policies:
+  ingressHostnamePattern: s??????.sandbox.crownlabs.polito.it
+  namespaceSelector:
+    matchExpressions:
+      - key: crownlabs.polito.it/type
+        operator: In
+        values:
+        - sandbox

--- a/infrastructure/policies/README.md
+++ b/infrastructure/policies/README.md
@@ -1,0 +1,22 @@
+# About Kyverno
+
+[Kyverno](https://kyverno.io/) is a policy engine designed specifically for Kubernetes. With Kyverno, policies are managed as Kubernetes resources and no new language is required to write policies. This allows using familiar tools such as kubectl, git, and kustomize to manage policies.
+
+## How Kyverno works
+
+Kyverno runs as a dynamic admission controller in a Kubernetes cluster. Kyverno receives validating and mutating admission webhook HTTP callbacks from the kube-apiserver and applies matching policies to return results that enforce admission policies or reject requests.
+
+### Installing Kyverno
+
+Before installing the chart, the Kyverno repository must be added to helm with the following command:
+
+```bash
+helm repo add kyverno https://kyverno.github.io/kyverno/
+helm repo update
+```
+
+Then, it is possible to install Kyverno through:
+
+```bash
+helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --values kyverno-values.yaml
+```

--- a/infrastructure/policies/kyverno-values.yaml
+++ b/infrastructure/policies/kyverno-values.yaml
@@ -1,0 +1,384 @@
+# -- Override the name of the chart
+nameOverride:
+​
+# -- Override the expanded name of the chart
+fullnameOverride:
+​
+# -- Namespace the chart deploys to
+namespace:
+​
+# -- Additional labels
+customLabels: {}
+​
+rbac:
+  # -- Create ClusterRoles, ClusterRoleBindings, and ServiceAccount
+  create: true
+  serviceAccount:
+    # -- Create a ServiceAccount
+    create: true
+    # -- The ServiceAccount name
+    name:
+    # -- Annotations for the ServiceAccount
+    annotations: {}
+      # example.com/annotation: value
+​
+image:
+  # -- Image repository
+  repository: ghcr.io/kyverno/kyverno
+  # -- Image tag
+  # Defaults to appVersion in Chart.yaml if omitted
+  tag:  # replaced in e2e tests
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Image pull secrets
+  pullSecrets: []
+  # - secretName
+​
+initImage:
+  # -- Image repository
+  repository: ghcr.io/kyverno/kyvernopre
+  # -- Image tag
+  # If initImage.tag is missing, defaults to image.tag
+  tag:  # replaced in e2e tests
+  # -- Image pull policy
+  # If initImage.pullPolicy is missing, defaults to image.pullPolicy
+  pullPolicy:
+​
+testImage:
+  # -- Image repository
+  # Defaults to `busybox` if omitted
+  repository:
+  # -- Image tag
+  # Defaults to `latest` if omitted
+  tag:
+  # -- Image pull policy
+  # Defaults to image.pullPolicy if omitted
+  pullPolicy:
+​
+# -- (int) Desired number of pods
+replicaCount: 3
+​
+# -- Additional labels to add to each pod
+podLabels: {}
+  # example.com/label: foo
+​
+# -- Additional annotations to add to each pod
+podAnnotations: {}
+  # example.com/annotation: foo
+​
+# -- Security context for the pod
+podSecurityContext: {}
+​
+# -- Security context for the containers
+securityContext:
+  runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+​
+# -- Optional priority class to be used for kyverno pods
+priorityClassName: ''
+​
+antiAffinity:
+  # -- Pod antiAffinities toggle.
+  # Enabled by default but can be disabled if you want to schedule pods to the same node.
+  enable: true
+​
+# -- Pod anti affinity constraints.
+# @default -- See [values.yaml](values.yaml)
+podAntiAffinity:
+  preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 1
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - kyverno
+        topologyKey: kubernetes.io/hostname
+​
+# -- Pod affinity constraints.
+podAffinity: {}
+​
+# -- Node affinity constraints.
+nodeAffinity: {}
+​
+podDisruptionBudget:
+  # -- Configures the minimum available pods for kyverno disruptions.
+  # Cannot be used if `maxUnavailable` is set.
+  minAvailable: 1
+  # -- Configures the maximum unavailable pods for kyverno disruptions.
+  # Cannot be used if `minAvailable` is set.
+  maxUnavailable:
+​
+# -- Node labels for pod assignment
+nodeSelector: {}
+​
+# -- List of node taints to tolerate
+tolerations: []
+​
+# -- Change `hostNetwork` to `true` when you want the kyverno's pod to share its host's network namespace.
+# Useful for situations like when you end up dealing with a custom CNI over Amazon EKS.
+# Update the `dnsPolicy` accordingly as well to suit the host network mode.
+hostNetwork: false
+​
+# -- `dnsPolicy` determines the manner in which DNS resolution happens in the cluster.
+# In case of `hostNetwork: true`, usually, the `dnsPolicy` is suitable to be `ClusterFirstWithHostNet`.
+# For further reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy.
+dnsPolicy: ClusterFirst
+​
+# -- Env variables for initContainers.
+envVarsInit: {}
+​
+# -- Env variables for containers.
+envVars: {}
+​
+# -- Extra arguments to give to the binary.
+extraArgs:
+  - --autogenInternals=false
+​
+# -- Image pull secrets for image verify and imageData policies.
+# This will define the `--imagePullSecrets` Kyverno argument.
+imagePullSecrets: {}
+  # Define two image pull secrets
+  # imagePullSecrets:
+  #   regcred:
+  #     registry: foo.example.com
+  #     username: foobar
+  #     password: secret
+  #   regcred2:
+  #     registry: bar.example.com
+  #     username: barbaz
+  #     password: secret2
+​
+resources:
+  # -- Pod resource limits
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  # -- Pod resource requests
+  requests:
+    cpu: 100m
+    memory: 512Mi
+​
+initResources:
+  # -- Pod resource limits
+  limits:
+    cpu: 100m
+    memory: 256Mi
+  # -- Pod resource requests
+  requests:
+    cpu: 10m
+    memory: 64Mi
+​
+# -- Liveness probe.
+# The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want.
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+# @default -- See [values.yaml](values.yaml)
+livenessProbe:
+  httpGet:
+    path: /health/liveness
+    port: 9443
+    scheme: HTTPS
+  initialDelaySeconds: 15
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+​
+# -- Readiness Probe.
+# The block is directly forwarded into the deployment, so you can use whatever readinessProbe configuration you want.
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+# @default -- See [values.yaml](values.yaml)
+readinessProbe:
+  httpGet:
+    path: /health/readiness
+    port: 9443
+    scheme: HTTPS
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+​
+# TODO(mbarrien): Should we just list all resources for the
+# generatecontroller in here rather than having defaults hard-coded?
+generatecontrollerExtraResources:
+# - ResourceA
+# - ResourceB
+​
+# -- Exclude Kyverno namespace
+# Determines if default Kyverno namespace exclusion is enabled for webhooks and resourceFilters
+excludeKyvernoNamespace: true
+​
+config:
+  # -- Resource types to be skipped by the Kyverno policy engine.
+  # Make sure to surround each entry in quotes so that it doesn't get parsed as a nested YAML list.
+  # These are joined together without spaces, run through `tpl`, and the result is set in the config map.
+  # @default -- See [values.yaml](values.yaml)
+  resourceFilters:
+  - '[Event,*,*]'
+  - '[*,kube-system,*]'
+  - '[*,kube-public,*]'
+  - '[*,kube-node-lease,*]'
+  - '[Node,*,*]'
+  - '[APIService,*,*]'
+  - '[TokenReview,*,*]'
+  - '[SubjectAccessReview,*,*]'
+  - '[SelfSubjectAccessReview,*,*]'
+  - '[Binding,*,*]'
+  - '[ReplicaSet,*,*]'
+  - '[ReportChangeRequest,*,*]'
+  - '[ClusterReportChangeRequest,*,*]'
+  # exclude resources from the chart
+  - '[ClusterRole,*,{{ template "kyverno.fullname" . }}:*]'
+  - '[ClusterRoleBinding,*,{{ template "kyverno.fullname" . }}:*]'
+  - '[ServiceAccount,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceAccountName" . }}]'
+  - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.configMapName" . }}]'
+  - '[ConfigMap,{{ include "kyverno.namespace" . }},{{ template "kyverno.metricsConfigMapName" . }}]'
+  - '[Deployment,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]'
+  - '[Job,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-hook-pre-delete]'
+  - '[NetworkPolicy,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]'
+  - '[PodDisruptionBudget,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}]'
+  - '[Role,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}:*]'
+  - '[RoleBinding,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}:*]'
+  - '[Secret,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}.{{ template "kyverno.namespace" . }}.svc.*]'
+  - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}]'
+  - '[Service,{{ include "kyverno.namespace" . }},{{ template "kyverno.serviceName" . }}-metrics]'
+  - '[ServiceMonitor,{{ if .Values.serviceMonitor.namespace }}{{ .Values.serviceMonitor.namespace }}{{ else }}{{ template "kyverno.namespace" . }}{{ end }},{{ template "kyverno.serviceName" . }}-service-monitor]'
+  - '[Pod,{{ include "kyverno.namespace" . }},{{ template "kyverno.fullname" . }}-test]'
+​
+  # -- Name of an existing config map (ignores default/provided resourceFilters)
+  existingConfig: ''
+  # -- Exclude group role
+  excludeGroupRole:
+  # - ''
+  # -- Exclude username
+  excludeUsername:
+  # - ''
+  # -- Defines the `namespaceSelector` in the webhook configurations.
+  # Note that it takes a list of `namespaceSelector` and/or `objectSelector` in the JSON format, and only the first element
+  # will be forwarded to the webhook configurations.
+  # The Kyverno namespace is excluded if `excludeKyvernoNamespace` is `true` (default)
+  webhooks:
+    # Exclude namespaces
+    # - namespaceSelector:
+    #     matchExpressions:
+    #     - key: kubernetes.io/metadata.name
+    #       operator: NotIn
+    #       values:
+    #         - kube-system
+    #         - kyverno
+    # Exclude objects
+    # - objectSelector:
+    #     matchExpressions:
+    #     - key: webhooks.kyverno.io/exclude
+    #       operator: DoesNotExist
+​
+  # -- Generate success events.
+  generateSuccessEvents: false
+  # -- Metrics config.
+  metricsConfig:
+    namespaces: {
+      "include": [],
+      "exclude": []
+    }
+    # 'namespaces.include': list of namespaces to capture metrics for. Default: metrics being captured for all namespaces except excludeNamespaces.
+    # 'namespaces.exclude': list of namespaces to NOT capture metrics for. Default: []
+​
+    # metricsRefreshInterval: 24h
+    # rate at which metrics should reset so as to clean up the memory footprint of kyverno metrics, if you might be expecting high memory footprint of Kyverno's metrics. Default: 0, no refresh of metrics
+​
+  # Or provide an existing metrics config-map by uncommenting the below line
+  # existingMetricsConfig: sample-metrics-configmap. Refer to the ./templates/metricsconfigmap.yaml for the structure of metrics configmap.
+# -- Deployment update strategy.
+# Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+# @default -- See [values.yaml](values.yaml)
+updateStrategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 40%
+  type: RollingUpdate
+​
+service:
+  # -- Service port.
+  port: 443
+  # -- Service type.
+  type: ClusterIP
+  # -- Service node port.
+  # Only used if `service.type` is `NodePort`.
+  nodePort:
+  # -- Service annotations.
+  annotations: {}
+​
+# -- Topology spread constraints.
+topologySpreadConstraints: []
+​
+metricsService:
+  # -- Create service.
+  create: true
+  # -- Service port.
+  # Kyverno's metrics server will be exposed at this port.
+  port: 8000
+  # -- Service type.
+  type: ClusterIP
+  # -- Service node port.
+  # Only used if `metricsService.type` is `NodePort`.
+  nodePort:
+  # -- Service annotations.
+  annotations: {}
+​
+serviceMonitor:
+  # -- Create a `ServiceMonitor` to collect Prometheus metrics.
+  enabled: true
+  # -- Additional labels
+  additionalLabels:
+    # key: value
+  # -- Override namespace (default is the same as kyverno)
+  namespace:
+  # --  Interval to scrape metrics
+  interval: 30s
+  # -- Timeout if metrics can't be retrieved in given time interval
+  scrapeTimeout: 25s
+  # -- Is TLS required for endpoint
+  secure: false
+  # -- TLS Configuration for endpoint
+  tlsConfig: {}
+​
+# -- Kyverno requires a certificate key pair and corresponding certificate authority
+# to properly register its webhooks. This can be done in one of 3 ways:
+# 1) Use kube-controller-manager to generate a CA-signed certificate (preferred)
+# 2) Provide your own CA and cert.
+#    In this case, you will need to create a certificate with a specific name and data structure.
+#    As long as you follow the naming scheme, it will be automatically picked up.
+#    kyverno-svc.(namespace).svc.kyverno-tls-ca (with data entry named rootCA.crt)
+#    kyverno-svc.kyverno.svc.kyverno-tls-pair (with data entries named tls.key and tls.crt)
+# 3) Let Helm generate a self signed cert, by setting createSelfSignedCert true
+# If letting Kyverno create its own CA or providing your own, make createSelfSignedCert is false
+createSelfSignedCert: false
+​
+# -- Whether to have Helm install the Kyverno CRDs.
+# If the CRDs are not installed by Helm, they must be added before policies can be created.
+installCRDs: true
+​
+networkPolicy:
+  # -- When true, use a NetworkPolicy to allow ingress to the webhook
+  # This is useful on clusters using Calico and/or native k8s network policies in a default-deny setup.
+  enabled: false
+  # -- A list of valid from selectors according to https://kubernetes.io/docs/concepts/services-networking/network-policies.
+  ingressFrom: []
+​
+webhooksCleanup:
+  # -- Create a helm pre-delete hook to cleanup webhooks.
+  enable: true
+  # -- `kubectl` image to run commands for deleting webhooks.
+  image: bitnami/kubectl:latest
+​
+# -- A writable volume to use for the TUF root initialization
+tufRootMountPath: /.sigstore

--- a/policies/.helmignore
+++ b/policies/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/policies/Chart.yaml
+++ b/policies/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: policies
+description: A set of policies for the sandbox namespaces
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+icon: https://crownlabs.polito.it/images/logo.svg

--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,33 @@
+# Kyverno policies for sandbox namespaces in CrownLabs
+
+This folder contains a set of policies restricting the operations that can be performed in sandbox namespaces. They address three main security requirements, grouped by the “least privilege principle”:
+
+- Pod Security Standards
+- Avoid creation of services like load balancers (i.e., avoid creation of routable IPs) and node ports.
+- Force specific names for ingress hostname.
+
+The above mentioned policies were mostly taken from [Kyverno Best Practices](https://kyverno.io/policies/?policytypes=Best%2520Practices).
+
+## Policies
+
+A Kyverno policy is a collection of rules. Each rule consists of a match declaration, an optional exclude declaration, and one of a validate, mutate, generate, or verifyImages declaration. Each rule can contain only a single validate, mutate, generate, or verifyImages child declaration.
+This initial set of policies is of the resources validation type. When a new resource is created by a user or process into the sandbox namespace, the properties of that resource are checked by Kyverno against the validation rules. If those properties are validated, meaning there is agreement, the resource is allowed to be created. If those properties are different, the creation is blocked.
+
+### Pod Security Standards
+
+Pods are configured to follow security best practices:
+
+- `privileged` is set to `false`
+- `spec.hostNetwork`, `spec.hostIPC`, and `spec.hostPID` must be unset
+- `spec.volumes[*].hostPath` must be unset
+- `spec.containers[*].ports[*].hostPort`, `spec.initContainers[*].ports[*].hostPort`, and `spec.ephemeralContainers[*].ports[*].hostPort` must be unset
+
+### Avoid creation of load balancer and nodePort services
+
+- **Disallow Service Type LoadBalancer**: This policy restricts use of the Service type LoadBalancer.
+- **Disallow NodePort**: This policy validates that any new Services do not use the `NodePort` type.
+
+### Force specific name for ingress hostname
+
+- **Disallow empty Ingress host**: This policy ensures that there is a hostname for each rule defined.
+- **Restrict Ingress host**: This policy ensures thatthe hostname has the required format.

--- a/policies/templates/_helpers.tpl
+++ b/policies/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "policies.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "policies.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The version of the application to be deployed
+*/}}
+{{- define "policies.version" -}}
+{{- if .Values.global }}
+{{- .Values.global.version | default .Chart.AppVersion }}
+{{- else }}
+{{- .Chart.AppVersion }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "policies.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "policies.labels" -}}
+helm.sh/chart: {{ include "policies.chart" . }}
+{{ include "policies.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ include "policies.version" . | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "policies.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "policies.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/policies/templates/disallow-empty-ingress-host.yaml
+++ b/policies/templates/disallow-empty-ingress-host.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-disallow-empty-ingress-host
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow empty Ingress host
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+        An ingress resource needs to define an actual host name
+        in order to be valid. This policy ensures that there is a
+        hostname for each rule defined.      
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: disallow-empty-ingress-host
+      match:
+        resources:
+          kinds:
+            - Ingress
+        {{- with .Values.namespaceSelector }}
+          namespaceSelector:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+      validate:
+        message: "The Ingress host name must be defined, not empty."
+        deny:
+          conditions:
+            - key: "{{printf "{{request.object.spec.rules[].host || `[]` | length(@) }}"}}"
+              operator: NotEquals
+              value: "{{printf "{{ request.object.spec.rules[].http || `[]` | length(@) }}"}}"

--- a/policies/templates/disallow-host-namespaces.yaml
+++ b/policies/templates/disallow-host-namespaces.yaml
@@ -1,0 +1,41 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-disallow-host-namespaces
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow Host Namespaces
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Host namespaces (Process ID namespace, Inter-Process Communication namespace, and
+      network namespace) allow access to shared information and can be used to elevate
+      privileges. Pods should not be allowed access to host namespaces. This policy ensures
+      fields which make use of these host namespaces are unset or set to `false`.      
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: disallow-host-namespaces
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+          {{- with .Values.namespaceSelector }}
+            namespaceSelector:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      validate:
+        message: >-
+          Sharing the host namespaces is disallowed. The fields spec.hostNetwork,
+          spec.hostIPC, and spec.hostPID must be unset or set to `false`.          
+        pattern:
+          spec:
+            =(hostPID): "false"
+            =(hostIPC): "false"
+            =(hostNetwork): "false"

--- a/policies/templates/disallow-hostpath.yaml
+++ b/policies/templates/disallow-hostpath.yaml
@@ -1,0 +1,38 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-host-path
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow hostPath
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod,Volume
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      HostPath volumes let Pods use host directories and volumes in containers.
+      Using host resources can be used to access shared data or escalate privileges
+      and should not be allowed. This policy ensures no hostPath volumes are in use.      
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: disallow-host-path-volumes
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+          {{- with .Values.namespaceSelector }}
+            namespaceSelector:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      validate:
+        message: >-
+          HostPath volumes are forbidden. The field spec.volumes[*].hostPath must be unset.
+        pattern:
+          spec:
+            =(volumes):
+              - X(hostPath): "null"

--- a/policies/templates/disallow-loadbalancer.yaml
+++ b/policies/templates/disallow-loadbalancer.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-disallow-loadbalancer
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow Service Type LoadBalancer
+    policies.kyverno.io/category: Sample
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      Especially in cloud provider environments, a Service having type LoadBalancer will cause the
+      provider to respond by creating a load balancer somewhere in the customer account. This adds
+      cost and complexity to a deployment. Without restricting this ability, users may easily
+      overrun established budgets and security practices set by the organization. This policy restricts
+      use of the Service type LoadBalancer.      
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: disallow-loadbalancer-services
+    match:
+      resources:
+        kinds:
+        - Service
+      {{- with .Values.namespaceSelector }}
+        namespaceSelector:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    validate:
+      message: "Service of type LoadBalancer is not allowed."
+      pattern:
+        spec:
+          type: "!LoadBalancer"

--- a/policies/templates/disallow-nodeport.yaml
+++ b/policies/templates/disallow-nodeport.yaml
@@ -1,0 +1,35 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-disallow-nodeport
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow NodePort
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    policies.kyverno.io/description: >-
+      A Kubernetes Service of type NodePort uses a host port to receive traffic from
+      any source. A NetworkPolicy cannot be used to control traffic to host ports.
+      Although NodePort Services can be useful, their use must be limited to Services
+      with additional upstream security checks. This policy validates that any new Services
+      do not use the `NodePort` type.          
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: disallow-nodeport-services
+    match:
+      resources:
+        kinds:
+        - Service
+      {{- with .Values.namespaceSelector }}
+        namespaceSelector:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    validate:
+      message: "Services of type NodePort are not allowed."
+      pattern:
+        spec:
+          type: "!NodePort"

--- a/policies/templates/disallow-privileged-containers.yaml
+++ b/policies/templates/disallow-privileged-containers.yaml
@@ -1,0 +1,45 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-disallow-privileged-containers
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow Privileged Containers
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Privileged mode disables most security mechanisms and must not be allowed. This policy
+      ensures Pods do not call for privileged mode.          
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: disallow-privileged-containers
+      match:
+        any:
+        - resources:
+            kinds:
+            - Pod
+          {{- with .Values.namespaceSelector }}
+            namespaceSelector:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      validate:
+        message: >-
+          Privileged mode is disallowed. The fields spec.containers[*].securityContext.privileged
+          and spec.initContainers[*].securityContext.privileged must be unset or set to `false`.
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - =(securityContext):
+                  =(privileged): "false"
+            =(initContainers):
+              - =(securityContext):
+                  =(privileged): "false"
+            containers:
+              - =(securityContext):
+                  =(privileged): "false"

--- a/policies/templates/host-ports-none.yaml
+++ b/policies/templates/host-ports-none.yaml
@@ -1,0 +1,47 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-host-ports-none
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Disallow hostPorts
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+    kyverno.io/kyverno-version: 1.6.0
+    kyverno.io/kubernetes-version: "1.22-1.23"
+    policies.kyverno.io/description: >-
+      Access to host ports allows potential snooping of network traffic and should not be
+      allowed, or at minimum restricted to a known list. This policy ensures the `hostPort`
+      field is unset or set to `0`.       
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+    - name: disallow-host-ports
+      match:
+        any:
+        - resources:
+            kinds:
+              - Pod
+          {{- with .Values.namespaceSelector }}
+            namespaceSelector:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+      validate:
+        message: >-
+          Use of host ports is disallowed. The fields spec.containers[*].ports[*].hostPort
+          , spec.initContainers[*].ports[*].hostPort, and spec.ephemeralContainers[*].ports[*].hostPort
+          must either be unset or set to `0`.          
+        pattern:
+          spec:
+            =(ephemeralContainers):
+              - =(ports):
+                  - =(hostPort): 0
+            =(initContainers):
+              - =(ports):
+                  - =(hostPort): 0
+            containers:
+              - =(ports):
+                  - =(hostPort): 0

--- a/policies/templates/restrict-host-ingress.yaml
+++ b/policies/templates/restrict-host-ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: {{ include "policies.fullname" . }}-restrict-host-ingress
+  labels:
+    {{- include "policies.labels" . | nindent 4 }}
+  annotations:
+    policies.kyverno.io/title: Restrict Ingress hostname
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/subject: Ingress
+    policies.kyverno.io/description: >-
+        An ingress resource needs to define a valid hostname. 
+        This policy ensures that the hostname follows the form {{ .Values.host }}.
+spec:
+  validationFailureAction: enforce
+  background: false
+  rules:
+  - name: restrict-ingress-hostnames
+    match:
+      resources:
+        kinds:
+        - Ingress
+      {{- with .Values.namespaceSelector }}
+        namespaceSelector:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    validate:
+      message: "The host name must be in the form {{ .Values.ingressHostnamePattern }}." 
+      pattern:
+        spec:
+          rules:
+          - host: {{ .Values.ingressHostnamePattern }}

--- a/policies/values.yaml
+++ b/policies/values.yaml
@@ -1,0 +1,12 @@
+# Default values for policies.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+ingressHostnamePattern: s??????.sandbox.crownlabs.polito.it
+
+namespaceSelector:
+  matchExpressions:
+    - key: crownlabs.polito.it/type
+      operator: In
+      values:
+      - sandbox


### PR DESCRIPTION
# Description

This PR aims to apply some cluster-wide policies based on Kyverno framework. Three main security requirements: 
- Avoid creation of privileged pods
- Avoid creation of load balancer services (i.e avoid creation of routable IPs) and nodePort
- Force specific name for ingress hostname

These policies are applied only to sandbox namespaces. 

