### PR TITLE
refactor: remove unused suffixes from ingress paths and related tests

### DIFF
--- a/operators/pkg/forge/ingresses.go
+++ b/operators/pkg/forge/ingresses.go
@@ -27,19 +27,9 @@ const (
 	// IngressInstancePrefix -> the prefix prepended to the path of any ingresses targeting the instance or its subresources.
 	IngressInstancePrefix = "/instance"
 
-	// IngressGUINameSuffix -> the suffix added to the name of the ingress targeting the environment GUI.
-	IngressGUINameSuffix = "gui"
-	// IngressAppSuffix -> the suffix added to the path of the ingress targeting standalone and container environments.
-	IngressAppSuffix = "app"
-
 	// IngressDefaultCertificateName -> the name of the secret containing the crownlabs certificate.
 	IngressDefaultCertificateName = "crownlabs-ingress-secret"
 
-	// IngressVNCGUIPathSuffix -> the suffix appended to the path of the ingress targeting the environment GUI websocketed vnc endpoint.
-	IngressVNCGUIPathSuffix = "vnc"
-
-	// WebsockifyRewriteEndpoint -> endpoint of the websocketed vnc server.
-	WebsockifyRewriteEndpoint = "/websockify"
 	// StandaloneRewriteEndpoint -> endpoint of the standalone application.
 	StandaloneRewriteEndpoint = "/$2"
 	// GUIRewriteEndpoint -> used to clean the path of the ingress targeting the environment GUI.
@@ -138,18 +128,12 @@ func IngressGUIPath(instance *clv1alpha2.Instance, environment *clv1alpha2.Envir
 
 // IngressGUICleanPath returns the path of the ingress targeting the environment GUI vnc or Standalone, without the url-rewrite's regex.
 func IngressGUICleanPath(instance *clv1alpha2.Instance, environment *clv1alpha2.Environment) string {
-	return strings.TrimRight(fmt.Sprintf("%v/%v/%v/%v", IngressInstancePrefix, instance.UID, environment.Name, IngressAppSuffix), "/")
+	return strings.TrimRight(fmt.Sprintf("%v/%v/%v", IngressInstancePrefix, instance.UID, environment.Name), "/")
 }
 
 // IngressGuiStatusURL returns the path of the ingress targeting the environment.
 func IngressGuiStatusURL(host string, environment *clv1alpha2.Environment, instance *clv1alpha2.Instance) string {
-	switch environment.EnvironmentType {
-	case clv1alpha2.ClassStandalone, clv1alpha2.ClassContainer:
-		return fmt.Sprintf("https://%v%v/%v/%v/%v/", host, IngressInstancePrefix, instance.UID, environment.Name, IngressAppSuffix)
-	case clv1alpha2.ClassVM, clv1alpha2.ClassCloudVM:
-		return fmt.Sprintf("https://%v%v/%v/%v/", host, IngressInstancePrefix, instance.UID, environment.Name)
-	}
-	return ""
+	return fmt.Sprintf("https://%v%v/%v/%v/", host, IngressInstancePrefix, instance.UID, environment.Name)
 }
 
 // IngressGuiStatusInstanceURL returns the root of the ingress url targeting an environment within the instance.
@@ -159,22 +143,5 @@ func IngressGuiStatusInstanceURL(host string, instance *clv1alpha2.Instance) str
 
 // IngressGuiStatusFromRootURL returns the path of the ingress targeting the environment given the root url (url of the instance).
 func IngressGuiStatusFromRootURL(rootURL string, environment *clv1alpha2.Environment) string {
-	switch environment.EnvironmentType {
-	case clv1alpha2.ClassStandalone, clv1alpha2.ClassContainer:
-		return rootURL + fmt.Sprintf("%v/%v/", environment.Name, IngressAppSuffix)
-	case clv1alpha2.ClassVM, clv1alpha2.ClassCloudVM:
-		return rootURL + fmt.Sprintf("%v/", environment.Name)
-	}
-	return ""
-}
-
-// IngressGUIName returns the name of the ingress resource.
-func IngressGUIName(environment *clv1alpha2.Environment) string {
-	switch environment.EnvironmentType {
-	case clv1alpha2.ClassStandalone:
-		return IngressAppSuffix
-	case clv1alpha2.ClassContainer, clv1alpha2.ClassVM, clv1alpha2.ClassCloudVM:
-		return IngressGUINameSuffix
-	}
-	return ""
+	return rootURL + fmt.Sprintf("%v/", environment.Name)
 }

--- a/operators/pkg/forge/ingresses_test.go
+++ b/operators/pkg/forge/ingresses_test.go
@@ -230,7 +230,6 @@ var _ = Describe("Ingresses", func() {
 			instance    clv1alpha2.Instance
 			path        string
 			statusPath  string
-			GUIName     string
 			environment clv1alpha2.Environment
 		)
 
@@ -325,43 +324,8 @@ var _ = Describe("Ingresses", func() {
 			JustBeforeEach(func() {
 				statusPath = forge.IngressGuiStatusURL(host, &environment, &instance)
 			})
-			When("EnvironmentType is ClassStandalone", func() {
-				BeforeEach(func() {
-					environment.EnvironmentType = clv1alpha2.ClassStandalone
-				})
-				It("Should generate a path based on the instance UID and /app at the end", func() {
-					Expect(statusPath).To(BeIdenticalTo("https://" + host + "/instance/" + instanceUID + "/" + environment.Name + "/app/"))
-				})
-			})
-			When("EnvironmentType is not ClassStandalone", func() {
-				BeforeEach(func() {
-					environment.EnvironmentType = clv1alpha2.ClassContainer
-				})
-				It("Should generate a path based on the instance UID and /app at the end", func() {
-					Expect(statusPath).To(BeIdenticalTo("https://" + host + "/instance/" + instanceUID + "/" + environment.Name + "/app/"))
-				})
-			})
-		})
-
-		Describe("The forge.IngressGUIName function", func() {
-			JustBeforeEach(func() {
-				GUIName = forge.IngressGUIName(&environment)
-			})
-			When("EnvironmentType is ClassStandalone", func() {
-				BeforeEach(func() {
-					environment.EnvironmentType = clv1alpha2.ClassStandalone
-				})
-				It("Should generate a path based on the instance UID and /app at the end", func() {
-					Expect(GUIName).To(BeIdenticalTo("app"))
-				})
-			})
-			When("EnvironmentType is not ClassStandalone", func() {
-				BeforeEach(func() {
-					environment.EnvironmentType = clv1alpha2.ClassContainer
-				})
-				It("Should generate a path based on the instance UID", func() {
-					Expect(GUIName).To(BeIdenticalTo("gui"))
-				})
+			It("Should generate a path based on the instance UID and /app at the end", func() {
+				Expect(statusPath).To(BeIdenticalTo("https://" + host + "/instance/" + instanceUID + "/" + environment.Name + "/"))
 			})
 		})
 	})

--- a/operators/pkg/instctrl/controller_test.go
+++ b/operators/pkg/instctrl/controller_test.go
@@ -162,7 +162,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 		Expect(k8sClient.Create(ctx, &instance)).To(Succeed())
 	})
 
-	StandaloneContainerIt := func(namespacedNameSuffix string) {
+	StandaloneContainerIt := func() {
 		It("Should correctly reconcile the instance", func() {
 			Expect(RunReconciler()).To(Succeed())
 
@@ -196,7 +196,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 			By("Asserting the exposition resources aren't present", func() {
 				for _, env := range template.Spec.EnvironmentList {
 					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &service)).To(FailBecauseNotFound())
-					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name+"-"+namespacedNameSuffix), &ingress)).To(FailBecauseNotFound())
+					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &ingress)).To(FailBecauseNotFound())
 				}
 			})
 
