### PR TITLE
operators makefile: fix command and align operator selector label

### DIFF
--- a/operators/Makefile
+++ b/operators/Makefile
@@ -90,11 +90,11 @@ run-instance: generate
 				--instances-auth-url=crownlabs.polito.it/app/instances/auth\
 				--nextcloud-base-url=crownlabs.polito.it/cloud
 
-#the double target below is used to set DOMAIN for local targets 
+#the double target below is used to set DOMAIN for local targets
 #reference: https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html
 run-instance-local: DOMAIN="crownlabsfake.polito.it"
 run-instance-local: samples-local install-local run-instance
-	
+
 
 run-tenant: generate
 	go run cmd/tenant-operator/main.go\
@@ -107,7 +107,7 @@ run-tenant: generate
 				--kc-target-client=$(KEYCLOAK_TARGET_CLIENT)\
 				--nc-url=$(NEXTCLOUD_URL)\
 				--nc-tenant-operator-user=$(NEXTCLOUD_TENANT_OPERATOR_USER)\
-				--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)
+				--nc-tenant-operator-psw=$(NEXTCLOUD_TENANT_OPERATOR_PSW)\
 				--enable-webhooks=false
 
 install-local: manifests
@@ -118,7 +118,7 @@ python-dependencies:
 	pip3 install -r ./build/delete-stale-instances/requirements.txt
 
 samples-local:
-	kubectl apply -f ./samples/	
+	kubectl apply -f ./samples/
 
 clean-local:
 	kubectl delete -f ./samples/

--- a/operators/samples/tenant.yml
+++ b/operators/samples/tenant.yml
@@ -3,7 +3,7 @@ kind: Tenant
 metadata:
   name: john.doe
   labels:
-    reconcile: "true"
+    crownlabs.polito.it/operator-selector: local
 spec:
   firstName: John
   lastName: Doe

--- a/operators/samples/workspace.yml
+++ b/operators/samples/workspace.yml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: tea
   labels:
-    reconcile: "true"
+    crownlabs.polito.it/operator-selector: local
 spec:
   prettyName: A cup of tea from the queen
   quota:
@@ -16,7 +16,7 @@ kind: Workspace
 metadata:
   name: coffee
   labels:
-    reconcile: "true"
+    crownlabs.polito.it/operator-selector: local
 spec:
   prettyName: Just coffee
   quota:
@@ -28,6 +28,8 @@ apiVersion: crownlabs.polito.it/v1alpha1
 kind: Workspace
 metadata:
   name: chill-pepper
+  labels:
+    crownlabs.polito.it/operator-selector: local
 spec:
   prettyName: A bit spicy
   quota:


### PR DESCRIPTION
# Description

This PR fixes a broken command in the operators makefile, and aligns the samples labels with the default operator selector.