### PR TITLE
Qlkube nodes labels

### DIFF
--- a/qlkube/deploy/qlkube/templates/clusterrole.yaml
+++ b/qlkube/deploy/qlkube/templates/clusterrole.yaml
@@ -17,3 +17,11 @@ rules:
       - list
       - watch
   {{- end }}
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch

--- a/qlkube/deploy/qlkube/templates/configmap.yaml
+++ b/qlkube/deploy/qlkube/templates/configmap.yaml
@@ -51,11 +51,11 @@ data:
 
     module.exports = { wrappers };
 
-  {{ .Values.configuration.nodesLabelsRegexes.fileName }}: |
+  {{ .Values.configuration.nodesLabels.fileName }}: |
     const regexes = [
-      {{- range .Values.configuration.nodesLabelsRegexes.regexes }}
+      {{- range .Values.configuration.nodesLabels.regexes }}
       {{ . }},
       {{- end }}
     ];
 
-    module.exports = { nodesLabels };
+    module.exports = { regexes };

--- a/qlkube/deploy/qlkube/templates/configmap.yaml
+++ b/qlkube/deploy/qlkube/templates/configmap.yaml
@@ -50,3 +50,12 @@ data:
     ];
 
     module.exports = { wrappers };
+
+  {{ .Values.configuration.nodesLabelsRegexes.fileName }}: |
+    const regexes = [
+      {{- range .Values.configuration.nodesLabelsRegexes.regexes }}
+      {{ . }},
+      {{- end }}
+    ];
+
+    module.exports = { nodesLabels };

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
           - name: configuration
             mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.wrappers.fileName }}"
             subPath: "{{ .Values.configuration.wrappers.fileName }}"
+          - name: configuration
+            mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.nodesLabelsRegexes.fileName }}"
+            subPath: "{{ .Values.configuration.nodesLabelsRegexes.fileName }}"
       volumes:
       - name: configuration
         configMap:

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -58,8 +58,8 @@ spec:
             mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.wrappers.fileName }}"
             subPath: "{{ .Values.configuration.wrappers.fileName }}"
           - name: configuration
-            mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.nodesLabelsRegexes.fileName }}"
-            subPath: "{{ .Values.configuration.nodesLabelsRegexes.fileName }}"
+            mountPath: "{{ .Values.configuration.mountPath }}/{{ .Values.configuration.nodesLabels.fileName }}"
+            subPath: "{{ .Values.configuration.nodesLabels.fileName }}"
       volumes:
       - name: configuration
         configMap:

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -42,7 +42,9 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 60
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -51,7 +51,7 @@ configuration:
 
   # This wrappers configuration maps to the current content
   # of the src/nodesLabelsRegexes.js file. Must be a subset of exposedAPIs.
-  nodesLabelsRegexes:
+  nodesLabels:
     fileName: nodesLabelsRegexes.js
     regexes:
       - /crownlabs\.polito\.it.+/

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -49,6 +49,13 @@ configuration:
         parents:
           - itPolitoCrownlabsV1alpha2Instance
 
+  # This wrappers configuration maps to the current content
+  # of the src/nodesLabelsRegexes.js file. Must be a subset of exposedAPIs.
+  nodesLabelsRegexes:
+    fileName: nodesLabelsRegexes.js
+    regexes:
+      - /crownlabs\.polito\.it.+/
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/qlkube/src/index.js
+++ b/qlkube/src/index.js
@@ -18,7 +18,7 @@ const { createSchema, oasToGraphQlSchema, joinSchemas } = require('./schema');
 const { subscriptions } = require('./subscriptions');
 const { kinformer } = require('./informer');
 const { getBearerToken, logger } = require('./utils');
-const { nodesLabelsSchema } = require('./nodesLabelsSchema');
+const { schema: nodeLabelsSchema } = require('./nodeLabels');
 
 dotenv.config();
 