@@ -209,7 +209,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 			By("Asserting the right exposition resources exist", func() {
 				for _, env := range template.Spec.EnvironmentList {
 					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &service)).To(Succeed())
-					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name+"-"+namespacedNameSuffix), &ingress)).To(Succeed())
+					Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &ingress)).To(Succeed())
 				}
 			})
 
@@ -247,7 +247,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				runInstance = false
 			})
 
-			StandaloneContainerIt(forge.IngressAppSuffix)
+			StandaloneContainerIt()
 		})
 		When("the environment is NOT persistent", func() {
 			BeforeEach(func() {
@@ -258,7 +258,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				}
 				runInstance = false
 			})
-			StandaloneContainerIt(forge.IngressAppSuffix)
+			StandaloneContainerIt()
 		})
 	})
 
@@ -272,7 +272,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				}
 				runInstance = false
 			})
-			StandaloneContainerIt(forge.IngressGUINameSuffix)
+			StandaloneContainerIt()
 		})
 		When("the environment is NOT persistent", func() {
 			BeforeEach(func() {
@@ -283,7 +283,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				}
 				runInstance = false
 			})
-			StandaloneContainerIt(forge.IngressGUINameSuffix)
+			StandaloneContainerIt()
 		})
 	})
 
@@ -328,7 +328,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 					By("Asserting the exposition resources aren't present", func() {
 						for _, env := range template.Spec.EnvironmentList {
 							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &service)).To(FailBecauseNotFound())
-							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name+"-"+forge.IngressGUINameSuffix), &ingress)).To(FailBecauseNotFound())
+							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &ingress)).To(FailBecauseNotFound())
 						}
 					})
 
@@ -341,7 +341,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 					By("Asserting the right exposition resources exist", func() {
 						for _, env := range template.Spec.EnvironmentList {
 							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &service)).To(Succeed())
-							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name+"-"+forge.IngressGUINameSuffix), &ingress)).To(Succeed())
+							Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, env.Name), &ingress)).To(Succeed())
 						}
 					})
 
@@ -421,7 +421,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				By("Asserting the exposition resources aren't present", func() {
 					for i := range template.Spec.EnvironmentList {
 						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name), &service)).To(FailBecauseNotFound())
-						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name+"-"+forge.IngressGUINameSuffix), &ingress)).To(FailBecauseNotFound())
+						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name), &ingress)).To(FailBecauseNotFound())
 					}
 				})
 
