### PR TITLE
Frontend: unify workspace quota fields, fix create mutation types, and set default operator selector label

### DIFF
--- a/frontend/src/components/shared/QuotaFields/QuotaFields.tsx
+++ b/frontend/src/components/shared/QuotaFields/QuotaFields.tsx
@@ -1,0 +1,94 @@
+import { Form, InputNumber } from 'antd';
+import type { FC, ReactNode } from 'react';
+import type { Rule } from 'antd/es/form';
+
+interface QuotaFieldRuleSet {
+  cpu?: Rule[];
+  memory?: Rule[];
+  instances?: Rule[];
+}
+
+interface QuotaFieldLimit {
+  min?: number;
+  max?: number;
+}
+
+interface QuotaFieldLimitSet {
+  cpu?: QuotaFieldLimit;
+  memory?: QuotaFieldLimit;
+  instances?: QuotaFieldLimit;
+}
+
+interface QuotaFieldTooltipSet {
+  cpu?: ReactNode;
+  memory?: ReactNode;
+  instances?: ReactNode;
+}
+
+export interface IQuotaFieldsProps {
+  disabled?: boolean;
+  validateTrigger?: string;
+  rules?: QuotaFieldRuleSet;
+  limits?: QuotaFieldLimitSet;
+  tooltips?: QuotaFieldTooltipSet;
+}
+
+const QuotaFields: FC<IQuotaFieldsProps> = ({
+  disabled = false,
+  validateTrigger,
+  rules,
+  limits,
+  tooltips,
+}) => {
+  return (
+    <>
+      <Form.Item
+        name="cpu"
+        label="CPU"
+        validateTrigger={validateTrigger}
+        rules={rules?.cpu}
+        tooltip={tooltips?.cpu}
+      >
+        <InputNumber
+          min={limits?.cpu?.min}
+          max={limits?.cpu?.max}
+          disabled={disabled}
+          className="w-100"
+        />
+      </Form.Item>
+
+      <Form.Item
+        name="memory"
+        label="Memory (Gi)"
+        validateTrigger={validateTrigger}
+        rules={rules?.memory}
+        tooltip={tooltips?.memory}
+      >
+        <InputNumber
+          min={limits?.memory?.min}
+          max={limits?.memory?.max}
+          disabled={disabled}
+          className="w-100"
+          addonAfter="Gi"
+        />
+      </Form.Item>
+
+      <Form.Item
+        name="instances"
+        label="Instances"
+        validateTrigger={validateTrigger}
+        rules={rules?.instances}
+        tooltip={tooltips?.instances}
+      >
+        <InputNumber
+          min={limits?.instances?.min}
+          max={limits?.instances?.max}
+          disabled={disabled}
+          className="w-100"
+        />
+      </Form.Item>
+    </>
+  );
+};
+
+export default QuotaFields;

--- a/frontend/src/components/shared/QuotaFields/index.ts
+++ b/frontend/src/components/shared/QuotaFields/index.ts
@@ -1,0 +1,3 @@
+import QuotaFields from './QuotaFields';
+
+export default QuotaFields;

