### PR TITLE
enforce macAddress consistency across VM restarts

### DIFF
--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -88,7 +88,7 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 		// Afterwards, the only modification to the specifications is performed to configure the running flag.
 		vm.Spec.Running = ptr.To(instance.Spec.Running)
 		vm.SetLabels(forge.EnvironmentObjectLabels(vm.GetLabels(), instance, environment))
-		if len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) > 0 && len(vmi.Status.Interfaces) > 0 && vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress == "" {
+		if vm.Spec.Template != nil && len(vm.Spec.Template.Spec.Domain.Devices.Interfaces) > 0 && len(vmi.Status.Interfaces) > 0 && vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress == "" {
 			vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = vmi.Status.Interfaces[0].MAC
 		}
 		return ctrl.SetControllerReference(instance, &vm, r.Scheme)


### PR DESCRIPTION
# Description

This pull request enhances the handling of MAC address persistence between `VirtualMachine` (VM) and `VirtualMachineInstance` (VMI) objects in the instance controller. The main improvement ensures that the MAC address assigned to a running VMI is enforced and persisted into the corresponding VM spec, preventing unnecessary MAC address changes and improving network stability. Additionally, a dedicated test is added to verify this behavior.

**Code refactoring:**

* The retrieval of the VMI object was moved earlier in the reconciliation logic to support MAC address enforcement, and the redundant retrieval later in the function was removed to streamline the code.

Closes #911 