### PR TITLE
Handle tenant.LastLogin validation on the tenantwh

### DIFF
--- a/operators/api/v1alpha2/tenant_types.go
+++ b/operators/api/v1alpha2/tenant_types.go
@@ -59,6 +59,9 @@ type TenantSpec struct {
 	// The last name of the Tenant.
 	LastName string `json:"lastName"`
 
+	// The last login timestamp.
+	LastLogin metav1.Time `json:"lastLogin"`
+
 	// +kubebuilder:validation:Pattern="^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 
 	// The email associated with the Tenant, which will be used to log-in
@@ -123,6 +126,7 @@ type TenantStatus struct {
 	// Whether all subscriptions and resource creations succeeded or an error
 	// occurred. In case of errors, the other status fields provide additional
 	// information about which problem occurred.
+	// Will be set to true even when personal workspace is intentionally deleted.
 	Ready bool `json:"ready"`
 
 	// The amount of resources associated with this Tenant, either inherited from the Workspaces in which he/she is enrolled, or manually overridden.

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -71,6 +71,10 @@ spec:
               firstName:
                 description: The first name of the Tenant.
                 type: string
+              lastLogin:
+                description: The last login timestamp.
+                format: date-time
+                type: string
               lastName:
                 description: The last name of the Tenant.
                 type: string
@@ -141,6 +145,7 @@ spec:
             required:
             - email
             - firstName
+            - lastLogin
             - lastName
             type: object
           status:
@@ -204,7 +209,8 @@ spec:
               ready:
                 description: Whether all subscriptions and resource creations succeeded
                   or an error occurred. In case of errors, the other status fields
-                  provide additional information about which problem occurred.
+                  provide additional information about which problem occurred. Will
+                  be set to true even when personal workspace is intentionally deleted.
                 type: boolean
               sandboxNamespace:
                 description: The namespace that can be freely used by the Tenant to

--- a/operators/pkg/tenantwh/validating_test.go
+++ b/operators/pkg/tenantwh/validating_test.go
@@ -16,6 +16,7 @@ package tenantwh_test
 
 import (
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -128,6 +129,34 @@ var _ = Describe("Validating webhook", func() {
 			})
 			It("should allow the change", func() {
 				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("lastLogin is changed within the LastLoginToleration", func() {
+			BeforeEach(func() {
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{
+					LastLogin: metav1.Time{
+						Time: time.Now().Add(tenantwh.LastLoginToleration / 2),
+					},
+				}}
+			})
+			It("should allow the change", func() {
+				Expect(response.Allowed).To(BeTrue())
+			})
+		})
+
+		When("lastLogin too far from now (abs(lastLogin-now)) > LastLoginToleration)", func() {
+			BeforeEach(func() {
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{
+					LastLogin: metav1.Time{
+						Time: time.Now().Add(tenantwh.LastLoginToleration + time.Millisecond),
+					},
+				}}
+			})
+			It("should deny the change", func() {
+				Expect(response.Allowed).To(BeFalse())
+				Expect(response.Result.Code).To(BeNumerically("==", http.StatusForbidden))
+				Expect(response.Result.Reason).NotTo(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
# Description

This PR adds validation logic to the validating webhook for the tenant resource (handled by the tenant operator), depends on #821.

# How Has This Been Tested?

- [x] Unit tests
- [ ] Staging
