### PR TITLE
Infrastructure: bump velero version and add selector

### DIFF
--- a/infrastructure/backup/velero-helm-values.yaml
+++ b/infrastructure/backup/velero-helm-values.yaml
@@ -6,7 +6,7 @@
 # enabling restic). Required.
 image:
   repository: velero/velero
-  tag: v1.8.1
+  tag: v1.9.0
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -53,13 +53,13 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-csi
-  #   image: velero/velero-plugin-for-csi:v0.2.0
+  #   image: velero/velero-plugin-for-csi:v0.3.0
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
   #       name: plugins
   - name: velero-plugin-for-aws
-    image: velero/velero-plugin-for-aws:v1.4.1
+    image: velero/velero-plugin-for-aws:v1.5.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - mountPath: /target
@@ -419,6 +419,13 @@ schedules:
       ttl: "720h"
       includedNamespaces:
       - "*"
+      labelSelector:
+        # Do not backup resources originated from CrownLabs instances
+        # This also prevents the bug afflicting VMs: https://github.com/kubevirt/kubevirt/issues/7750
+        matchExpressions:
+        - key: crownlabs.polito.it/instance
+          operator: DoesNotExist
+
 
 # Velero ConfigMaps.
 # Eg:
@@ -428,7 +435,7 @@ schedules:
 #       velero.io/plugin-config: ""
 #       velero.io/restic: RestoreItemAction
 #     data:
-#       image: velero/velero-restic-restore-helper:v1.8.1
+#       image: velero/velero-restic-restore-helper:v1.9.0
 configMaps: {}
 
 ##


### PR DESCRIPTION
# Description

This PR bumps the version of velero, and introduces a label selector to filter out the resources originated from CrownLabs instances, in order to prevent the partial failures due to the [kubevirt/velero issue](https://github.com/kubevirt/kubevirt/issues/7750).

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Deploying the updated manifest in the cluster, and checking that the backup completed correctly