--- a/frontend/src/components/tenants/TenantPersonalWorkspaceSettings/TenantPersonalWorkspaceSettings.tsx
+++ b/frontend/src/components/tenants/TenantPersonalWorkspaceSettings/TenantPersonalWorkspaceSettings.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Form, InputNumber, Row } from 'antd';
+import { Button, Checkbox, Form, Row } from 'antd';
 import { useContext, useState, type FC } from 'react';
 import {
   TenantDocument,
@@ -9,6 +9,7 @@ import type { RuleRender, RuleObject } from 'antd/es/form';
 import { convertToGiB } from '../../../utils';
 import { ErrorContext } from '../../../errorHandling/ErrorContext';
 import { CheckOutlined } from '@ant-design/icons';
+import QuotaFields from '../../shared/QuotaFields';
 
 export interface ITenantPersonalWorkspaceSettingsProps {
   tenant: TenantQuery;
@@ -127,37 +128,20 @@ const TenantPersonalWorkspaceSettings: FC<
         <Checkbox />
       </Form.Item>
 
-      <Form.Item
-        name="cpu"
-        label="CPU"
+      <QuotaFields
+        disabled={!isEnabled}
         validateTrigger="onBlur"
-        rules={[numberValidator]}
-      >
-        <InputNumber min={0} disabled={!isEnabled} className="w-100" />
-      </Form.Item>
-
-      <Form.Item
-        name="memory"
-        label="Memory (Gi)"
-        validateTrigger="onBlur"
-        rules={[numberValidator]}
-      >
-        <InputNumber
-          min={0}
-          disabled={!isEnabled}
-          className="w-100"
-          addonAfter="Gi"
-        />
-      </Form.Item>
-
-      <Form.Item
-        name="instances"
-        label="Instances"
-        validateTrigger="onBlur"
-        rules={[numberValidator]}
-      >
-        <InputNumber min={0} disabled={!isEnabled} className="w-100" />
-      </Form.Item>
+        rules={{
+          cpu: [numberValidator],
+          memory: [numberValidator],
+          instances: [numberValidator],
+        }}
+        limits={{
+          cpu: { min: 0 },
+          memory: { min: 0 },
+          instances: { min: 0 },
+        }}
+      />
 
       <Row justify="center">
         <Form.Item>

--- a/frontend/src/components/workspaces/ModalCreateWorkspace/ModalCreateWorkspace.tsx
+++ b/frontend/src/components/workspaces/ModalCreateWorkspace/ModalCreateWorkspace.tsx
@@ -103,6 +103,9 @@ const ModalCreateWorkspace: FC<IModalCreateWorkspaceProps> = ({
             autoEnroll: normalizeAutoEnroll(values.autoEnroll),
             cpu: String(values.cpu),
             memory: `${values.memory}Gi`, // Kubernetes Quantity format
+            labels: {
+              'crownlabs.polito.it/operator-selector': 'production',
+            },
             instances: values.instances,
           },
         });

--- a/frontend/src/components/workspaces/ModalCreateWorkspace/ModalCreateWorkspace.tsx
+++ b/frontend/src/components/workspaces/ModalCreateWorkspace/ModalCreateWorkspace.tsx
@@ -1,10 +1,11 @@
 import type { FC } from 'react';
 import { useState, useContext, useEffect } from 'react';
-import { Modal, Form, Input, InputNumber, Select, Button } from 'antd';
+import { Modal, Form, Input, Select, Button } from 'antd';
 import { useCreateWorkspaceMutation, useApplyWorkspaceMutation, AutoEnroll } from '../../../generated-types';
 import type { ApolloError } from '@apollo/client';
 import { ErrorContext } from '../../../errorHandling/ErrorContext';
-import { convertToGB } from '../../../utils';
+import { convertToGiB } from '../../../utils';
+import QuotaFields from '../../shared/QuotaFields';
 
 export interface WorkspaceEditData {
   name: string;
@@ -59,7 +60,7 @@ const ModalCreateWorkspace: FC<IModalCreateWorkspaceProps> = ({
         prettyName: editWorkspace.prettyName,
         autoEnroll: editWorkspace.autoEnroll || undefined,
         cpu: parseFloat(editWorkspace.cpu),
-        memory: convertToGB(editWorkspace.memory),
+        memory: convertToGiB(editWorkspace.memory),
         instances: editWorkspace.instances,
       });
     } else if (show && !editWorkspace) {
@@ -199,34 +200,23 @@ const ModalCreateWorkspace: FC<IModalCreateWorkspaceProps> = ({
           />
         </Form.Item>
 
-        <Form.Item
-          label="CPU"
-          name="cpu"
-          rules={[{ required: true, message: 'Please input CPU quota!' }]}
-          tooltip="Maximum number of CPU cores"
-        >
-          <InputNumber min={1} max={128} className="w-100" />
-        </Form.Item>
-
-        <Form.Item
-          label="Memory (GB)"
-          name="memory"
-          rules={[{ required: true, message: 'Please input memory quota!' }]}
-          tooltip="Maximum memory in gigabytes"
-        >
-          <InputNumber min={1} max={512} className="w-100" addonAfter="GB" />
-        </Form.Item>
-
-        <Form.Item
-          label="Instances"
-          name="instances"
-          rules={[
-            { required: true, message: 'Please input max instances!' },
-          ]}
-          tooltip="Maximum number of concurrent instances"
-        >
-          <InputNumber min={1} max={100} className="w-100" />
-        </Form.Item>
+        <QuotaFields
+          rules={{
+            cpu: [{ required: true, message: 'Please input CPU quota!' }],
+            memory: [{ required: true, message: 'Please input memory quota!' }],
+            instances: [{ required: true, message: 'Please input max instances!' }],
+          }}
+          limits={{
+            cpu: { min: 1, max: 128 },
+            memory: { min: 1, max: 512 },
+            instances: { min: 1, max: 100 },
+          }}
+          tooltips={{
+            cpu: 'Maximum number of CPU cores',
+            memory: 'Maximum memory in gibibytes',
+            instances: 'Maximum number of concurrent instances',
+          }}
+        />
       </Form>
     </Modal>
   );

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -3825,7 +3825,7 @@ export type CreateWorkspaceMutationVariables = Exact<{
   autoEnroll?: InputMaybe<AutoEnroll>;
   cpu: Scalars['JSON']['input'];
   memory: Scalars['JSON']['input'];
-  instances: Scalars['Int']['input'];
+  instances: Scalars['BigInt']['input'];
 }>;
 
 
@@ -4584,7 +4584,7 @@ export type CreateTemplateMutationHookResult = ReturnType<typeof useCreateTempla
 export type CreateTemplateMutationResult = Apollo.MutationResult<CreateTemplateMutation>;
 export type CreateTemplateMutationOptions = Apollo.BaseMutationOptions<CreateTemplateMutation, CreateTemplateMutationVariables>;
 export const CreateWorkspaceDocument = gql`
-    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $instances: Int!) {
+    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $instances: BigInt!) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
     itPolitoCrownlabsV1alpha1WorkspaceInput: {kind: "Workspace", apiVersion: "crownlabs.polito.it/v1alpha1", spec: {prettyName: $prettyName, autoEnroll: $autoEnroll, quota: {cpu: $cpu, memory: $memory, instances: $instances}}, metadata: {name: $name}}
   ) {

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -3825,6 +3825,7 @@ export type CreateWorkspaceMutationVariables = Exact<{
   autoEnroll?: InputMaybe<AutoEnroll>;
   cpu: Scalars['JSON']['input'];
   memory: Scalars['JSON']['input'];
+  labels: Scalars['JSON']['input'];
   instances: Scalars['BigInt']['input'];
 }>;
 
@@ -4584,9 +4585,9 @@ export type CreateTemplateMutationHookResult = ReturnType<typeof useCreateTempla
 export type CreateTemplateMutationResult = Apollo.MutationResult<CreateTemplateMutation>;
 export type CreateTemplateMutationOptions = Apollo.BaseMutationOptions<CreateTemplateMutation, CreateTemplateMutationVariables>;
 export const CreateWorkspaceDocument = gql`
-    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $instances: BigInt!) {
+    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $labels: JSON!, $instances: BigInt!) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
-    itPolitoCrownlabsV1alpha1WorkspaceInput: {kind: "Workspace", apiVersion: "crownlabs.polito.it/v1alpha1", spec: {prettyName: $prettyName, autoEnroll: $autoEnroll, quota: {cpu: $cpu, memory: $memory, instances: $instances}}, metadata: {name: $name}}
+    itPolitoCrownlabsV1alpha1WorkspaceInput: {kind: "Workspace", apiVersion: "crownlabs.polito.it/v1alpha1", spec: {prettyName: $prettyName, autoEnroll: $autoEnroll, quota: {cpu: $cpu, memory: $memory, instances: $instances}}, metadata: {name: $name, labels: $labels}}
   ) {
     spec {
       prettyName
@@ -4624,6 +4625,7 @@ export type CreateWorkspaceMutationFn = Apollo.MutationFunction<CreateWorkspaceM
  *      autoEnroll: // value for 'autoEnroll'
  *      cpu: // value for 'cpu'
  *      memory: // value for 'memory'
+ *      labels: // value for 'labels'
  *      instances: // value for 'instances'
  *   },
  * });

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -3826,7 +3826,7 @@ export type CreateWorkspaceMutationVariables = Exact<{
   cpu: Scalars['JSON']['input'];
   memory: Scalars['JSON']['input'];
   labels: Scalars['JSON']['input'];
-  instances: Scalars['BigInt']['input'];
+  instances: Scalars['Int']['input'];
 }>;
 
 
