### PR TITLE
Github actions: fix build all

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           # The optional images (i.e., user environments) are built only in case of version tags,
           # and when the /deploy-staging event is dispatched with the build-all flag
           [[ "${{ steps.version.outputs.version }}" != "" || \
-            ("${{ github.event_name }}" == "repository_dispatch" && github.event.client_payload.slash_command.args.all == 'build-all') ]] && \
+            ("${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.client_payload.slash_command.args.all }}" == "build-all") ]] && \
             echo "::set-output name=filter-optional-images::false" || \
             echo "::set-output name=filter-optional-images::true"
 


### PR DESCRIPTION
# Description

This PR fixes an issue in the build GitHub action, which caused the `/deploy-staging build-all` command not to work properly.
