### PR TITLE
chore: pipeline autocancel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ on:
     types:
       - deploy-staging-command
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   configure:
     name: Preliminary configuration

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golang-lint:
     name: Lint golang files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   configure:
     name: Preliminary configuration


### PR DESCRIPTION
This pull request updates our GitHub Actions workflows to improve CI/CD efficiency by preventing duplicate or overlapping runs. The main change is the addition of concurrency controls to the build, lint, and test workflows, ensuring that only the latest run for a given pull request or branch is active.

Workflow concurrency improvements:

* Added a `concurrency` group to `.github/workflows/build.yml`, `.github/workflows/lint.yml`, `.github/workflows/test.yml` to ensure that only the latest workflows are active for a given pull request or branch.