### PR TITLE
Add component rust-src to enable rust-analyzer linting

### DIFF
--- a/provisioning/standalone/vscode/rust/Dockerfile
+++ b/provisioning/standalone/vscode/rust/Dockerfile
@@ -29,8 +29,21 @@ USER ${USER}
 ENV HOME=${VSCODE_SRV_DIR}
 RUN curl -sSf https://sh.rustup.rs | /bin/bash -s -- -y -v && \
     ${RSPATH}/rustup component remove rust-docs && \
+    ${RSPATH}/rustup component add rust-src && \
     ${RSPATH}/rustup completions bash >> $HOME/.bashrc && \
     ${RSPATH}/rustup completions bash cargo >> $HOME/.bashrc
+
+# Enable proxy if needed
+ARG PROXY
+ENV https_proxy=${PROXY} http_proxy=${PROXY} no_proxy=localhost 
+RUN if [ -n "${PROXY}" ]; then \
+echo \
+"[http]\n\
+proxy = \"${PROXY}\"\n\
+timeout = 30\n\
+check-revoke = false\n\
+multiplexing = false\n" >> ${RSPATH}/../config.toml; \
+fi
 
 ENTRYPOINT [ "/start.sh" ]
 CMD [ "--load-example", "/vscode/workspace/project" ]


### PR DESCRIPTION
# Description

This PR introduces a new rustup component to the docker image of VSCode+Rust, since Rust Analyzer needs `rust-src` (the source code of the Rust language) to give suggestions of imports and fixes.

Fixes issue happened during Programmazione di Sistema's First Call (on 2025-06-17), where students couldn't use properly (or at all) Rust Analyzer, since all connections to Internet were blocked, and only cargo know who the proxy was; so RA was trying to execute `rustup install rust-src`, but without Internet connection, it failed, and RA server died.
During local tests, it came to light that RA does not work without connection ( rust-lang/rust-analyzer#12499 ), but logging the requests it does, it seems to only need connection to crates.io, which the proxy allows.

# How Has This Been Tested?

Only locally with WSL, by a compose with VSC-RS and a Tinyproxy container.
All traffic from cargo is being proxied, and only crates.io is allowed.
