### PR TITLE
fix: move nodeSelector in graph

### DIFF
--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -128,12 +128,6 @@ export type EnvironmentListListItem = {
    */
   name: Scalars['String']['output'];
   /**
-   * Labels that are used for the selection of the node.
-   * They are given by means of a pointer to check the presence of the field.
-   * In case it is present, the labels that are chosen are the ones present on the instance
-   */
-  nodeSelector?: Maybe<Scalars['JSON']['output']>;
-  /**
    * Whether the environment should be persistent (i.e. preserved when the
    * corresponding instance is terminated) or not.
    */
@@ -174,12 +168,6 @@ export type EnvironmentListListItemInput = {
    * '-' or '.', must start and end with an alphanumeric character.
    */
   name: Scalars['String']['input'];
-  /**
-   * Labels that are used for the selection of the node.
-   * They are given by means of a pointer to check the presence of the field.
-   * In case it is present, the labels that are chosen are the ones present on the instance
-   */
-  nodeSelector?: InputMaybe<Scalars['JSON']['input']>;
   /**
    * Whether the environment should be persistent (i.e. preserved when the
    * corresponding instance is terminated) or not.
@@ -3743,7 +3731,7 @@ export type WorkspaceTemplatesQueryVariables = Exact<{
 }>;
 
 
-export type WorkspaceTemplatesQuery = { __typename?: 'Query', templateList?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateList', templates: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, deleteAfter?: string | null, inactivityTimeout?: string | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, environmentType: EnvironmentType, mountMyDriveVolume: boolean, image: string, guiEnabled?: boolean | null, persistent?: boolean | null, nodeSelector?: any | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number }, sharedVolumeMounts?: Array<{ __typename?: 'SharedVolumeMountsListItem', mountPath: string, readOnly: boolean, sharedVolume: { __typename?: 'SharedVolume', name: string, namespace?: string | null } } | null> | null } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null> } | null };
+export type WorkspaceTemplatesQuery = { __typename?: 'Query', templateList?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateList', templates: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, deleteAfter?: string | null, inactivityTimeout?: string | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, environmentType: EnvironmentType, mountMyDriveVolume: boolean, image: string, guiEnabled?: boolean | null, persistent?: boolean | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number }, sharedVolumeMounts?: Array<{ __typename?: 'SharedVolumeMountsListItem', mountPath: string, readOnly: boolean, sharedVolume: { __typename?: 'SharedVolume', name: string, namespace?: string | null } } | null> | null } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null> } | null };
 
 export type TenantQueryVariables = Exact<{
   tenantId: Scalars['String']['input'];
@@ -3795,7 +3783,7 @@ export type UpdatedWorkspaceTemplatesSubscriptionVariables = Exact<{
 }>;
 
 
-export type UpdatedWorkspaceTemplatesSubscription = { __typename?: 'Subscription', updatedTemplate?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateUpdate', updateType?: UpdateType | null, template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, nodeSelector?: any | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any } } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null } | null };
+export type UpdatedWorkspaceTemplatesSubscription = { __typename?: 'Subscription', updatedTemplate?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateUpdate', updateType?: UpdateType | null, template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any } } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null } | null };
 
 export type UpdatedTenantSubscriptionVariables = Exact<{
   tenantId: Scalars['String']['input'];
@@ -4880,7 +4868,6 @@ export const WorkspaceTemplatesDocument = gql`
           image
           guiEnabled
           persistent
-          nodeSelector
           resources {
             cpu
             disk
@@ -5397,7 +5384,6 @@ export const UpdatedWorkspaceTemplatesDocument = gql`
           name
           guiEnabled
           persistent
-          nodeSelector
           resources {
             cpu
             disk

--- a/frontend/src/graphql-components/query/templates.query.graphql
+++ b/frontend/src/graphql-components/query/templates.query.graphql
@@ -17,7 +17,6 @@ query workspaceTemplates($workspaceNamespace: String!) {
           image
           guiEnabled
           persistent
-          nodeSelector
           resources {
             cpu
             disk

--- a/frontend/src/graphql-components/subscription/templates.subscription.ts
+++ b/frontend/src/graphql-components/subscription/templates.subscription.ts
@@ -19,7 +19,6 @@ export default gql`
             name
             guiEnabled
             persistent
-            nodeSelector
             resources {
               cpu
               disk

--- a/frontend/src/utilsLogic.tsx
+++ b/frontend/src/utilsLogic.tsx
@@ -74,9 +74,6 @@ export const makeGuiTemplate = (
   const environmentList = tq.original.spec?.environmentList ?? [];
   const hasMultipleEnvironments = environmentList.length > 1;
 
-  // For backwards compatibility use the first environment for main properties
-  const primaryEnvironment = environmentList[0];
-
   const hasGUI = environmentList.some(env => env?.guiEnabled);
   const hasPersistent = environmentList.some(env => env?.persistent);
 
@@ -116,7 +113,7 @@ export const makeGuiTemplate = (
     deleteAfter: tq.original.spec?.deleteAfter ?? 'never',
     inactivityTimeout: tq.original.spec?.inactivityTimeout ?? 'never',
     persistent: hasPersistent,
-    nodeSelector: primaryEnvironment?.nodeSelector,
+    nodeSelector: tq.original.spec?.nodeSelector,
     resources: {
       cpu: aggregatedResources.cpu,
       memory:


### PR DESCRIPTION
This pull request removes the `nodeSelector` field from the `EnvironmentListListItem` and related types, queries, and subscriptions in the codebase. The handling of `nodeSelector` has been refactored so that it is no longer part of individual environment items, but is now accessed from the parent spec object. This streamlines the data model and GraphQL queries, reducing redundancy and potential confusion about where `nodeSelector` is defined.
