### PR TITLE
Add VSCode+Rust as Standalone

### DIFF
--- a/provisioning/standalone/vscode/base/Dockerfile
+++ b/provisioning/standalone/vscode/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV CODESERVER_VERSION=4.22.0
+ENV CODESERVER_VERSION=4.98.2
 ENV SERVICE_URL=https://open-vsx.org/vscode/gallery
 ENV ITEM_URL=https://open-vsx.org/vscode/item
 

--- a/provisioning/standalone/vscode/base/start.sh
+++ b/provisioning/standalone/vscode/base/start.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 shopt -s dotglob
 
+TARGETDIR="$VSCODE_SRV_DIR/workspace"
+
 # Check if in the passed arguments is specified to disable workspace through the option --disable-marketplace
 for ARGUMENT in "$@"; do
     if [ "$ARGUMENT" == "--disable-marketplace" ] ; then
@@ -14,7 +16,9 @@ for ARGUMENT in "$@"; do
             echo "[Persistent Only Feature]" > "$VSCODE_SRV_DIR/workspace/.vscode/.startup"
             echo "If your CrownLabs instance is persistent, delete this file if you want to reset the workspace on next startup." >> "$VSCODE_SRV_DIR/workspace/.vscode/.startup"
         fi
-
+    fi
+    if [ -d "$ARGUMENT" ] ; then
+        TARGETDIR="$ARGUMENT"
     fi
 done
 
@@ -26,4 +30,4 @@ code-server \
 --user-data-dir "$VSCODE_SRV_DIR/data" \
 --extensions-dir "$VSCODE_SRV_DIR/extensions" \
 --disable-telemetry \
-"$VSCODE_SRV_DIR/workspace"
+"$TARGETDIR"

--- a/provisioning/standalone/vscode/rust/.gitignore
+++ b/provisioning/standalone/vscode/rust/.gitignore
@@ -1,0 +1,1 @@
+!project/.vscode

--- a/provisioning/standalone/vscode/rust/Dockerfile
+++ b/provisioning/standalone/vscode/rust/Dockerfile
@@ -1,0 +1,36 @@
+# syntax = edrevo/dockerfile-plus
+
+INCLUDE+ ./base/Dockerfile
+
+ENV SUDO_FORCE_REMOVE yes
+ENV RSPATH=${VSCODE_SRV_DIR}/.cargo/bin
+
+COPY ./rust/settings.json ${VSCODE_SRV_DIR}/data/User/settings.json
+COPY --chown=${USER}:${USER} ./rust/project /example_project/project
+COPY ./rust/config.toml ${RSPATH}/../config.toml
+
+# Install required packages and remove apt and useless/dangerous packages
+RUN apt-get update && \
+    apt-get install -y curl gcc bash-completion && \
+    curl -L -o /tmp/codelldb-linux-x64.vsix https://github.com/vadimcn/codelldb/releases/download/v1.11.4/codelldb-linux-x64.vsix && \
+    apt-get clean && \
+    apt-get remove --autoremove --purge -y apt sudo --allow-remove-essential
+
+# Install extensions and setup permissions
+RUN code-server --extensions-dir ${VSCODE_SRV_DIR}/extensions --install-extension formulahendry.code-runner && \
+    code-server --extensions-dir ${VSCODE_SRV_DIR}/extensions --install-extension rust-lang.rust-analyzer && \
+    code-server --extensions-dir ${VSCODE_SRV_DIR}/extensions --install-extension /tmp/codelldb-linux-x64.vsix && \
+    rm -f /tmp/codelldb-linux-x64.vsix && \
+    chown -R ${USER}:${USER} ${VSCODE_SRV_DIR} && \
+    chown -R ${USER}:${USER} /example_project
+
+# Install Rust
+USER ${USER}
+ENV HOME=${VSCODE_SRV_DIR}
+RUN curl -sSf https://sh.rustup.rs | /bin/bash -s -- -y -v && \
+    ${RSPATH}/rustup component remove rust-docs && \
+    ${RSPATH}/rustup completions bash >> $HOME/.bashrc && \
+    ${RSPATH}/rustup completions bash cargo >> $HOME/.bashrc
+
+ENTRYPOINT [ "/start.sh" ]
+CMD [ "--load-example", "/vscode/workspace/project" ]

--- a/provisioning/standalone/vscode/rust/config.toml
+++ b/provisioning/standalone/vscode/rust/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "/tmp/target"

--- a/provisioning/standalone/vscode/rust/project/.vscode/launch.json
+++ b/provisioning/standalone/vscode/rust/project/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "/tmp/target/debug/${workspaceFolderBasename}",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "cargo build"
+        }
+    ]
+}

--- a/provisioning/standalone/vscode/rust/project/.vscode/tasks.json
+++ b/provisioning/standalone/vscode/rust/project/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+        "label": "cargo build",
+        "type": "shell",
+        "command": "cargo build",
+        "problemMatcher": [
+            "$rustc"
+        ],
+        "group": {
+            "kind": "build",
+            "isDefault": true
+        }
+        }
+    ]
+}

--- a/provisioning/standalone/vscode/rust/project/Cargo.toml
+++ b/provisioning/standalone/vscode/rust/project/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "project"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/provisioning/standalone/vscode/rust/project/src/main.rs
+++ b/provisioning/standalone/vscode/rust/project/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/provisioning/standalone/vscode/rust/settings.json
+++ b/provisioning/standalone/vscode/rust/settings.json
@@ -1,0 +1,12 @@
+{
+    "security.workspace.trust.enabled": false,
+    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.startupEditor": "none",
+    "window.menuBarVisibility": "visible",
+    "output.smartScroll.enabled": false,
+    "chat.commandCenter.enabled": false,
+    "code-runner.executorMap": {
+        "rust": "cd $dir.. && cargo run"
+    },
+    "rust-analyzer.cache.warmup": false
+}


### PR DESCRIPTION
# Description

This PR wants to introduce a new Standalone container for Rust programming on VSCode.
The extensions installed are the ones suggested by VSCode [here](https://code.visualstudio.com/docs/languages/rust) as of 2025-04-04.

Fixes necessity of PoliTo's course Programmazione di Sistema (02GRSOV).

~ Alessio Giliberti, Chiara Mercurio