### PR TITLE
Fix instctrl permissions

### DIFF
--- a/operators/deploy/instance-operator/templates/clusterrole.yaml
+++ b/operators/deploy/instance-operator/templates/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
   verbs: ["get","list","watch","create","update","patch"]
 
 - apiGroups: ["crownlabs.polito.it"]
-  resources: ["templates", "tenants"]
+  resources: ["templates", "tenants", "sharedvolumes", "sharedvolumes/status"]
   verbs: ["get","list","watch"]
 
 - apiGroups: [""]


### PR DESCRIPTION
This pull request makes a small change to the `clusterrole.yaml` file, fixing the permissions for the **instance operator**. The change restores permissions for the operator to interact with `sharedvolumes` and their status that were removed in #1063.

- **Permissions update:**
  * [`operators/deploy/instance-operator/templates/clusterrole.yaml`](diffhunk://#diff-d03c7485087356c97b228e983be718483d018bd898ec88752c502e8438eaa4f4L17-R17): Added `sharedvolumes` and `sharedvolumes/status` to the list of resources with `get`, `list`, and `watch` permissions.