### PR TITLE
Add VSCode+LaTeX as Standalone

### DIFF
--- a/provisioning/standalone/vscode/latex/.gitignore
+++ b/provisioning/standalone/vscode/latex/.gitignore
@@ -1,0 +1,1 @@
+!project/.vscode

--- a/provisioning/standalone/vscode/latex/Dockerfile
+++ b/provisioning/standalone/vscode/latex/Dockerfile
@@ -1,0 +1,36 @@
+# syntax = edrevo/dockerfile-plus
+
+INCLUDE+ ./base/Dockerfile
+
+ENV SUDO_FORCE_REMOVE yes
+COPY ./latex/settings.json ${VSCODE_SRV_DIR}/data/User/settings.json
+COPY --chown=${USER}:${USER} ./latex/project /example_project/project
+COPY --chown=${USER}:${USER} ./latex/project/.vscode /example_project/project/.vscode
+
+# Install required packages and remove apt and useless/dangerous packages
+# Installation steps are taken from https://www.tug.org/texlive/quickinstall.html
+RUN apt-get update && \
+    apt-get install -y curl perl && \
+    cd /tmp && \
+    curl -L https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar -zx && \
+    cd install-tl-2* && \
+    perl ./install-tl --scheme=small --no-doc-install --no-src-install --no-interaction && \
+    apt-get clean && \
+    apt-get remove --autoremove --purge -y apt sudo --allow-remove-essential && \
+    rm -rf /tmp/install-tl-2*
+
+# Install extensions and setup permissions
+RUN code-server --extensions-dir ${VSCODE_SRV_DIR}/extensions --install-extension James-Yu.latex-workshop && \
+    chown -R ${USER}:${USER} ${VSCODE_SRV_DIR} && \
+    chown -R ${USER}:${USER} /example_project
+
+# Finalizing TeX Live installation
+USER ${USER}
+ENV HOME=${VSCODE_SRV_DIR}
+RUN YEAR=$(ls /usr/local/texlive | head -n 1) && \
+    ARCH=$(ls /usr/local/texlive/$YEAR/bin | head -n 1) && \
+    echo "export PATH=/usr/local/texlive/$YEAR/bin/$ARCH:$PATH" >> $HOME/.bashrc
+
+
+ENTRYPOINT [ "/start.sh" ]
+CMD [ "--load-example", "/vscode/workspace/project" ]

--- a/provisioning/standalone/vscode/latex/project/.vscode/settings.json
+++ b/provisioning/standalone/vscode/latex/project/.vscode/settings.json
@@ -1,0 +1,40 @@
+{
+  "editor.wordWrap": "bounded",
+  "latex-workshop.latex.tools": [
+    {
+      "name": "pdflatex",
+      "command": "pdflatex",
+      "args": [
+        "-interaction=nonstopmode",
+        "-output-directory=build",
+        "%DOC%"
+      ]
+    },
+    {
+      "name": "cp-pdf",
+      "command": "bash",
+      "args": [
+        "-c",
+        "cp %DIR%/build/*.pdf %DIR%"
+      ]
+    },
+    {
+      "name": "mkdir-build",
+      "command": "mkdir",
+      "args": [
+        "-p",
+        "build"
+      ]
+    }
+  ],
+  "latex-workshop.latex.recipes": [
+    {
+      "name": "pdflatex",
+      "tools": [
+        "mkdir-build",
+        "pdflatex",
+        "cp-pdf"
+      ]
+    }
+  ]
+}

--- a/provisioning/standalone/vscode/latex/project/main.tex
+++ b/provisioning/standalone/vscode/latex/project/main.tex
@@ -1,0 +1,24 @@
+\documentclass[11pt,a4paper]{article}
+
+\usepackage[utf8]{inputenc}   % UTF-8 encoding
+\usepackage[T1]{fontenc}      % font encoding for hyphenation
+\usepackage[english]{babel}   % language
+
+\title{My Big Important Paper}
+\author{It's me}
+\date{\today}
+
+\begin{document}
+
+	\maketitle
+
+	\section{Introduction}
+		This is a sample \LaTeX{} document. Here you can write text, equations, lists, ...
+
+	\subsection{Example}
+		\begin{equation}
+			E = mc^2
+		\end{equation}
+
+\end{document}
+

--- a/provisioning/standalone/vscode/latex/settings.json
+++ b/provisioning/standalone/vscode/latex/settings.json
@@ -1,0 +1,8 @@
+{
+    "security.workspace.trust.enabled": false,
+    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.startupEditor": "none",
+    "window.menuBarVisibility": "visible",
+    "output.smartScroll.enabled": false,
+    "chat.commandCenter.enabled": true,
+}


### PR DESCRIPTION
# Description

This PR aims to add a new standalone template to the VSCode collection, now with a LaTeX compiler (TeX Live). 
It could be used by students or researchers which do not have access to the unlimited version of OverLeaf that teachers have (we have for example a timeout on the compilation time). 

Fixes no issue

# How Has This Been Tested?

Not formally tested
