### PR TITLE
Helm include global version upon packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,10 +258,14 @@ jobs:
         run: |
           curl -sSL "https://github.com/helm/chart-releaser/releases/download/v1.4.0/chart-releaser_1.4.0_linux_amd64.tar.gz" | tar -xz
 
+      - name: Enforce global version
+        run: |
+          sed -i 's|  version: "" # default set while packaging|  version: "${{ needs.configure.outputs.version }}"|' deploy/crownlabs/values.yaml
+
       - name: Package helm chart
         run: |
           # the output should be in the .cr-release-packages since cr index expects to find it there to create the helm index
-          helm dependency update deploy/crownlabs && helm package deploy/crownlabs --version "${{ needs.configure.outputs.version }}" --app-version "${{ needs.configure.outputs.version }}" --destination .cr-release-packages
+          helm package deploy/crownlabs --depencency-update --version "${{ needs.configure.outputs.version }}" --app-version "${{ needs.configure.outputs.version }}" --destination .cr-release-packages
 
       - uses: ncipollo/release-action@v1
         with:

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
-  version: ""
+  version: "" # default set while packaging
 
 createClusterRoles: true
 


### PR DESCRIPTION
# Description

This PR fixes a limitation given by Helm's design that does not permit to propagate values from a chart to its subcharts, by running sed on the values file of the main CrownLabs chart.
