### PR TITLE
Fix VSCode+LaTeX permissions and package auto-install

### DIFF
--- a/provisioning/standalone/vscode/latex/Dockerfile
+++ b/provisioning/standalone/vscode/latex/Dockerfile
@@ -10,7 +10,7 @@ COPY --chown=${USER}:${USER} ./latex/project/.vscode /example_project/project/.v
 # Install required packages and remove apt and useless/dangerous packages
 # Installation steps are taken from https://www.tug.org/texlive/quickinstall.html
 RUN apt-get update && \
-    apt-get install -y curl perl && \
+    apt-get install -y curl perl python3 python-is-python3 && \
     cd /tmp && \
     curl -L https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | tar -zx && \
     cd install-tl-2* && \
@@ -22,14 +22,17 @@ RUN apt-get update && \
 # Install extensions and setup permissions
 RUN code-server --extensions-dir ${VSCODE_SRV_DIR}/extensions --install-extension James-Yu.latex-workshop && \
     chown -R ${USER}:${USER} ${VSCODE_SRV_DIR} && \
-    chown -R ${USER}:${USER} /example_project
+    chown -R ${USER}:${USER} /example_project && \
+    chown -R ${USER}:${USER} /usr/local/texlive
 
 # Finalizing TeX Live installation
 USER ${USER}
 ENV HOME=${VSCODE_SRV_DIR}
 RUN YEAR=$(ls /usr/local/texlive | head -n 1) && \
     ARCH=$(ls /usr/local/texlive/$YEAR/bin | head -n 1) && \
-    echo "export PATH=/usr/local/texlive/$YEAR/bin/$ARCH:$PATH" >> $HOME/.bashrc
+    TLPATH=/usr/local/texlive/$YEAR/bin/$ARCH && \
+    echo "export PATH=$TLPATH:\$PATH" >> $HOME/.bashrc && \
+    $TLPATH/tlmgr install texliveonfly
 
 
 ENTRYPOINT [ "/start.sh" ]

--- a/provisioning/standalone/vscode/latex/project/.vscode/settings.json
+++ b/provisioning/standalone/vscode/latex/project/.vscode/settings.json
@@ -3,10 +3,11 @@
   "latex-workshop.latex.tools": [
     {
       "name": "pdflatex",
-      "command": "pdflatex",
+      "command": "texliveonfly",
       "args": [
-        "-interaction=nonstopmode",
-        "-output-directory=build",
+        "--compiler=pdflatex",
+        "-a", // Arguments for compiler
+        "-interaction=nonstopmode -output-directory=build",
         "%DOC%"
       ]
     },


### PR DESCRIPTION
# Description

This PR aims to fix some problems that we missed during #1000, since we only tried with a basic TeX example.

Fixes:
- permissions of the binary TeX Live folder, making now possible to update and/or install new packages from the terminal
- adds TeX's [`texliveonfly` package](https://ctan.org/pkg/texliveonfly) which enables the compiler to automatically install the missing packages that are found in the source file

# How Has This Been Tested?

No formal testing was done
