### PR TITLE
Removed useless button

### DIFF
--- a/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
+++ b/frontend/src/components/activePage/TableInstance/TableInstanceLogic.tsx
@@ -1,6 +1,5 @@
-import { Button, Empty, Spin } from 'antd';
+import { Empty, Spin } from 'antd';
 import { type FC, useContext, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
 import { ErrorContext } from '../../../errorHandling/ErrorContext';
 import { ErrorTypes } from '../../../errorHandling/utils';
 import {


### PR DESCRIPTION
The PR deletes a button which is rather useless, as in the picture below, and it tends to be overlapped with other sections of the screen.
<img width="1179" height="667" alt="image" src="https://github.com/user-attachments/assets/7c8cc8ff-844e-4a9f-becb-ef4ac97e8132" />