@@ -4585,7 +4585,7 @@ export type CreateTemplateMutationHookResult = ReturnType<typeof useCreateTempla
 export type CreateTemplateMutationResult = Apollo.MutationResult<CreateTemplateMutation>;
 export type CreateTemplateMutationOptions = Apollo.BaseMutationOptions<CreateTemplateMutation, CreateTemplateMutationVariables>;
 export const CreateWorkspaceDocument = gql`
-    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $labels: JSON!, $instances: BigInt!) {
+    mutation createWorkspace($name: String!, $prettyName: String!, $autoEnroll: AutoEnroll, $cpu: JSON!, $memory: JSON!, $labels: JSON!, $instances: Int!) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
     itPolitoCrownlabsV1alpha1WorkspaceInput: {kind: "Workspace", apiVersion: "crownlabs.polito.it/v1alpha1", spec: {prettyName: $prettyName, autoEnroll: $autoEnroll, quota: {cpu: $cpu, memory: $memory, instances: $instances}}, metadata: {name: $name, labels: $labels}}
   ) {

--- a/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
+++ b/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
@@ -4,6 +4,7 @@ mutation createWorkspace(
   $autoEnroll: AutoEnroll
   $cpu: JSON!
   $memory: JSON!
+  $labels: JSON!
   $instances: BigInt!
 ) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
@@ -15,7 +16,10 @@ mutation createWorkspace(
         autoEnroll: $autoEnroll
         quota: { cpu: $cpu, memory: $memory, instances: $instances }
       }
-      metadata: { name: $name }
+      metadata: {
+        name: $name
+        labels: $labels
+      }
     }
   ) {
     spec {

--- a/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
+++ b/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
@@ -4,7 +4,7 @@ mutation createWorkspace(
   $autoEnroll: AutoEnroll
   $cpu: JSON!
   $memory: JSON!
-  $instances: Int!
+  $instances: BigInt!
 ) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
     itPolitoCrownlabsV1alpha1WorkspaceInput: {

--- a/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
+++ b/frontend/src/graphql-components/mutation/createWorkspace.mutation.graphql
@@ -5,7 +5,7 @@ mutation createWorkspace(
   $cpu: JSON!
   $memory: JSON!
   $labels: JSON!
-  $instances: BigInt!
+  $instances: Int!
 ) {
   createdWorkspace: createCrownlabsPolitoItV1alpha1Workspace(
     itPolitoCrownlabsV1alpha1WorkspaceInput: {


### PR DESCRIPTION
This MR includes the latest two commits from feat/manage-workspaces and improves workspace creation reliability and consistency.

What is included:
Quota fields refactor
Extracted CPU, Memory (Gi), and Instances into a single reusable component.
Reused the same component in both:
Personal Workspace settings (Manage user)
Create New Workspace form
This removes duplicated UI logic and keeps validation/behavior aligned.
GraphQL create workspace fixes
Updated the create workspace flow to use the correct instances scalar type (BigInt) to match backend expectations and avoid 400 validation errors.
Default operator selector label on creation
Added automatic label assignment during workspace creation:
crownlabs.polito.it/operator-selector = production
Applied only on create flow, not on edit flow, as required.
