### PR TITLE
Bastion SSH Tracker

### DIFF
--- a/.github/workflows/build-matrix.json
+++ b/.github/workflows/build-matrix.json
@@ -21,6 +21,13 @@
         "harbor-project": "crownlabs-core"
     },
     {
+        "component": "bastion-ssh-tracker",
+        "context": "./operators",
+        "dockerfile": "./operators/build/ssh-tracker/Dockerfile",
+        "build-args": "COMPONENT=bastion-ssh-tracker",
+        "harbor-project": "crownlabs-core"
+    },
+    {
         "component": "exam-agent",
         "context": "./operators",
         "dockerfile": "./operators/build/golang-common/Dockerfile",

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -y \
+          libpcap-dev
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: configure
     steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -y \
+          libpcap-dev
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -100,6 +105,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: configure
     steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends -y \
+          libpcap-dev
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/deploy/crownlabs/Chart.yaml
+++ b/deploy/crownlabs/Chart.yaml
@@ -41,7 +41,7 @@ dependencies:
   condition: tenant-operator.enabled
 
 - name: bastion-operator
-  version: "0.1.0"
+  version: "0.1.1"
   repository: file://../../operators/deploy/bastion-operator
   condition: bastion-operator.enabled
 

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -107,12 +107,18 @@ bastion-operator:
   image:
     repositoryBastion: crownlabs/ssh-bastion
     repositorySidecar: crownlabs/bastion-operator
+    repositoryTrackerSidecar: crownlabs/bastion-ssh-tracker
   rbacResourcesName: crownlabs-bastion-operator
   serviceAnnotations: {}
   service:
     type: LoadBalancer
     port: 22
     externalTrafficPolicy: Cluster
+  configurations:
+    sshTrackerInterface: any
+    sshTrackerPort: 22
+    sshTrackerSnaplen: 1600
+    sshTrackerMetricsAddr: ":8082"
 
 image-list:
   replicaCount: 1

--- a/operators/build/ssh-tracker/Dockerfile
+++ b/operators/build/ssh-tracker/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.21-alpine AS builder
+WORKDIR /tmp/builder
+
+RUN apk add --no-cache build-base libpcap-dev linux-headers
+
+COPY go.mod ./go.mod
+COPY go.sum ./go.sum
+RUN  go mod download
+
+ARG COMPONENT
+RUN test -n "$COMPONENT" || ( echo "The COMPONENT argument is unset. Aborting" && false )
+
+COPY . ./
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=$(go env GOARCH) go build -ldflags="-s -w -linkmode=external -extldflags=-static" ./cmd/$COMPONENT
+
+
+FROM alpine:3.19
+
+RUN apk update && \
+    apk add --no-cache ca-certificates libpcap tcpdump && \
+    update-ca-certificates && \
+    rm -rf /var/cache/apk/*
+
+ARG COMPONENT
+COPY --from=builder /tmp/builder/$COMPONENT /usr/bin/$COMPONENT
+RUN ln -s /usr/bin/$COMPONENT /usr/bin/crownlabs-component
+
+ENTRYPOINT [ "/usr/bin/crownlabs-component" ]

--- a/operators/cmd/bastion-ssh-tracker/main.go
+++ b/operators/cmd/bastion-ssh-tracker/main.go
@@ -1,0 +1,139 @@
+// Copyright 2020-2025 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main contains the entrypoint for the bastion ssh tracker.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	tracker "github.com/netgroup-polito/CrownLabs/operators/pkg/bastion-ssh-tracker"
+)
+
+var (
+	trackerRunning atomic.Bool
+	trackerError   error
+	healthMutex    sync.RWMutex
+)
+
+func main() {
+	// Ensure to correctly handle tracker graceful shutdown
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
+
+	iface := flag.String("ssh-tracker-interface", "any", "The network interface on which the SSH tracker will listen for connections.")
+	port := flag.Int("ssh-tracker-port", 22, "The port on which the SSH tracker will listen for connections.")
+	snaplen := flag.Int("ssh-tracker-snaplen", 1600, "The snaplen for the SSH tracker.")
+	metricsAddr := flag.String("ssh-tracker-metrics-addr", ":8082", "The address the metric endpoint binds to.")
+
+	flag.Parse()
+
+	metricsHandler := http.NewServeMux()
+	metricsHandler.Handle("/metrics", promhttp.Handler())
+	metricsServer := &http.Server{
+		Addr:         *metricsAddr,
+		Handler:      metricsHandler,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  15 * time.Second,
+	}
+
+	go func() {
+		log.Println("Starting metrics server on", *metricsAddr)
+		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("Metrics server error: %v", err)
+		}
+	}()
+
+	healthHandler := http.NewServeMux()
+	healthHandler.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		healthMutex.RLock()
+		defer healthMutex.RUnlock()
+		if trackerError != nil {
+			http.Error(w, trackerError.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !trackerRunning.Load() {
+			http.Error(w, "Tracker is not running", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	healthHandler.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		healthMutex.RLock()
+		defer healthMutex.RUnlock()
+		if trackerError != nil {
+			http.Error(w, trackerError.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !trackerRunning.Load() {
+			http.Error(w, "Tracker is not running", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	healthServer := &http.Server{
+		Addr:         ":8083",
+		Handler:      healthHandler,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  15 * time.Second,
+	}
+
+	go func() {
+		log.Println("Starting health check server on :8083")
+		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("Health check server error: %v", err)
+		}
+	}()
+
+	sshTracker := tracker.NewSSHTracker()
+	go func() {
+		trackerRunning.Store(true)
+		log.Printf("Starting SSH tracker on interface %s, port %d, snaplen %d", *iface, *port, *snaplen)
+		if err := sshTracker.Start(*iface, *port, *snaplen); err != nil {
+			healthMutex.Lock()
+			trackerError = err
+			healthMutex.Unlock()
+			trackerRunning.Store(false)
+			log.Printf("Tracker stopped with error: %v", err)
+		}
+	}()
+
+	<-signalCh
+	log.Println("Signal received, shutting down...")
+	trackerRunning.Store(false)
+	sshTracker.Stop()
+
+	// Graceful shutdown for HTTP servers
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_ = metricsServer.Shutdown(ctx)
+	_ = healthServer.Shutdown(ctx)
+
+	log.Println("Shutdown complete")
+}

--- a/operators/deploy/bastion-operator/Chart.yaml
+++ b/operators/deploy/bastion-operator/Chart.yaml
@@ -15,6 +15,6 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 icon: https://crownlabs.polito.it/images/logo.svg

--- a/operators/deploy/bastion-operator/templates/deployment.yaml
+++ b/operators/deploy/bastion-operator/templates/deployment.yaml
@@ -46,35 +46,66 @@ spec:
               name : host-keys
           resources:
             {{- toYaml .Values.resources.bastion | nindent 12 }}
-        - name: {{ .Chart.Name }}-sidecar
+        - name: {{ .Chart.Name }}-operator-sidecar
           securityContext:
-            {{- toYaml .Values.securityContexts.sidecar | nindent 12 }}
+            {{- toYaml .Values.securityContexts.operatorSidecar | nindent 12 }}
           image: "{{ .Values.image.repositorySidecar }}:{{ include "bastion-operator.version" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-            - name: metrics
+            - name: op-metrics
               containerPort: 8080
               protocol: TCP
-            - name: probes
+            - name: op-probes
               containerPort: 8081
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: probes
+              port: op-probes
             initialDelaySeconds: 3
             periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /ready
-              port: probes
+              port: op-probes
             initialDelaySeconds: 3
             periodSeconds: 3
           volumeMounts:
             - name: authorized-keys
               mountPath: /auth-keys-vol
           resources:
-            {{- toYaml .Values.resources.sidecar | nindent 12 }}
+            {{- toYaml .Values.resources.operatorSidecar | nindent 12 }}
+        - name: {{ .Chart.Name }}-tracker-sidecar
+          securityContext:
+            {{- toYaml .Values.securityContexts.trackerSidecar | nindent 12 }}
+          image: "{{ .Values.image.repositoryTrackerSidecar }}:{{ include "bastion-operator.version" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--ssh-tracker-interface={{ .Values.configurations.sshTrackerInterface }}"
+            - "--ssh-tracker-port={{ .Values.configurations.sshTrackerPort }}"
+            - "--ssh-tracker-snaplen={{ .Values.configurations.sshTrackerSnaplen }}"
+            - "--ssh-tracker-metrics-addr={{ .Values.configurations.sshTrackerMetricsAddr }}"
+          ports:
+            - name: trk-metrics
+              containerPort: 8082
+              protocol: TCP
+            - name: trk-probes
+              containerPort: 8083
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: trk-probes
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: trk-probes
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          resources:
+            {{- toYaml .Values.resources.trackerSidecar | nindent 12 }}
       volumes:
         - name: authorized-keys
           emptyDir: {}

--- a/operators/deploy/bastion-operator/templates/service-metrics.yaml
+++ b/operators/deploy/bastion-operator/templates/service-metrics.yaml
@@ -9,8 +9,12 @@ spec:
   type: ClusterIP
   ports:
     - port: 8080
-      targetPort: metrics
+      targetPort: op-metrics
       protocol: TCP
-      name: metrics
+      name: op-metrics
+    - port: 8082
+      targetPort: trk-metrics
+      protocol: TCP
+      name: trk-metrics
   selector:
     {{- include "bastion-operator.selectorLabels" . | nindent 4 }}

--- a/operators/deploy/bastion-operator/templates/servicemonitor.yaml
+++ b/operators/deploy/bastion-operator/templates/servicemonitor.yaml
@@ -9,7 +9,10 @@ spec:
   endpoints:
     - interval: 15s
       path: /metrics
-      port: metrics
+      port: op-metrics
+    - interval: 15s
+      path: /metrics
+      port: trk-metrics
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/operators/deploy/bastion-operator/values.yaml
+++ b/operators/deploy/bastion-operator/values.yaml
@@ -4,9 +4,16 @@
 
 replicaCount: 1
 
+configurations:
+  sshTrackerInterface: any
+  sshTrackerPort: 22
+  sshTrackerSnaplen: 1600
+  sshTrackerMetricsAddr: ":8082"
+
 image:
   repositoryBastion: crownlabs/ssh-bastion
   repositorySidecar: crownlabs/bastion-operator
+  repositoryTrackerSidecar: crownlabs/bastion-ssh-tracker
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart version.
   tag: ""
@@ -29,7 +36,7 @@ securityContexts:
     runAsUser: 1000
     runAsGroup: 1000
     privileged: false
-  sidecar:
+  operatorSidecar:
     capabilities:
       drop:
       - ALL
@@ -37,6 +44,18 @@ securityContexts:
     runAsNonRoot: true
     runAsUser: 100000
     runAsGroup: 100000
+    privileged: false
+  trackerSidecar:
+    capabilities:
+      drop:
+      - ALL
+      add:
+      - NET_RAW
+      - NET_ADMIN
+    readOnlyRootFilesystem: true
+    runAsNonRoot: false
+    runAsUser: 0
+    runAsGroup: 0
     privileged: false
   hookCreateSecret:
     capabilities:
@@ -48,6 +67,7 @@ securityContexts:
     runAsGroup: 65534
     privileged: false
 
+
 resources:
   bastion:
     limits:
@@ -56,7 +76,14 @@ resources:
     requests:
       memory: 100Mi
       cpu: 100m
-  sidecar:
+  operatorSidecar:
+    limits:
+      memory: 250Mi
+      cpu: 1000m
+    requests:
+      memory: 100Mi
+      cpu: 100m
+  trackerSidecar:
     limits:
       memory: 250Mi
       cpu: 1000m

--- a/operators/go.mod
+++ b/operators/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/gopacket v1.1.19
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
@@ -63,7 +64,7 @@ require (
 	github.com/segmentio/ksuid v1.0.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
-	golang.org/x/net v0.22.0 // indirect
+	golang.org/x/net v0.22.0
 	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect

--- a/operators/go.sum
+++ b/operators/go.sum
@@ -106,6 +106,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -235,6 +237,8 @@ golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2F
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -335,6 +339,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=

--- a/operators/pkg/bastion-ssh-tracker/afpacket.go
+++ b/operators/pkg/bastion-ssh-tracker/afpacket.go
@@ -1,0 +1,131 @@
+// Copyright 2020-2025 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bastion_ssh_tracker
+
+// Copyright 2018 Google, Inc. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file in the root of the source
+// tree.
+
+// afpacket provides a simple zero-copy mechanism to read packet data.
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/afpacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcap"
+	"golang.org/x/net/bpf"
+)
+
+type afpacketHandle struct {
+	TPacket *afpacket.TPacket
+}
+
+func newAfpacketHandle(device string, snaplen, blockSize, numBlocks int,
+	useVLAN bool, timeout time.Duration) (*afpacketHandle, error) {
+	h := &afpacketHandle{}
+	var err error
+
+	if device == "any" {
+		h.TPacket, err = afpacket.NewTPacket(
+			afpacket.OptFrameSize(snaplen),
+			afpacket.OptBlockSize(blockSize),
+			afpacket.OptNumBlocks(numBlocks),
+			afpacket.OptAddVLANHeader(useVLAN),
+			afpacket.OptPollTimeout(timeout),
+			afpacket.SocketRaw,
+			afpacket.TPacketVersion3)
+	} else {
+		h.TPacket, err = afpacket.NewTPacket(
+			afpacket.OptInterface(device),
+			afpacket.OptFrameSize(snaplen),
+			afpacket.OptBlockSize(blockSize),
+			afpacket.OptNumBlocks(numBlocks),
+			afpacket.OptAddVLANHeader(useVLAN),
+			afpacket.OptPollTimeout(timeout),
+			afpacket.SocketRaw,
+			afpacket.TPacketVersion3)
+	}
+	return h, err
+}
+
+// ZeroCopyReadPacketData satisfies ZeroCopyPacketDataSource interface.
+func (h *afpacketHandle) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+	return h.TPacket.ZeroCopyReadPacketData()
+}
+
+// SetBPFFilter translates a BPF filter string into BPF RawInstruction and applies them.
+func (h *afpacketHandle) SetBPFFilter(filter string, snaplen int) (err error) {
+	pcapBPF, err := pcap.CompileBPFFilter(layers.LinkTypeEthernet, snaplen, filter)
+	if err != nil {
+		return err
+	}
+	bpfIns := []bpf.RawInstruction{}
+	for _, ins := range pcapBPF {
+		bpfIns2 := bpf.RawInstruction{
+			Op: ins.Code,
+			Jt: ins.Jt,
+			Jf: ins.Jf,
+			K:  ins.K,
+		}
+		bpfIns = append(bpfIns, bpfIns2)
+	}
+	if err := h.TPacket.SetBPF(bpfIns); err != nil {
+		return err
+	}
+	return nil
+}
+
+// LinkType returns ethernet link type.
+func (h *afpacketHandle) LinkType() layers.LinkType {
+	return layers.LinkTypeEthernet
+}
+
+// Close will close afpacket source.
+func (h *afpacketHandle) Close() {
+	h.TPacket.Close()
+}
+
+// SocketStats prints received, dropped, queue-freeze packet stats.
+func (h *afpacketHandle) SocketStats() (as afpacket.SocketStats, asv afpacket.SocketStatsV3, err error) {
+	return h.TPacket.SocketStats()
+}
+
+// afpacketComputeSize computes the block_size and the num_blocks in such a way that the
+// allocated mmap buffer is close to but smaller than target_size_mb.
+// The restriction is that the block_size must be divisible by both the
+// frame size and page size.
+func afpacketComputeSize(targetSizeMb, snaplen, pageSize int) (
+	frameSize, blockSize, numBlocks int, err error) {
+	if snaplen < pageSize {
+		frameSize = pageSize / (pageSize / snaplen)
+	} else {
+		frameSize = (snaplen/pageSize + 1) * pageSize
+	}
+
+	// 128 is the default from the gopacket library so just use that
+	blockSize = frameSize * 128
+	numBlocks = (targetSizeMb * 1024 * 1024) / blockSize
+
+	if numBlocks == 0 {
+		return 0, 0, 0, fmt.Errorf("interface buffersize is too small")
+	}
+
+	return frameSize, blockSize, numBlocks, nil
+}

--- a/operators/pkg/bastion-ssh-tracker/metrics.go
+++ b/operators/pkg/bastion-ssh-tracker/metrics.go
@@ -1,0 +1,33 @@
+// Copyright 2020-2025 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bastion_ssh_tracker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	sshConnections = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bastion_ssh_connections",
+			Help: "SSH connections detected from bastion to a target",
+		},
+		[]string{"destination_ip", "destination_port"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(sshConnections)
+}

--- a/operators/pkg/bastion-ssh-tracker/tracker.go
+++ b/operators/pkg/bastion-ssh-tracker/tracker.go
@@ -1,0 +1,186 @@
+// Copyright 2020-2025 Politecnico di Torino
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bastion_ssh_tracker allows tracking SSH connections from the bastion host to target hosts.
+package bastion_ssh_tracker
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+// SSHTracker tracks SSH connections and emits metrics.
+type SSHTracker struct {
+	stopCh chan struct{}
+	done   chan struct{}
+}
+
+// SSHConnection represents an SSH connection.
+type SSHConnection struct {
+	SourceIP   string
+	SourcePort uint16
+	DestIP     string
+	DestPort   uint16
+	StartTime  time.Time
+}
+
+// ConnectionEvent represents an event related to SSH connection.
+type ConnectionEvent struct {
+	Conn *SSHConnection
+}
+
+// processPacket is the handler called each time the BPF filter identifies a new
+// TCP session (TCP packet with only the SYN flag set). It extracts SSH
+// connection information from the packet layers and creates a ConnectionEvent
+// that will be processed by handleEvent to update Prometheus metrics.
+// This function acts as the bridge between raw network packet data and the
+// metrics collection system.
+func processPacket(packet gopacket.Packet, eventQueue chan ConnectionEvent) {
+	// Get IP layer
+	ipLayer := packet.Layer(layers.LayerTypeIPv4)
+	if ipLayer == nil {
+		return
+	}
+	ip, _ := ipLayer.(*layers.IPv4)
+
+	// Get TCP layer
+	tcpLayer := packet.Layer(layers.LayerTypeTCP)
+	if tcpLayer == nil {
+		return
+	}
+	tcp, _ := tcpLayer.(*layers.TCP)
+
+	srcIP := ip.SrcIP.String()
+	dstIP := ip.DstIP.String()
+	srcPort := uint16(tcp.SrcPort)
+	dstPort := uint16(tcp.DstPort)
+
+	newConn := &SSHConnection{
+		SourceIP:   srcIP,
+		SourcePort: srcPort,
+		DestIP:     dstIP,
+		DestPort:   dstPort,
+		StartTime:  time.Now(),
+	}
+
+	// Send to event queue
+	eventQueue <- ConnectionEvent{
+		Conn: newConn,
+	}
+}
+
+// handleEvent function is called by the event processing goroutine whenever a
+// ConnectionEvent is received from the eventQueue channel. The eventQueue is
+// populated by the processPacket function when new SSH connections are detected
+// from network packet analysis.
+// handleEvent processes an SSH connection event and updates corresponding metrics.
+func handleEvent(event ConnectionEvent) {
+	fmt.Print("New connection detected towards: ", event.Conn.DestIP, ":", event.Conn.DestPort, "\n")
+	sshConnections.WithLabelValues(event.Conn.DestIP, strconv.Itoa(int(event.Conn.DestPort))).Inc()
+}
+
+// NewSSHTracker creates and initializes a new SSH tracker.
+func NewSSHTracker() *SSHTracker {
+	return &SSHTracker{
+		stopCh: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start begins tracking SSH connections on the specified interface, port, and snaplen.
+func (t *SSHTracker) Start(iface string, port, snaplen int) error {
+	defer close(t.done)
+
+	szFrame, szBlock, numBlocks, err := afpacketComputeSize(8, snaplen, os.Getpagesize())
+	if err != nil {
+		return fmt.Errorf("error computing afpacket size: %w", err)
+	}
+
+	timeout := time.Millisecond * 100
+
+	afHandle, err := newAfpacketHandle(iface, szFrame, szBlock, numBlocks, false, timeout)
+	if err != nil {
+		return fmt.Errorf("error creating afpacket handle: %w", err)
+	}
+	defer afHandle.Close()
+
+	// Filter for new outbound TCP packets on the specified port
+	// Explicitly check for SYN packets to identify new connections
+	// We want to track when a connection is established
+	filter := fmt.Sprintf("tcp dst port %d and tcp[tcpflags] & tcp-syn != 0", port)
+	if err := afHandle.SetBPFFilter(filter, snaplen); err != nil {
+		return fmt.Errorf("error setting BPF filter: %w", err)
+	}
+
+	source := gopacket.ZeroCopyPacketDataSource(afHandle)
+
+	eventQueue := make(chan ConnectionEvent, 100)
+
+	var wg sync.WaitGroup
+	stopWorkers := make(chan struct{})
+	stopPackets := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case event := <-eventQueue:
+				handleEvent(event)
+			case <-stopWorkers:
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stopPackets:
+				return
+			default:
+				data, _, err := source.ZeroCopyReadPacketData()
+				if err != nil {
+					continue
+				}
+				packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.Default)
+				processPacket(packet, eventQueue)
+			}
+		}
+	}()
+
+	<-t.stopCh
+	close(stopPackets)
+	// Let the packet processing finish
+	time.Sleep(2 * timeout)
+	afHandle.Close()
+	close(stopWorkers)
+	wg.Wait()
+
+	return nil
+}
+
+// Stop gracefully stops the SSH tracker.
+func (t *SSHTracker) Stop() {
+	close(t.stopCh)
+	<-t.done
+}


### PR DESCRIPTION
# Description

This PR adds the `bastion-ssh-tracker`, a golang app based on Google `gopacket`,  as a sidecar to the bastion deployment, allowing to track SSH connections from the bastion to target instances, exposing them as Prometheus metrics.

This PR allows to easily extend https://github.com/netgroup-polito/CrownLabs/pull/934 with SSH connections instead of relying only on remote-desktop-based metrics, guaranteeing a more precise distinction between active and inactive instances.

A current limitation for the first usage usage of the tracker (instance inactivity detection) is the following:
When stopped and restarted, persistent instances could get a different IP address assigned, effectively reducing effectiveness of the metric resenting the ssh connections towards that instance.
For network performance reasons at the moment it does not make sense to resolve the current destination IP address to the instance name/hostname.
It is not clear if this is something that can be solved during instances IP address assignation.

The `bastion-ssh-tracker` has been tested locally with success. No unit tests are present at the moment.
```
ssh -J crownlabs@172.19.0.129 test@1.2.3.4
```

![image](https://github.com/user-attachments/assets/e0964bd5-6ba3-495b-ad08-cc19db61889d)
