### PR TITLE
Thanos: reduce retention and increase PVC size

### DIFF
--- a/infrastructure/monitoring/kube-prometheus-stack/thanos/thanos-values.yaml
+++ b/infrastructure/monitoring/kube-prometheus-stack/thanos/thanos-values.yaml
@@ -84,7 +84,7 @@ bucketCacheConfig: ""
 existingObjstoreSecret: thanos-objstore-config
 ## @param existingObjstoreSecretItems Optional item list for specifying a custom Secret key. If so, path should be objstore.yml
 ##
-existingObjstoreSecretItems: 
+existingObjstoreSecretItems:
   - key: thanos.yaml
     path: objstore.yml
 ## @param existingServiceAccount Provide a common service account to be shared with all components
@@ -117,7 +117,7 @@ query:
     sidecarsNamespace: ""
   ## @param query.stores Statically configure store APIs to connect with Thanos Query
   ##
-  stores: 
+  stores:
     - dnssrv+_grpc._tcp.kube-prometheus-stack-thanos-discovery.monitoring.svc.cluster.local
   ## @param query.sdConfig Query Service Discovery Configuration
   ## Specify content for servicediscovery.yml
@@ -1076,7 +1076,7 @@ queryFrontend:
 bucketweb:
   ## @param bucketweb.enabled Enable/disable Thanos Bucket Web component
   ##
-  enabled: false
+  enabled: true
   ## @param bucketweb.logLevel Thanos Bucket Web log level
   ##
   logLevel: info
@@ -1469,7 +1469,7 @@ compactor:
   ##
   retentionResolutionRaw: 30d
   retentionResolution5m: 30d
-  retentionResolution1h: 10y
+  retentionResolution1h: 365d
   ## @param compactor.consistencyDelay Minimum age of fresh (non-compacted) blocks before they are being processed
   ##
   consistencyDelay: 30m
@@ -1827,7 +1827,7 @@ compactor:
       - ReadWriteOnce
     ## @param compactor.persistence.size PVC Storage Request for data volume
     ##
-    size: 75Gi 
+    size: 100Gi
     ## @param compactor.persistence.annotations Annotations for the PVC
     ##
     annotations: {}


### PR DESCRIPTION
# Description

This PR applies a few modifications to the thanos values file, to:
* Reduce the retention period to 1y, to save object store space
* Increase the compactor PVC size
* Enable the bucketweb ui (although not exposed), to graphically view the storage blocks. 

Fixes # (issue)

# How Has This Been Tested?

Apply the modifications to the CrownLabs cluster.
