### PR TITLE
Revert "Bump got from 9.6.0 to 11.8.5 in /qlkube"

### DIFF
--- a/qlkube/package.json
+++ b/qlkube/package.json
@@ -37,7 +37,7 @@
     "dotenv": "^9.0.2",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
-    "got": "^11.8.5",
+    "got": "^9.6.0",
     "graphql": "^15.5.1",
     "graphql-tools": "^8.1.0",
     "oasgraph": "^0.14.3",

--- a/qlkube/yarn.lock
+++ b/qlkube/yarn.lock
@@ -973,7 +973,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-cacheable-request@^7.0.2:
+cacheable-request@^7.0.1:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
   integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
@@ -1874,17 +1874,17 @@ global-dirs@^2.0.1:
   dependencies:
     ini "1.3.7"
 
-got@^11.8.0, got@^11.8.5:
-  version "11.8.5"
-  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
-  integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
+got@^11.8.0:
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.2.tgz#7abb3959ea28c31f3576f1576c1effce23f33599"
+  integrity sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==
   dependencies:
     "@sindresorhus/is" "^4.0.0"
     "@szmarczak/http-timer" "^4.0.5"
     "@types/cacheable-request" "^6.0.1"
     "@types/responselike" "^1.0.0"
     cacheable-lookup "^5.0.3"
-    cacheable-request "^7.0.2"
+    cacheable-request "^7.0.1"
     decompress-response "^6.0.0"
     http2-wrapper "^1.0.0-beta.5.2"
     lowercase-keys "^2.0.0"


### PR DESCRIPTION
Reverts netgroup-polito/CrownLabs#796, as currently not working.