### PR TITLE
EnforceWorkdir & Submission Jobs TTL

### DIFF
--- a/infrastructure/monitoring/loki-promtail/README.md
+++ b/infrastructure/monitoring/loki-promtail/README.md
@@ -40,7 +40,7 @@ To install the chart with the release name `loki` and apply the configuration sp
 helm upgrade --install --namespace monitoring --create-namespace loki -f loki-values.yaml grafana/loki
 ```
 
-The [loki-values.yaml](./loki-values.yaml) defines the Loki configuration. You must configure the values file according to your specifications; here, we modified it to suit the CrownLabs needs. The main changes are below, the original values file is located [here](https://github.com/grafana/helm-charts/blob/main/charts/loki/values.yaml).
+The [loki-values.yaml](./loki-values.yaml) defines the Loki configuration. You must configure the values file according to your specifications; here, we modified it to suit the CrownLabs needs. The main changes are below, the original values file is located [here](https://github.com/grafana/helm-charts/blob/loki-2.8.1/charts/loki/values.yaml).
 
 ```yaml
   ingester:

--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -160,6 +160,10 @@ type ContainerStartupOpts struct {
 	ContentPath string `json:"contentPath,omitempty"`
 	// Arguments to be passed to the application container on startup
 	StartupArgs []string `json:"startupArgs,omitempty"`
+	// Whether forcing the container working directory to be the same as the contentPath (or default mydrive path if not specified)
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	EnforceWorkdir bool `json:"enforceWorkdir"`
 }
 
 // +kubebuilder:object:root=true

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -92,6 +92,12 @@ spec:
                             be mounted and into which, if given in SourceArchiveURL,
                             will be extracted the archive
                           type: string
+                        enforceWorkdir:
+                          default: false
+                          description: Whether forcing the container working directory
+                            to be the same as the contentPath (or default mydrive
+                            path if not specified)
+                          type: boolean
                         sourceArchiveURL:
                           description: URL from which GET the archive to be extracted
                             into ContentPath


### PR DESCRIPTION
# Description

This PR includes the following changes:
- add TTLSecondsAfterFinished (fixed to 5 minutes) to Submission Jobs: in case of success or failure, after such time the Job is deleted. In case of successful submission this provides simple cleanup. In case of error, this should trigger the recreation of the Job from the submission controller.
- add the EnforceWorkdir directive to the ContainerStartupOpts field in the template. In case this directive is set to true, the application container workdir will be enforced to be the one specified by the contentPath (if set) or to the default mydrive path (otherwise). When enforcing the workdir, volume mount is ensured onto the workdir. 
- changes websockify probe from TCP to HTTP

# How Has This Been Tested?
- [x] Unit tests
- [x] Staging
