### PR TITLE
Add disableControls to Template

### DIFF
--- a/operators/api/v1alpha2/template_types.go
+++ b/operators/api/v1alpha2/template_types.go
@@ -96,6 +96,11 @@ type Environment struct {
 
 	// +kubebuilder:default=false
 
+	// For VNC based containers, hide the noVNC control bar when true
+	DisableControls bool `json:"disableControls,omitempty"`
+
+	// +kubebuilder:default=false
+
 	// Whether the environment should be persistent (i.e. preserved when the
 	// corresponding instance is terminated) or not.
 	Persistent bool `json:"persistent,omitempty"`

--- a/operators/deploy/crds/crownlabs.polito.it_templates.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_templates.yaml
@@ -109,6 +109,11 @@ spec:
                             type: string
                           type: array
                       type: object
+                    disableControls:
+                      default: false
+                      description: For VNC based containers, hide the noVNC control
+                        bar when true
+                      type: boolean
                     environmentType:
                       description: The type of environment to be instantiated, among
                         VirtualMachine, Container, CloudVM and Standalone.

--- a/operators/pkg/forge/containers.go
+++ b/operators/pkg/forge/containers.go
@@ -207,7 +207,7 @@ func WebsockifyContainer(opts *ContainerEnvOpts, environment *clv1alpha2.Environ
 	AddContainerArg(&websockifyContainer, "http-addr", fmt.Sprintf(":%d", GUIPortNumber))
 	AddContainerArg(&websockifyContainer, "base-path", IngressGUICleanPath(instance))
 	AddContainerArg(&websockifyContainer, "metrics-addr", fmt.Sprintf(":%d", MetricsPortNumber))
-	AddContainerArg(&websockifyContainer, "show-controls", fmt.Sprint(environment.Mode == clv1alpha2.ModeStandard))
+	AddContainerArg(&websockifyContainer, "show-controls", fmt.Sprint(!environment.DisableControls))
 	AddContainerArg(&websockifyContainer, "instmetrics-server-endpoint", opts.InstMetricsEndpoint)
 	AddContainerArg(&websockifyContainer, "pod-name", fmt.Sprintf("$(%s)", PodNameEnvName))
 	AddContainerArg(&websockifyContainer, "cpu-limit", fmt.Sprintf("$(%s)", AppCPULimitsEnvName))

--- a/operators/pkg/forge/containers_test.go
+++ b/operators/pkg/forge/containers_test.go
@@ -399,6 +399,25 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 			Expect(actual.Env).To(ConsistOf(expected.Env))
 		})
 
+		disableCtrlsWhenBody := func(disableCtrls bool) func() {
+			return func() {
+				BeforeEach(func() {
+					environment.DisableControls = disableCtrls
+				})
+
+				It("Should set the related argument accordingly", func() {
+					Expect(actual.Args).To(ContainElement(
+						fmt.Sprintf("--show-controls=%v", !disableCtrls),
+					))
+					Expect(actual.Args).NotTo(ContainElement(
+						fmt.Sprintf("--show-controls=%v", disableCtrls),
+					))
+				})
+			}
+		}
+		When("disableControls is true", disableCtrlsWhenBody(true))
+		When("disableControls is false", disableCtrlsWhenBody(false))
+
 		When("the environment mode is Standard", func() {
 			BeforeEach(func() {
 				instance.UID = instanceName
@@ -409,7 +428,7 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 					fmt.Sprintf("--http-addr=:%d", forge.GUIPortNumber),
 					fmt.Sprintf("--base-path=%s", forge.IngressGUICleanPath(&instance)),
 					fmt.Sprintf("--metrics-addr=:%d", forge.MetricsPortNumber),
-					"--show-controls=true",
+					fmt.Sprintf("--show-controls=%v", !environment.DisableControls),
 					fmt.Sprintf("--instmetrics-server-endpoint=%s", opts.InstMetricsEndpoint),
 					fmt.Sprintf("--pod-name=$(%s)", forge.PodNameEnvName),
 					fmt.Sprintf("--cpu-limit=$(%s)", forge.AppCPULimitsEnvName),
@@ -428,7 +447,7 @@ var _ = Describe("Containers and Deployment spec forging", func() {
 					fmt.Sprintf("--http-addr=:%d", forge.GUIPortNumber),
 					fmt.Sprintf("--base-path=%s", forge.IngressGUICleanPath(&instance)),
 					fmt.Sprintf("--metrics-addr=:%d", forge.MetricsPortNumber),
-					"--show-controls=false",
+					fmt.Sprintf("--show-controls=%v", !environment.DisableControls),
 					fmt.Sprintf("--instmetrics-server-endpoint=%s", opts.InstMetricsEndpoint),
 					fmt.Sprintf("--pod-name=$(%s)", forge.PodNameEnvName),
 					fmt.Sprintf("--cpu-limit=$(%s)", forge.AppCPULimitsEnvName),


### PR DESCRIPTION
# Description

This PR adds a `DisableControls` flag (defaulting to **false**) to the Template CRD, in order to specify the behavior of the _noVNC control bar_ based on that flag instead of the `EnvironmentType`.

# How Has This Been Tested?
- [x] Unit tests
- [ ] Staging
