### PR TITLE
Disable servicelinks, generate container hostname if not standard mode

### DIFF
--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -19,6 +19,7 @@ package forge
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -135,6 +136,8 @@ func PodSpec(instance *clv1alpha2.Instance, environment *clv1alpha2.Environment,
 		AutomountServiceAccountToken:  pointer.Bool(false),
 		TerminationGracePeriodSeconds: pointer.Int64(containersTerminationGracePeriod),
 		InitContainers:                InitContainers(instance, environment, opts),
+		EnableServiceLinks:            pointer.Bool(false),
+		Hostname:                      InstanceHostname(environment),
 	}
 	return spec
 }
@@ -454,4 +457,13 @@ func MyDriveMountPath(environment *clv1alpha2.Environment) string {
 	}
 
 	return MyDriveDefaultMountPath
+}
+
+// InstanceHostname forges the hostname of the instance:
+// empty for standard mode (will use pod name) or the lowercase mode otherwise.
+func InstanceHostname(environment *clv1alpha2.Environment) string {
+	if environment.Mode != clv1alpha2.ModeStandard {
+		return strings.ToLower(string(environment.Mode))
+	}
+	return ""
 }

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -249,6 +249,14 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 			Expect(spec.AutomountServiceAccountToken).To(PointTo(BeFalse()))
 		})
 
+		It("Should disable service links", func() {
+			Expect(spec.EnableServiceLinks).To(PointTo(BeFalse()))
+		})
+
+		It("Should set the container hostname accordingly", func() {
+			Expect(spec.Hostname).To(Equal(forge.InstanceHostname(&environment)))
+		})
+
 		When("the environment type is Standalone", func() {
 			When("the environment mode is Standard", ContainersWhenBody(PodSpecContainersCase{
 				Mode:            clv1alpha2.ModeStandard,
@@ -1158,4 +1166,43 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 		}))
 	})
 
+	Describe("The forge.InstanceHostname function", func() {
+		var actual string
+
+		JustBeforeEach(func() {
+			actual = forge.InstanceHostname(&environment)
+		})
+
+		type EnvModeCase struct {
+			EnvMode        clv1alpha2.EnvironmentMode
+			ExpectedOutput string
+		}
+
+		WhenBody := func(c EnvModeCase) func() {
+			return func() {
+				BeforeEach(func() {
+					environment.Mode = c.EnvMode
+				})
+
+				It("Should return the correct hostname", func() {
+					Expect(actual).To(Equal(c.ExpectedOutput))
+				})
+			}
+		}
+
+		When("the environment mode is Exercise", WhenBody(EnvModeCase{
+			EnvMode:        clv1alpha2.ModeExercise,
+			ExpectedOutput: "exercise",
+		}))
+
+		When("the environment mode is Exam", WhenBody(EnvModeCase{
+			EnvMode:        clv1alpha2.ModeExam,
+			ExpectedOutput: "exam",
+		}))
+
+		When("the environment mode is Standard", WhenBody(EnvModeCase{
+			EnvMode:        clv1alpha2.ModeStandard,
+			ExpectedOutput: "",
+		}))
+	})
 })


### PR DESCRIPTION
# Description

This PR 
- sets `enableServiceLinks: false` on instance deployments so that a possibly high number of environment variables is not set (service links);
- forges the container hostname based on the environment mode so that the instance name is hidden (when not default env mode)

# Testing
- [x] go tests
- [ ] staging