### PR TITLE
Fix ssh keys being removed at login time

### DIFF
--- a/frontend/src/contexts/TenantContext.tsx
+++ b/frontend/src/contexts/TenantContext.tsx
@@ -105,7 +105,7 @@ const TenantContextProvider: FC<PropsWithChildren<{}>> = props => {
         patchJson: getTenantPatchJson({
           lastLogin: new Date(),
         }),
-        manager: 'frontend-tenant-new-keys',
+        manager: 'frontend-tenant-lastlogin',
       },
       onError: apolloErrorCatcher,
     });


### PR DESCRIPTION
# Description

The copy-paste phenomenon made the manager key for the tenant update query that happens at login to match the one used during ssh keys update. This made ssh keys being deleted when the user first opened the dashboard (while setting the new lastLogin value).