### PR TITLE
Student insertion from csv: fix issue with (**)

### DIFF
--- a/frontend/src/components/accountPage/UploadProgressModal/UploadProgressContent.tsx
+++ b/frontend/src/components/accountPage/UploadProgressModal/UploadProgressContent.tsx
@@ -79,7 +79,9 @@ const UploadProgressContent: FC<IUploadProgressContent> = props => {
       key: user[CSVFields.userid].trim(),
       name: capitalizeName(user[CSVFields.name]) ?? '',
       surname:
-        capitalizeName(user[CSVFields.surname_inserted].replace('(*)', '')) ??
+        capitalizeName(
+          user[CSVFields.surname_inserted].replace(/\(\*+\)/, '')
+        ) ??
         capitalizeName(user[CSVFields.surname]) ??
         '',
       userid: handleUserId(user[CSVFields.userid]) ?? '',

--- a/operators/pkg/tenant-controller/tenant_controller.go
+++ b/operators/pkg/tenant-controller/tenant_controller.go
@@ -586,14 +586,12 @@ func updateTnLabels(tn *crownlabsv1alpha2.Tenant, tenantExistingWorkspaces []cro
 		delete(tn.Labels, NoWorkspacesLabel)
 	}
 
-	cleanedFirstName := cleanName(tn.Spec.FirstName)
-	cleanedLastName := cleanName(tn.Spec.LastName)
-	tn.Labels["crownlabs.polito.it/first-name"] = *cleanedFirstName
-	tn.Labels["crownlabs.polito.it/last-name"] = *cleanedLastName
+	tn.Labels["crownlabs.polito.it/first-name"] = cleanName(tn.Spec.FirstName)
+	tn.Labels["crownlabs.polito.it/last-name"] = cleanName(tn.Spec.LastName)
 	return nil
 }
 
-func cleanName(name string) *string {
+func cleanName(name string) string {
 	okRegex := regexp.MustCompile("^[a-zA-Z0-9_]+$")
 	name = strings.ReplaceAll(name, " ", "_")
 
@@ -608,7 +606,8 @@ func cleanName(name string) *string {
 			name = strings.Replace(name, v, "", 1)
 		}
 	}
-	return &name
+
+	return strings.Trim(name, "_")
 }
 
 // cleanWorkspaceLabels removes all the labels of a workspace from a tenant.


### PR DESCRIPTION
# Description

This PR fixes an issue concerning students' insertion from CSV, which occurs when the surname contains the `(**)` string (used by the portal to signal certain conditions). This includes the frontend, to appropriately remove it, and the backend, to prevent issues with names that end with a space (after the removal of invalid characters).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Deploy staging
