### PR TITLE
Update Dependabot configuration for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,28 @@ updates:
     directory: /qlkube
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
       qlkube:
-        patterns:
-          - "*"
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: npm
     directory: /frontend
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
       frontend:
-        patterns:
-          - "*"
+        applies-to: security-updates
+        patterns: ["*"]
 
   - package-ecosystem: gomod
     directory: /operators
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
       operators:
-        patterns:
-          - "*"
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
This pull request updates the Dependabot configuration to limit its activity and focus on security updates across multiple directories. The main changes ensure that only security-related updates are grouped and that no new pull requests are automatically opened by Dependabot.

**Dependabot configuration updates:**

* Added `open-pull-requests-limit: 0` to the `qlkube`, `frontend`, and `operators` package ecosystems to prevent Dependabot from opening new pull requests automatically (it would still do for sec-updates).
* Restricted update groups for `qlkube`, `frontend`, and `operators` to only apply to security updates using `applies-to: security-updates`.
* Simplified the group `patterns` syntax for each ecosystem.