@@ -434,7 +434,7 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 				By("Asserting the right exposition resources exist", func() {
 					for i := range template.Spec.EnvironmentList {
 						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name), &service)).To(Succeed())
-						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name+"-"+forge.IngressGUINameSuffix), &ingress)).To(Succeed())
+						Expect(k8sClient.Get(ctx, forge.NamespacedNameWithSuffix(&instance, template.Spec.EnvironmentList[i].Name), &ingress)).To(Succeed())
 					}
 				})
 

--- a/operators/pkg/instctrl/exposition.go
+++ b/operators/pkg/instctrl/exposition.go
@@ -87,7 +87,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionPresence(ctx context.Conte
 
 	host := forge.HostName(r.ServiceUrls.WebsiteBaseURL, template.Spec.Scope)
 
-	ingressGUI := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name+"-"+forge.IngressGUIName(environment))}
+	ingressGUI := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
 	res, err = ctrl.CreateOrUpdate(ctx, r.Client, &ingressGUI, func() error {
 		// Ingress specifications are forged only at creation time, to prevent issues in case of updates.
 		// Indeed, enforcing the specs may cause service disruption if they diverge from the service configuration.
@@ -139,7 +139,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionAbsence(ctx context.Contex
 	}
 
 	// Enforce gui ingress absence
-	ingressGUI := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name+"-"+forge.IngressGUINameSuffix)}
+	ingressGUI := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
 	if err := utils.EnforceObjectAbsence(ctx, r.Client, &ingressGUI, "ingress"); err != nil {
 		return err
 	}

--- a/operators/pkg/instctrl/exposition_test.go
+++ b/operators/pkg/instctrl/exposition_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Generation of the exposition environment", func() {
 		index = 0
 
 		serviceName = forge.NamespacedNameWithSuffix(&instance, environment.Name)
-		ingressGUIName = forge.NamespacedNameWithSuffix(&instance, environment.Name+"-"+forge.IngressGUINameSuffix)
+		ingressGUIName = forge.NamespacedNameWithSuffix(&instance, environment.Name)
 
 		service = corev1.Service{}
 		ingress = netv1.Ingress{}


### PR DESCRIPTION
This pull request simplifies and unifies the naming and path conventions for ingress resources in the codebase. The main change is the removal of the `IngressGUINameSuffix` and `IngressAppSuffix` constants and their associated logic, resulting in ingress resources being named and addressed solely by the environment name. This impacts both the implementation and the related tests, making the ingress handling more consistent and less error-prone. Some older, forgotten, variables have been removed too.

Key changes include:

### Ingress Naming and Path Simplification

* Removed the use of `IngressGUINameSuffix` and `IngressAppSuffix` constants, so ingress resources are now named only with the environment name, eliminating the previous suffix-based differentiation. (`operators/pkg/forge/ingresses.go`, `operators/pkg/instctrl/exposition.go`) [[1]](diffhunk://#diff-8e2e2dbea50d346ddcd4198ec973565ce492db012f7b9ef8a2e882224a225cf9L30-L42) [[2]](diffhunk://#diff-9be8433d4fba385d337e96d10457e53fd21a7eef88f05ccc8a34e7be0a2f70eeL90-R90) [[3]](diffhunk://#diff-9be8433d4fba385d337e96d10457e53fd21a7eef88f05ccc8a34e7be0a2f70eeL142-R142)
* Updated all functions and logic that previously appended suffixes to ingress names or paths to use only the environment name, simplifying URL and resource generation. (`operators/pkg/forge/ingresses.go`) [[1]](diffhunk://#diff-8e2e2dbea50d346ddcd4198ec973565ce492db012f7b9ef8a2e882224a225cf9L141-L153) [[2]](diffhunk://#diff-8e2e2dbea50d346ddcd4198ec973565ce492db012f7b9ef8a2e882224a225cf9L162-L180)

### Test Updates

* Refactored tests to remove references to the old suffix-based ingress names, updating expectations to match the new naming scheme. (`operators/pkg/forge/ingresses_test.go`, `operators/pkg/instctrl/controller_test.go`, `operators/pkg/instctrl/exposition_test.go`) [[1]](diffhunk://#diff-283b3b0cff498c0b8ea8302b0db7c49d222f4bba4fa25970a2ef4535b5b28e34L233) [[2]](diffhunk://#diff-283b3b0cff498c0b8ea8302b0db7c49d222f4bba4fa25970a2ef4535b5b28e34L328-R328) [[3]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L165-R165) [[4]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L199-R199) [[5]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L212-R212) [[6]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L250-R250) [[7]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L261-R261) [[8]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L275-R275) [[9]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L286-R286) [[10]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L331-R331) [[11]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L344-R344) [[12]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L424-R424) [[13]](diffhunk://#diff-b79e3c7660bcf6114f305605b2b6a016abc6707a2b75a42c2c4c00a9aca29ac4L437-R437) [[14]](diffhunk://#diff-95c4edabe8f4b30ea60f9fbfbda469a2d3c125e65e09759962b52e2549b014e0L120-R120)

These changes make ingress resource handling more straightforward, reducing complexity and potential for naming inconsistencies.