### PR TITLE
Nextcloud: use fixed image and change storage class

### DIFF
--- a/infrastructure/file-sharing/README.md
+++ b/infrastructure/file-sharing/README.md
@@ -37,7 +37,7 @@ For more information about the Postgres Operator please refer to this [README.md
 ## CEPHfs for the PVC
 The Ceph File System, or CephFS, is a POSIX-compliant file system built on top of Ceph’s distributed object store, RADOS. CephFS endeavors to provide a state-of-the-art, multi-use, highly available,
 and performant file store for a variety of applications, including traditional use-cases like shared home directories, HPC scratch space, and distributed workflow shared storage.
-Now we will create a Persistent Volume Claim which will be attached to the Nextcloud Deployment. Applying the [nextcloud-pvc.yaml](manifests/nextcloud-pvc.yaml) we will have a PVC of 700 Gi in size provisioned
+Now we will create a Persistent Volume Claim which will be attached to the Nextcloud Deployment. Applying the [nextcloud-pvc.yaml](manifests/nextcloud-pvc.yaml) we will have a PVC of 500 Gi in size provisioned
 by the **csi-cephfs** storage class.
 ```bash
 kubectl create -n nextcloud -f nextcloud-pvc.yaml

--- a/infrastructure/file-sharing/manifests/nextcloud-deployment.yaml
+++ b/infrastructure/file-sharing/manifests/nextcloud-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       volumes:
       - name: nextcloud-data
         persistentVolumeClaim:
-          claimName: nextcloud-cephfs-pvc
+          claimName: nextcloud-data
       - name: php-configmap-volume
         configMap:
           name: nextcloud-php-configmap
@@ -49,8 +49,7 @@ spec:
           - key: custom-php.ini
             path: custom-php.ini
       containers:
-      - image: nextcloud:production-apache
-        imagePullPolicy: Always
+      - image: nextcloud:24.0.1-apache
         name: nextcloud
         env:
         - name: POSTGRES_HOST

--- a/infrastructure/file-sharing/manifests/nextcloud-pvc.yaml
+++ b/infrastructure/file-sharing/manifests/nextcloud-pvc.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: nextcloud-cephfs-pvc
+  name: nextcloud-data
 spec:
   accessModes:
   - ReadWriteMany
   resources:
     requests:
-      storage: 700Gi
-  storageClassName: csi-cephfs
+      storage: 500Gi
+  storageClassName: rook-cephfs-primary


### PR DESCRIPTION
# Description

This PR updates the nextcloud manifests to:
* Use a fixed version, and prevent unexpected version changes
* Migrate the PVC to the primary storage class, for better performance

Fixes # (issue)

# How Has This Been Tested?
Checking the successful outcome of the modifications on CrownLabs
