### PR TITLE
Tenant Autoenrolling feature - api & operator

### DIFF
--- a/infrastructure/certificate-provisioning/README.md
+++ b/infrastructure/certificate-provisioning/README.md
@@ -134,7 +134,7 @@ helm install kubed appscode/kubed \
 
 ### Secret synchronization
 
-Once kubed is installed, secrets can be duplicated in multiple namespaces, and kept synchronized, by adding the ad-hoc annotation [[6]](https://appscode.com/products/kubed/v0.12.0-rc.2/welcome/):
+Once kubed is installed, secrets can be duplicated in multiple namespaces, and kept synchronized, by adding the ad-hoc annotation [[6]](https://cert-manager.io/v1.1-docs/faq/kubed/#syncing-arbitrary-secrets-across-namespaces-using-kubed):
 
 ```yaml
 ...

--- a/operators/api/v1alpha1/workspace_types.go
+++ b/operators/api/v1alpha1/workspace_types.go
@@ -24,10 +24,29 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// +kubebuilder:validation:Enum="";withApproval;immediate
+
+// WorkspaceAutoenroll defines auto-enroll capabilities of the Workspace.
+type WorkspaceAutoenroll string
+
+const (
+	// AutoenrollNone -> no auto-enroll capabilities.
+	AutoenrollNone WorkspaceAutoenroll = ""
+
+	// AutoenrollWithApproval -> auto-enroll is enabled, but requires approval by a manager.
+	AutoenrollWithApproval WorkspaceAutoenroll = "withApproval"
+
+	// AutoenrollImmediate -> auto-enroll is enabled, and the user can enroll himself/herself.
+	AutoenrollImmediate WorkspaceAutoenroll = "immediate"
+)
+
 // WorkspaceSpec is the specification of the desired state of the Workspace.
 type WorkspaceSpec struct {
 	// The human-readable name of the Workspace.
 	PrettyName string `json:"prettyName"`
+
+	// AutoEnroll capability definition. If omitted, no autoenroll features will be added.
+	AutoEnroll WorkspaceAutoenroll `json:"autoEnroll,omitempty"`
 
 	// The amount of resources associated with this workspace, and inherited by enrolled tenants.
 	Quota WorkspaceResourceQuota `json:"quota"`

--- a/operators/api/v1alpha2/common.go
+++ b/operators/api/v1alpha2/common.go
@@ -52,5 +52,8 @@ const (
 // WorkspaceLabelPrefix is the prefix of a label assigned to a tenant indicating it is subscribed to a workspace.
 const WorkspaceLabelPrefix = "crownlabs.polito.it/workspace-"
 
+// WorkspaceLabelAutoenroll is the label assigned to a workspace in which autoenroll is enabled.
+const WorkspaceLabelAutoenroll = "crownlabs.polito.it/autoenroll"
+
 // TnOperatorFinalizerName is the name of the finalizer corresponding to the tenant operator.
 const TnOperatorFinalizerName = "crownlabs.polito.it/tenant-operator"

--- a/operators/api/v1alpha2/tenant_types.go
+++ b/operators/api/v1alpha2/tenant_types.go
@@ -23,7 +23,7 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
-// +kubebuilder:validation:Enum=manager;user
+// +kubebuilder:validation:Enum=manager;user;candidate
 
 // WorkspaceUserRole is an enumeration of the different roles that can be
 // associated to a Tenant in a Workspace.
@@ -36,6 +36,9 @@ const (
 	// User -> a Tenant with User role can only interact with his/her own
 	// environments (e.g. VMs) within that Workspace.
 	User WorkspaceUserRole = "user"
+	// Candidate -> a Tenant with Candidate role wants to be added to the
+	// Workspace, but he/she is not yet enrolled.
+	Candidate WorkspaceUserRole = "candidate"
 
 	// SVCTenantName -> name of a system/service tenant to which other resources might belong.
 	SVCTenantName string = "service-tenant"

--- a/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_tenants.yaml
@@ -132,6 +132,7 @@ spec:
                       enum:
                       - manager
                       - user
+                      - candidate
                       type: string
                   required:
                   - name

--- a/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
+++ b/operators/deploy/crds/crownlabs.polito.it_workspaces.yaml
@@ -49,6 +49,14 @@ spec:
             description: WorkspaceSpec is the specification of the desired state of
               the Workspace.
             properties:
+              autoEnroll:
+                description: AutoEnroll capability definition. If omitted, no autoenroll
+                  features will be added.
+                enum:
+                - ""
+                - withApproval
+                - immediate
+                type: string
               prettyName:
                 description: The human-readable name of the Workspace.
                 type: string

--- a/operators/pkg/utils/common.go
+++ b/operators/pkg/utils/common.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 )
 
 // ParseDockerDirectory returns a valid Docker image directory.
@@ -89,4 +91,10 @@ func Contains(slice []string, value string) bool {
 func CheckSingleLabel(obj client.Object, label, value string) bool {
 	labels := obj.GetLabels()
 	return labels != nil && labels[label] == value
+}
+
+// AutoEnrollEnabled checks if the specified WorkspaceAutoenroll enables any feature.
+func AutoEnrollEnabled(autoEnroll clv1alpha1.WorkspaceAutoenroll) bool {
+	return autoEnroll == clv1alpha1.AutoenrollImmediate ||
+		autoEnroll == clv1alpha1.AutoenrollWithApproval
 }


### PR DESCRIPTION
# Description

Workspaces can now set AutoEnroll features with two flags in the Spec (no auto enroll / enroll request and manager's approval / completely self enroll)
Tenants can now autoenroll in Workspaces enabled (with `user` or `candidate` role depending on settings)

Tenants are able to edit themselves in order to add or remove Workspaces with `autoEnroll` enabled

# How Has This Been Tested?

Environment:
KinD with CRDs installed, Tenant Operator and Webhooks running. Keycloak not configured.

- [ ] through `kubectl` api - Tenant edit as root user
- [ ] through `kubectl` api - Tenant edit as tenant user role (`kubectl --as <tenantname>`)
- [ ] through `kubectl` api - Workspace edit as root user
- [ ] through `graphql` - Tenant & Workspace edit as default user