@@ -45,7 +45,7 @@ async function main() {
 
   global.kubeSchema = kubeSchema;
 
-  const schemas = [{ schema: kubeSchema }, { schema: nodesLabelsSchema }];
+  const schemas = [{ schema: kubeSchema }, { schema: nodeLabelsSchema }];
 
   try {
     const registryOas = await getOpenApiSpec(registryUrl, ['docs/openapi.json']);

--- a/qlkube/src/index.js
+++ b/qlkube/src/index.js
@@ -18,11 +18,15 @@ const { createSchema, oasToGraphQlSchema, joinSchemas } = require('./schema');
 const { subscriptions } = require('./subscriptions');
 const { kinformer } = require('./informer');
 const { getBearerToken, logger } = require('./utils');
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const nodesLabels = require('./informer').nodesLabels;
+
 
 dotenv.config();
 
 async function main() {
-  const inCluster = process.env.IN_CLUSTER !== 'false';
+  //const inCluster = process.env.IN_CLUSTER !== 'false';
+  inCluster = false;
   logger.info({ inCluster }, 'cluster mode configured');
 
   const kubeApiUrl = inCluster
@@ -44,7 +48,31 @@ async function main() {
 
   global.kubeSchema = kubeSchema;
 
-  const schemas = [{ schema: kubeSchema }];
+  typeDefs = `type Query {
+    getLabels: [Label!]
+  }
+  type Label {
+    key: String!
+    value: String
+  }
+  `; 
+  resolvers = {
+    Query: {
+      getLabels: async (parent, args, context, info) => {
+        const labels = [];
+
+        nodesLabels.forEach((label) => {
+          const [key, value] = label.split("=");
+          labels.push({ key, value });
+        });
+
+        return labels;
+      }
+    },
+  };
+  const nodesLabelsSchema = makeExecutableSchema({ typeDefs, resolvers });
+
+  const schemas = [{ schema: kubeSchema }, { schema: nodesLabelsSchema}];
 
   try {
     const registryOas = await getOpenApiSpec(registryUrl, ['docs/openapi.json']);

--- a/qlkube/src/informer.js
+++ b/qlkube/src/informer.js
@@ -1,6 +1,7 @@
 const k8s = require('@kubernetes/client-node');
 const { publishEvent } = require('./pubsub');
 const { logger } = require('./utils');
+const regexes = require('./nodesLabelsRegexes');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -9,6 +10,39 @@ kc.loadFromDefault();
  * @type k8s.AuthorizationV1Api
  */
 const authApi = kc.makeApiClient(k8s.AuthorizationV1Api);
+
+/**
+ * @type k8s.CoreV1Api
+ */
+const nonApiClient = kc.makeApiClient(k8s.CoreV1Api);
+const nodesLabels = new Set();  // All the labels that match the regexes. To be shown on the frontend.
+
+async function updateNodesLabels() {
+  try{
+    nodesLabels.clear();
+    const nodes = await nonApiClient.listNode();
+    nodes.body.items.forEach(node => {
+      const labels = node.metadata.labels;
+      if (labels) {
+        console.log('Node labels: ', labels);
+        console.log('Regexes: ', regexes);
+        Object.keys(labels).forEach((label) => {
+          regexes.regexes.forEach((regex) => {
+            if(regex.test(label)){
+              nodesLabels.add(`${label}=${labels[label]}`);
+            }
+          });
+        });
+      }
+    });
+    console.log('Matching node labels: ', nodesLabels);
+  } catch (e) {
+    logger.error(e.message, 'Node labels error');
+  }
+};
+
+setInterval(updateNodesLabels, 60000);
+updateNodesLabels();
 
 async function canWatchResource(
   token,
@@ -80,4 +114,4 @@ function kinformer(sub) {
   informer.start();
 }
 
-module.exports = { kinformer, canWatchResource };
+module.exports = { kinformer, canWatchResource, nodesLabels };

--- a/qlkube/src/informer.js
+++ b/qlkube/src/informer.js
@@ -80,4 +80,4 @@ function kinformer(sub) {
   informer.start();
 }
 
-module.exports = { kinformer, canWatchResource, kc };
+module.exports = { kinformer, canWatchResource, kubeClient: kc };

--- a/qlkube/src/nodeLabels.js
+++ b/qlkube/src/nodeLabels.js
@@ -1,7 +1,7 @@
 const { makeExecutableSchema } = require('@graphql-tools/schema');
 const k8s = require('@kubernetes/client-node');
 const { regexes } = require('./nodesLabelsRegexes');
-const { kc: kubeClient } = require('./informer');
+const { kubeClient } = require('./informer');
 const { logger } = require('./utils');
 
 const apiClient = kubeClient.makeApiClient(k8s.CoreV1Api);
@@ -52,5 +52,6 @@ const resolvers = {
   },
 };
 
-module.exports = { nodesLabelsSchema: makeExecutableSchema({ typeDefs, resolvers }) };
-module.exports.updateNodesLabels = updateNodesLabels;
+module.exports = {
+  schema: makeExecutableSchema({ typeDefs, resolvers }),
+};

--- a/qlkube/src/nodesLabelsRegexes.js
+++ b/qlkube/src/nodesLabelsRegexes.js
@@ -1,0 +1,9 @@
+// This file serves development/testing purposes only.
+// When qlkube is deployed with Helm, it is overwritten by an equivalent
+// one automatically generated from the configuration therein specified.
+
+const regexes = [
+    /crownlabs\.polito\.it.+/,
+];
+
+module.exports = { regexes };

--- a/qlkube/src/nodesLabelsRegexes.js
+++ b/qlkube/src/nodesLabelsRegexes.js
@@ -3,7 +3,7 @@
 // one automatically generated from the configuration therein specified.
 
 const regexes = [
-    /crownlabs\.polito\.it.+/,
+  /crownlabs\.polito\.it.+/,
 ];
 
 module.exports = { regexes };

--- a/qlkube/src/nodesLabelsSchema.js
+++ b/qlkube/src/nodesLabelsSchema.js
@@ -1,0 +1,56 @@
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const k8s = require('@kubernetes/client-node');
+const { regexes } = require('./nodesLabelsRegexes');
+const { kc: kubeClient } = require('./informer');
+const { logger } = require('./utils');
+
+const apiClient = kubeClient.makeApiClient(k8s.CoreV1Api);
+const nodesLabels = new Set();
+
+async function updateNodesLabels() {
+  try {
+    nodesLabels.clear();
+    const nodes = await apiClient.listNode();
+    nodes.body.items.forEach((node) => {
+      const { labels } = node.metadata;
+      if (labels) {
+        Object.keys(labels).forEach((label) => {
+          regexes.forEach((regex) => {
+            if (regex.test(label)) {
+              nodesLabels.add(`${label}=${labels[label]}`);
+            }
+          });
+        });
+      }
+    });
+  } catch (e) {
+    logger.error(e.message, 'Node labels error');
+  }
+}
+
+updateNodesLabels();
+setInterval(updateNodesLabels, 6000);
+
+const typeDefs = `
+type Query {
+    getLabels: [Label!]
+}
+type Label {
+    key: String!
+    value: String
+}`;
+const resolvers = {
+  Query: {
+    getLabels: async () => { // parent, args, context, info
+      const labels = [];
+      nodesLabels.forEach((label) => {
+        const [key, value] = label.split('=');
+        labels.push({ key, value });
+      });
+      return labels;
+    },
+  },
+};
+
+module.exports = { nodesLabelsSchema: makeExecutableSchema({ typeDefs, resolvers }) };
+module.exports.updateNodesLabels = updateNodesLabels;

--- a/qlkube/src/utils.js
+++ b/qlkube/src/utils.js
@@ -33,6 +33,7 @@ function getBearerToken(connectionParams) {
       extensions: {
         code: 'FORBIDDEN',
         connectionParams,
+        http: { status: 403 },
       },
     });
   }
@@ -41,6 +42,7 @@ function getBearerToken(connectionParams) {
     throw new GraphQLError('Token Error! Token not valid!', {
       extensions: {
         code: 'FORBIDDEN',
+        http: { status: 403 },
       },
     });
   }


### PR DESCRIPTION
# Description
This PR aims to enable the retrieval of the labels attached to the cluster nodes, by using GraphQL. It is part of a project made to let CrownLabs users choose a specific node (server) when creating a new instance, if they are allowed.


