### PR TITLE
Harbor documentation: fix dead link

### DIFF
--- a/infrastructure/docker-registry/README.md
+++ b/infrastructure/docker-registry/README.md
@@ -23,7 +23,7 @@ You should use the Harbor Registry if you want to:
 - leverage the high-speed network that connects your servers, avoiding to consume precious Internet bandwidth to transfer images stored in the Docker Hub public service.
 - leverage [Proxy Cache](https://goharbor.io/docs/2.7.0/administration/configure-proxy-cache/) functionalities, to not exceed Docker Hub’s rate limiting policy.
 - have a [vulnerability scanner](https://goharbor.io/docs/2.7.0/administration/vulnerability-scanning/) to detect possible image vulnerabilities.
-- manage your [Helm Charts](https://goharbor.io/docs/edge/working-with-projects/working-with-images/managing-helm-charts/).
+- manage your [Helm Charts](https://goharbor.io/docs/2.7.0/working-with-projects/working-with-images/managing-helm-charts/).
 
 Finally, consider that, in this Kubernetes setup, users instantiate mainly VMs, whose image may be rather large. Allowing users to download the VM image locally, instead of from a remote server, would greatly impact on their quality of experience in term of time required to start their service.
 


### PR DESCRIPTION
# Description

This PR fixes a dead link present in the Harbor (docker registry) documentation.