### PR TITLE
Bump golangci-lint version and fix issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check linting
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43.0
+          version: v1.50.1
           working-directory: operators
           args: --timeout=600s
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -86,7 +85,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
   # - lll
@@ -101,14 +99,12 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
   # - testpackage
     - typecheck
     - unconvert
   # - unparam
     - unused
-    - varcheck
     - whitespace
   # - wsl
 

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -35,9 +35,7 @@ manifests: controller-gen
 # Install gci if not available
 gci:
 ifeq (, $(shell which gci))
-	@{ \
-	go get github.com/daixiang0/gci@v0.2.9 ;\
-	}
+	@go install github.com/daixiang0/gci@v0.7.0
 endif
 
 # Install addlicense if not available
@@ -52,7 +50,7 @@ endif
 fmt: gci addlicense
 	go mod tidy
 	go fmt ./...
-	find $(pwd) -type f -name '*.go' -a ! -name '*zz_generated*' -exec gci -local github.com/netgroup-polito/CrownLabs -w {} \;
+	find $(pwd) -type f -name '*.go' -a ! -name '*zz_generated*' -exec gci write -s standard -s default -s "prefix(github.com/netgroup-polito/CrownLabs)" {} \;
 	find . -type f -name '*.go' -exec addlicense -l apache -c "Politecnico di Torino" -y "2020-$(shell date +%Y)" {} \;
 
 # Run go vet against code

--- a/operators/cmd/bastion-operator/main.go
+++ b/operators/cmd/bastion-operator/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main contains the entrypoint for the bastion operator.
 package main
 
 import (

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main contains the entrypoint for the instance operator.
 package main
 
 import (

--- a/operators/cmd/instmetrics/main.go
+++ b/operators/cmd/instmetrics/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main contains the entrypoint for the instance metrics collector.
 package main
 
 import (
@@ -64,6 +65,7 @@ func main() {
 
 	go func() {
 		http.Handle("/ready", &instmetrics.ReadinessProbeHandler{RuntimeClient: remoteRuntimeClient, Log: log.WithName("probeHandler"), Ready: false})
+		//nolint:gosec // The server is meant to be accessed only by well behaving clients, hence there are no issues with timeouts.
 		if err = http.ListenAndServe(":8081", nil); err != nil {
 			log.Error(err, "Error serving readiness probe")
 		}

--- a/operators/cmd/tenant-operator/main.go
+++ b/operators/cmd/tenant-operator/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package main contains the entrypoint for the tenant operator.
 package main
 
 import (

--- a/operators/go.mod
+++ b/operators/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/onsi/gomega v1.11.0
 	github.com/prometheus/client_golang v1.10.0
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/text v0.3.7
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/operators/pkg/forge/utils.go
+++ b/operators/pkg/forge/utils.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 
 	petname "github.com/dustinkirkland/golang-petname"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,7 +90,7 @@ func CanonicalSandboxName(name string) string {
 
 // RandomInstancePrettyName generates a random name of 2 capitalized words.
 func RandomInstancePrettyName() string {
-	return strings.Title(petname.Generate(2, " "))
+	return cases.Title(language.AmericanEnglish).String(petname.Generate(2, " "))
 }
 
 // CapResourceQuantity compares a resource.Quantity value with a given cap and returns the lower.

--- a/operators/pkg/forge/virtualmachines.go
+++ b/operators/pkg/forge/virtualmachines.go
@@ -29,9 +29,9 @@ import (
 const (
 	urlDockerPrefix = "docker://"
 
-	// nolint:gosec // The constant refers to the name of a secret, and it is not a secret itself.
+	//nolint:gosec // The constant refers to the name of a secret, and it is not a secret itself.
 	registryCredentialsSecretName = "registry-credentials"
-	// nolint:gosec // The constant refers to the name of a secret, and it is not a secret itself.
+	//nolint:gosec // The constant refers to the name of a secret, and it is not a secret itself.
 	cdiSecretName = "registry-credentials-cdi"
 
 	volumeRootName      = "root"

--- a/operators/pkg/instctrl/statusinspection_test.go
+++ b/operators/pkg/instctrl/statusinspection_test.go
@@ -142,9 +142,9 @@ var _ = Describe("Status Inspection", func() {
 		ForgeResourceQuotaExceededDeployment := func(desired, ready int32) *appsv1.Deployment {
 			deployment := ForgeDeployment(desired, ready)
 			deployment.Status.Conditions = []appsv1.DeploymentCondition{{
-				Type:   "ReplicaFailure",
-				Status: corev1.ConditionTrue,
-				Reason: "FailedCreate",
+				Type:    "ReplicaFailure",
+				Status:  corev1.ConditionTrue,
+				Reason:  "FailedCreate",
 				Message: "pod is forbidden: exceeded quota:	crownlabs-resource-quota",
 			}}
 			return deployment

--- a/operators/pkg/instmetrics/instmetrics.pb.go
+++ b/operators/pkg/instmetrics/instmetrics.pb.go
@@ -7,10 +7,11 @@
 package instmetrics
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/operators/pkg/instmetrics/instmetrics_grpc.pb.go
+++ b/operators/pkg/instmetrics/instmetrics_grpc.pb.go
@@ -8,6 +8,7 @@ package instmetrics
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/operators/pkg/tenant-controller/sandbox_test.go
+++ b/operators/pkg/tenant-controller/sandbox_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package tenant_controller_test
 
 import (

--- a/operators/pkg/tenant-controller/suite_test.go
+++ b/operators/pkg/tenant-controller/suite_test.go
@@ -51,7 +51,7 @@ const kcAccessToken = "keycloak-token"
 const kcTargetRealm = "targetRealm"
 const kcTargetClientID = "targetClientId"
 
-//  keycloak variables
+// keycloak variables.
 var mKcClient *mocks.MockGoCloak
 var mToken *gocloak.JWT = &gocloak.JWT{AccessToken: kcAccessToken}
 var reqActions = []string{"UPDATE_PASSWORD", "VERIFY_EMAIL"}
@@ -65,7 +65,7 @@ var kcA = KcActor{
 	EmailActionsLifeSpanS: emailActionLifespan,
 }
 
-//  nextcloud variables
+// nextcloud variables.
 var mNcA *mocks.NcHandlerMock
 
 func TestAPIs(t *testing.T) {


### PR DESCRIPTION
# Description

This PR bumps golangci-lint to the latest version, removes deprecated linters, and fixes the reported issues.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing tests
- [x] Ensuring no lining errors are reported.
