### PR TITLE
chore: switch pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,11 +180,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: always()
 
-      - name: Notify Event to CrownOps
-        uses: peter-evans/repository-dispatch@v2
+      - name: Notify Event to OPS
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
-          repository: netgroup-polito/CrownOps
+          repository: netgroup-polito/ArgoCD-CrownNG
           event-type: preprod-event
           client-payload: '{"tag": "${{ needs.configure.outputs.ref }}"}'
 
@@ -199,11 +199,11 @@ jobs:
       needs.configure.outputs.repo-push == 'true'
 
     steps:
-      - name: Notify Event to CrownOps
-        uses: peter-evans/repository-dispatch@v2
+      - name: Notify Event to OPS
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
-          repository: netgroup-polito/CrownOps
+          repository: netgroup-polito/ArgoCD-CrownNG
           event-type: deploy-staging-event
           client-payload: |
             {
@@ -294,10 +294,10 @@ jobs:
               --pages-index-path index.yaml \
               --push
 
-      - name: Notify Event to CrownOps
-        uses: peter-evans/repository-dispatch@v2
+      - name: Notify Event to OPS
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
-          repository: netgroup-polito/CrownOps
+          repository: netgroup-polito/ArgoCD-CrownNG
           event-type: release-event
           client-payload: '{"version": "${{ needs.configure.outputs.version }}"}'

--- a/.github/workflows/delete-staging.yml
+++ b/.github/workflows/delete-staging.yml
@@ -20,11 +20,11 @@ jobs:
             echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT || \
             echo "number=${{ github.event.client_payload.github.payload.issue.number }}" >> $GITHUB_OUTPUT
 
-      - name: Notify Event to CrownOps
-        uses: peter-evans/repository-dispatch@v2
+      - name: Notify Event to OPS
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CI_TOKEN }}
-          repository: netgroup-polito/CrownOps
+          repository: netgroup-polito/ArgoCD-CrownNG
           event-type: undeploy-staging-event
           client-payload: |
             {
@@ -37,5 +37,5 @@ jobs:
         with:
           token: ${{ secrets.CI_TOKEN }}
           comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
-          reactions: 'hooray'
+          reactions: "hooray"
         if: github.event_name == 'repository_dispatch'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to modernize event notification steps and align repository references with current infrastructure. The main changes are the upgrade of the `peter-evans/repository-dispatch` action to a newer version and the switch of target repository references from `CrownOps` to `ArgoCD-CrownNG`.
