### PR TITLE
Configure golangci-lint plugin to tidy imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,68 @@ linters:
         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         See the License for the specific language governing permissions and
         limitations under the License.
+    importas:
+      no-unaliased: true
+      no-extra-aliases: false
+      alias:
+      # CrownLabs Internal APIs
+      - pkg: github.com/netgroup-polito/CrownLabs/operators/api/common
+        alias: apicommon
+      - pkg: github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1
+        alias: clv1alpha1
+      - pkg: github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2
+        alias: clv1alpha2
+      - pkg: github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext
+        alias: clctx
+      - pkg: github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common
+        alias: ctrlcommon
+      
+      # Kubernetes APIs (Standard Naming Convention)
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/api/batch/v1
+        alias: batchv1
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/api/networking/v1
+        alias: netv1
+      - pkg: k8s.io/api/rbac/v1
+        alias: rbacv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: kerrors
+      - pkg: k8s.io/apimachinery/pkg/runtime
+        
+      # Controller Runtime
+      - pkg: sigs.k8s.io/controller-runtime
+        alias: ctrl
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client
+      - pkg: sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
+        alias: ctrlutil
+      
+      # Kubernetes Client
+      - pkg: k8s.io/client-go/kubernetes/scheme
+      
+      # KubeVirt
+      - pkg: kubevirt.io/api/core/v1
+        alias: virtv1
+      
+      # Mocking
+      - pkg: github.com/golang/mock/gomock
+      - pkg: go.uber.org/mock/gomock
+
+      # Keycloak
+      - pkg: github.com/Nerzal/gocloak/v7
+        alias: gocloak7
+      - pkg: github.com/Nerzal/gocloak/v13
+        alias: gocloak13
+      
+      # Standard Library (no aliases)
+      - pkg: context
+      - pkg: time
+      - pkg: io
+      - pkg: reflect
     misspell:
       locale: US
     nolintlint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,16 +98,19 @@ linters:
       - pkg: k8s.io/apimachinery/pkg/api/errors
         alias: kerrors
       - pkg: k8s.io/apimachinery/pkg/runtime
+        alias: ""
         
       # Controller Runtime
       - pkg: sigs.k8s.io/controller-runtime
         alias: ctrl
       - pkg: sigs.k8s.io/controller-runtime/pkg/client
+        alias: ""
       - pkg: sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
         alias: ctrlutil
       
       # Kubernetes Client
       - pkg: k8s.io/client-go/kubernetes/scheme
+        alias: ""
       
       # KubeVirt
       - pkg: kubevirt.io/api/core/v1
@@ -115,7 +118,9 @@ linters:
       
       # Mocking
       - pkg: github.com/golang/mock/gomock
+        alias: ""
       - pkg: go.uber.org/mock/gomock
+        alias: ""
 
       # Keycloak
       - pkg: github.com/Nerzal/gocloak/v7
@@ -125,9 +130,13 @@ linters:
       
       # Standard Library (no aliases)
       - pkg: context
+        alias: ""
       - pkg: time
+        alias: ""
       - pkg: io
+        alias: ""
       - pkg: reflect
+        alias: ""
     misspell:
       locale: US
     nolintlint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,8 +119,6 @@ linters:
       # Mocking
       - pkg: github.com/golang/mock/gomock
         alias: ""
-      - pkg: go.uber.org/mock/gomock
-        alias: ""
 
       # Keycloak
       - pkg: github.com/Nerzal/gocloak/v7

--- a/operators/api/v1alpha1/workspace_types.go
+++ b/operators/api/v1alpha1/workspace_types.go
@@ -17,8 +17,8 @@ package v1alpha1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -49,7 +49,7 @@ type WorkspaceSpec struct {
 	AutoEnroll WorkspaceAutoenroll `json:"autoEnroll,omitempty"`
 
 	// The amount of resources associated with this workspace, and inherited by enrolled tenants.
-	Quota common.WorkspaceResourceQuota `json:"quota"`
+	Quota apicommon.WorkspaceResourceQuota `json:"quota"`
 }
 
 // WorkspaceStatus reflects the most recently observed status of the Workspace.
@@ -58,12 +58,12 @@ type WorkspaceStatus struct {
 	// This is the namespace that groups multiple related templates, together
 	// with all the accessory resources (e.g. RBACs) created by the tenant
 	// operator.
-	Namespace v1alpha2.NameCreated `json:"namespace,omitempty"`
+	Namespace clv1alpha2.NameCreated `json:"namespace,omitempty"`
 
 	// The list of the subscriptions to external services (e.g. Keycloak,
 	// ...), indicating for each one whether it succeeded or an error
 	// occurred.
-	Subscriptions map[string]v1alpha2.SubscriptionStatus `json:"subscription,omitempty"`
+	Subscriptions map[string]clv1alpha2.SubscriptionStatus `json:"subscription,omitempty"`
 
 	// Whether all subscriptions and resource creations succeeded or an error
 	// occurred. In case of errors, the other status fields provide additional

--- a/operators/api/v1alpha2/instance_types.go
+++ b/operators/api/v1alpha2/instance_types.go
@@ -15,7 +15,7 @@
 package v1alpha2
 
 import (
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -186,7 +186,7 @@ type PublicServicePort struct {
 	// The port protocol
 	// +kubebuilder:validation:Enum=TCP;UDP;SCTP
 	// +kubebuilder:default=TCP
-	Protocol v1.Protocol `json:"protocol,omitempty"`
+	Protocol corev1.Protocol `json:"protocol,omitempty"`
 }
 
 // PublicExposurePhase is an enumeration of the different phases associated with the public exposure of an instance.

--- a/operators/api/v1alpha2/tenant_types.go
+++ b/operators/api/v1alpha2/tenant_types.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -91,7 +91,7 @@ type TenantSpec struct {
 	CreateSandbox bool `json:"createSandbox,omitempty"`
 
 	// The amount of resources associated with the Tenant's personal workspace. If defined, the personal workspace is enabled.
-	PersonalWorkspace *common.WorkspaceResourceQuota `json:"personalWorkspace,omitempty"`
+	PersonalWorkspace *apicommon.WorkspaceResourceQuota `json:"personalWorkspace,omitempty"`
 }
 
 // KeycloakStatus defines the status of the authentication flow with Keycloak.

--- a/operators/cmd/bastion-operator/main.go
+++ b/operators/cmd/bastion-operator/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -28,20 +28,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	bastion_controller "github.com/netgroup-polito/CrownLabs/operators/pkg/bastion-controller"
 )
 
 var (
-	scheme = runtime.NewScheme()
+	rscheme = runtime.NewScheme()
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
+	_ = scheme.AddToScheme(rscheme)
 
-	_ = crownlabsv1alpha1.AddToScheme(scheme)
-	_ = crownlabsv1alpha2.AddToScheme(scheme)
+	_ = clv1alpha1.AddToScheme(rscheme)
+	_ = clv1alpha2.AddToScheme(rscheme)
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -56,7 +56,7 @@ func main() {
 	flag.Parse()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme:                 rscheme,
 		Metrics:                server.Options{BindAddress: metricsAddr},
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		LeaderElection:         enableLeaderElection,

--- a/operators/cmd/instance-automation/main.go
+++ b/operators/cmd/instance-automation/main.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/mail"
@@ -43,18 +43,18 @@ import (
 )
 
 var (
-	scheme     = runtime.NewScheme()
+	rscheme    = runtime.NewScheme()
 	mailClient *mail.Client
 )
 
 func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(scheme.AddToScheme(rscheme))
 
-	utilruntime.Must(crownlabsv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(crownlabsv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(clv1alpha1.AddToScheme(rscheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(rscheme))
 
-	utilruntime.Must(virtv1.AddToScheme(scheme))
-	utilruntime.Must(cdiv1beta1.AddToScheme(scheme))
+	utilruntime.Must(virtv1.AddToScheme(rscheme))
+	utilruntime.Must(cdiv1beta1.AddToScheme(rscheme))
 }
 
 func main() {
@@ -118,7 +118,7 @@ func main() {
 	log.Info("restricting reconciled namespaces", "labels", *namespaceWhiteList)
 
 	mgr, err := ctrl.NewManager(restcfg.SetRateLimiter(ctrl.GetConfigOrDie()), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme:                 rscheme,
 		Metrics:                server.Options{BindAddress: *metricsAddr},
 		LeaderElection:         *enableLeaderElection,
 		HealthProbeBindAddress: ":8081",

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
@@ -34,8 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	instancesnapshot_controller "github.com/netgroup-polito/CrownLabs/operators/pkg/instancesnapshot-controller"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instctrl"
@@ -44,17 +44,17 @@ import (
 )
 
 var (
-	scheme = runtime.NewScheme()
+	rscheme = runtime.NewScheme()
 )
 
 func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(scheme.AddToScheme(rscheme))
 
-	utilruntime.Must(crownlabsv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(crownlabsv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(clv1alpha1.AddToScheme(rscheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(rscheme))
 
-	utilruntime.Must(virtv1.AddToScheme(scheme))
-	utilruntime.Must(cdiv1beta1.AddToScheme(scheme))
+	utilruntime.Must(virtv1.AddToScheme(rscheme))
+	utilruntime.Must(cdiv1beta1.AddToScheme(rscheme))
 }
 
 func main() {
@@ -112,7 +112,7 @@ func main() {
 
 	// Configure the manager
 	mgr, err := ctrl.NewManager(restcfg.SetRateLimiter(ctrl.GetConfigOrDie()), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme:                 rscheme,
 		Metrics:                server.Options{BindAddress: *metricsAddr},
 		LeaderElection:         *enableLeaderElection,
 		HealthProbeBindAddress: ":8081",

--- a/operators/cmd/operator/instance.go
+++ b/operators/cmd/operator/instance.go
@@ -18,7 +18,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	instancewebhook "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/instance/webhook"
 )
 
@@ -44,7 +44,7 @@ func setupInstanceWebhook(
 	mgr ctrl.Manager,
 ) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&crownlabsv1alpha2.Instance{}).
+		For(&clv1alpha2.Instance{}).
 		WithValidator(&instancewebhook.InstanceValidator{
 			Client: mgr.GetClient(),
 		}).

--- a/operators/cmd/operator/keycloak.go
+++ b/operators/cmd/operator/keycloak.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 var (
@@ -63,7 +63,7 @@ func setupKeycloak(
 	if keycloakCompatibilityMode {
 		log.Info("WARNING: Keycloak compatibility mode is enabled")
 
-		err := common.SetupKeycloakActorCompatibility(
+		err := ctrlcommon.SetupKeycloakActorCompatibility(
 			ctx,
 			keycloakURL,
 			keycloakClientID,
@@ -76,7 +76,7 @@ func setupKeycloak(
 			return err
 		}
 	} else {
-		err := common.SetupKeycloakActor(
+		err := ctrlcommon.SetupKeycloakActor(
 			ctx,
 			keycloakURL,
 			keycloakClientID,

--- a/operators/cmd/operator/main.go
+++ b/operators/cmd/operator/main.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -29,25 +29,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 var (
-	scheme         = runtime.NewScheme()
+	rscheme        = runtime.NewScheme()
 	enableWebhooks bool
-	reschedule     = common.Rescheduler{
+	reschedule     = ctrlcommon.Rescheduler{
 		RequeueAfterMin: 1 * 24 * time.Hour,
 		RequeueAfterMax: 7 * 24 * time.Hour,
 	}
 )
 
 func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(scheme.AddToScheme(rscheme))
 
-	utilruntime.Must(v1alpha1.AddToScheme(scheme))
-	utilruntime.Must(v1alpha2.AddToScheme(scheme))
+	utilruntime.Must(clv1alpha1.AddToScheme(rscheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(rscheme))
 }
 
 func main() {
@@ -99,7 +99,7 @@ func main() {
 	log := ctrl.Log.WithName("setup")
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
+		Scheme:                 rscheme,
 		Metrics:                server.Options{BindAddress: metricsAddr},
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		LeaderElection:         enableLeaderElection,
@@ -111,7 +111,7 @@ func main() {
 		klog.Fatal(err, "Unable to create manager")
 	}
 
-	targetLabel, err := common.ParseLabel(targetLabelStr)
+	targetLabel, err := ctrlcommon.ParseLabel(targetLabelStr)
 	if err != nil {
 		klog.Fatal(err, "Unable to parse target label")
 	}

--- a/operators/cmd/operator/pmp.go
+++ b/operators/cmd/operator/pmp.go
@@ -21,7 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/pmp"
 )
 
@@ -39,7 +39,7 @@ func setupPmp(
 	ctx context.Context,
 	mgr manager.Manager,
 	log logr.Logger,
-	targetLabel common.KVLabel,
+	targetLabel ctrlcommon.KVLabel,
 ) error {
 	log = log.WithName("pmp")
 

--- a/operators/cmd/operator/sharedvolume.go
+++ b/operators/cmd/operator/sharedvolume.go
@@ -19,7 +19,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/sharedvolume"
 )
 
@@ -39,7 +39,7 @@ func init() {
 
 func setupSharedVolume(
 	mgr manager.Manager,
-	targetLabel common.KVLabel,
+	targetLabel ctrlcommon.KVLabel,
 ) error {
 	shvol := &sharedvolume.Reconciler{
 		Client:          mgr.GetClient(),

--- a/operators/cmd/operator/tenant.go
+++ b/operators/cmd/operator/tenant.go
@@ -27,8 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/tenant"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/tenant/webhook"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
@@ -82,7 +82,7 @@ func init() {
 func setupTenant(
 	mgr manager.Manager,
 	log logr.Logger,
-	targetLabel common.KVLabel,
+	targetLabel ctrlcommon.KVLabel,
 ) error {
 	var baseWorkspacesList []string
 	if tenantBaseWorkspaces != "" {
@@ -100,7 +100,7 @@ func setupTenant(
 		MyDrivePVCsStorageClassName: mydrivePVCsStorageClassName,
 		MyDrivePVCsNamespace:        myDrivePVCsNamespace,
 		MirrorPVCStorageClassName:   mirrorStorageClass,
-		KeycloakActor:               common.GetKeycloakActor(),
+		KeycloakActor:               ctrlcommon.GetKeycloakActor(),
 		WaitUserVerification:        waitUserVerification,
 		SandboxClusterRole:          sandboxClusterRole,
 		BaseWorkspaces:              baseWorkspacesList,
@@ -182,7 +182,7 @@ func startKeycloakWebhookHTTPServer(
 
 func setupTenantWebhook(
 	mgr manager.Manager,
-	targetLabel common.KVLabel,
+	targetLabel ctrlcommon.KVLabel,
 	baseWorkspaces []string,
 ) error {
 	tnWh := webhook.TenantWebhook{
@@ -191,7 +191,7 @@ func setupTenantWebhook(
 	}
 
 	if err := ctrl.NewWebhookManagedBy(mgr).
-		For(&v1alpha2.Tenant{}).
+		For(&clv1alpha2.Tenant{}).
 		WithValidator(&webhook.TenantValidator{
 			TenantWebhook: tnWh,
 		}).

--- a/operators/cmd/operator/workspace.go
+++ b/operators/cmd/operator/workspace.go
@@ -18,7 +18,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/workspace"
 )
 
@@ -27,14 +27,14 @@ func init() {}
 func setupWorkspace(
 	mgr manager.Manager,
 	log logr.Logger,
-	targetLabel common.KVLabel,
+	targetLabel ctrlcommon.KVLabel,
 ) error {
 	// Create the Workspace Reconciler
 	wr := &workspace.Reconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		TargetLabel:   targetLabel,
-		KeycloakActor: common.GetKeycloakActor(),
+		KeycloakActor: ctrlcommon.GetKeycloakActor(),
 		Reschedule:    reschedule,
 	}
 

--- a/operators/cmd/webssh/main.go
+++ b/operators/cmd/webssh/main.go
@@ -24,23 +24,23 @@ import (
 
 	"github.com/go-logr/stdr"
 	"k8s.io/apimachinery/pkg/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
-	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/webssh"
 )
 
 var (
-	scheme = runtime.NewScheme()
+	rscheme = runtime.NewScheme()
 )
 
 func init() {
-	_ = clientgoscheme.AddToScheme(scheme)
-	_ = crownlabsv1alpha1.AddToScheme(scheme)
-	_ = crownlabsv1alpha2.AddToScheme(scheme)
+	_ = scheme.AddToScheme(rscheme)
+	_ = clv1alpha1.AddToScheme(rscheme)
+	_ = clv1alpha2.AddToScheme(rscheme)
 }
 
 func main() {

--- a/operators/go.mod
+++ b/operators/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/onsi/gomega v1.37.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/prometheus/common v0.66.0
-	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
 	golang.org/x/text v0.32.0

--- a/operators/go.sum
+++ b/operators/go.sum
@@ -272,8 +272,6 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
-go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/operators/pkg/bastion-controller/bastion_controller.go
+++ b/operators/pkg/bastion-controller/bastion_controller.go
@@ -20,13 +20,13 @@ import (
 	"os"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crownlabsalpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // BastionReconciler reconciles a Bastion object.
@@ -49,10 +49,10 @@ func (r *BastionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	klog.Infof("reconciling bastion [tenant=%s]", req.Name)
 
-	tenant := &crownlabsalpha2.Tenant{}
+	tenant := &clv1alpha2.Tenant{}
 	deleted := false
 
-	if err := r.Get(ctx, req.NamespacedName, tenant); apierrors.IsNotFound(err) {
+	if err := r.Get(ctx, req.NamespacedName, tenant); kerrors.IsNotFound(err) {
 		deleted = true
 	} else if err != nil {
 		return ctrl.Result{}, err
@@ -100,6 +100,6 @@ func (r *BastionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager registers a new controller for Tenant resources.
 func (r *BastionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&crownlabsalpha2.Tenant{}).
+		For(&clv1alpha2.Tenant{}).
 		Complete(r)
 }

--- a/operators/pkg/bastion-controller/bastion_controller_test.go
+++ b/operators/pkg/bastion-controller/bastion_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
-	crownlabsalpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Bastion controller - creating two tenants", func() {
@@ -86,13 +86,13 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 			"ssh-rsa abcdefghi comment",
 		}
 
-		tenant1 := &crownlabsalpha2.Tenant{}
-		tenant2 := &crownlabsalpha2.Tenant{}
+		tenant1 := &clv1alpha2.Tenant{}
+		tenant2 := &clv1alpha2.Tenant{}
 
 		// create or update tenant in order to reset the specs
 
 		if err1 := k8sClient.Get(ctx, tenant1LookupKey, tenant1); err1 != nil {
-			tenant1 = &crownlabsalpha2.Tenant{
+			tenant1 = &clv1alpha2.Tenant{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "crownlabs.polito.it/v1alpha1",
 					Kind:       "Tenant",
@@ -100,11 +100,11 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: NameTenant1,
 				},
-				Spec: crownlabsalpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName:  "Mario",
 					LastName:   "Rossi",
 					Email:      "mario.rossi@fakemail.com",
-					Workspaces: []crownlabsalpha2.TenantWorkspaceEntry{},
+					Workspaces: []clv1alpha2.TenantWorkspaceEntry{},
 					PublicKeys: PublicKeysTenant1,
 				},
 			}
@@ -114,7 +114,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 			Expect(k8sClient.Update(ctx, tenant1)).Should(Succeed())
 		}
 
-		updatedTenant1 := &crownlabsalpha2.Tenant{}
+		updatedTenant1 := &clv1alpha2.Tenant{}
 
 		Eventually(func() []string {
 			err := k8sClient.Get(ctx, tenant1LookupKey, updatedTenant1)
@@ -125,7 +125,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 		}, timeout, interval).Should(Equal(PublicKeysTenant1))
 
 		if err2 := k8sClient.Get(ctx, tenant2LookupKey, tenant2); err2 != nil {
-			tenant2 = &crownlabsalpha2.Tenant{
+			tenant2 = &clv1alpha2.Tenant{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "crownlabs.polito.it/v1alpha1",
 					Kind:       "Tenant",
@@ -133,11 +133,11 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: NameTenant2,
 				},
-				Spec: crownlabsalpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName:  "Fabio",
 					LastName:   "Bianchi",
 					Email:      "fabio.bianchi@fakemail.com",
-					Workspaces: []crownlabsalpha2.TenantWorkspaceEntry{},
+					Workspaces: []clv1alpha2.TenantWorkspaceEntry{},
 					PublicKeys: PublicKeysTenant2,
 				},
 			}
@@ -147,7 +147,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 			Expect(k8sClient.Update(ctx, tenant2)).Should(Succeed())
 		}
 
-		updatedTenant2 := &crownlabsalpha2.Tenant{}
+		updatedTenant2 := &clv1alpha2.Tenant{}
 
 		Eventually(func() []string {
 			err := k8sClient.Get(ctx, tenant2LookupKey, updatedTenant2)
@@ -181,7 +181,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 	Context("When updating the keys of the one tenant", func() {
 		BeforeEach(func() {
 
-			createdTenant := &crownlabsalpha2.Tenant{}
+			createdTenant := &clv1alpha2.Tenant{}
 
 			Eventually(func() []string {
 				err := k8sClient.Get(ctx, tenant1LookupKey, createdTenant)
@@ -202,7 +202,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 				return k8sClient.Update(ctx, createdTenant)
 			})).Should(Succeed())
 
-			updatedTenant := &crownlabsalpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 
 			Eventually(func() []string {
 				err := k8sClient.Get(ctx, tenant1LookupKey, updatedTenant)
@@ -224,7 +224,7 @@ var _ = Describe("Bastion controller - creating two tenants", func() {
 
 	Context("When deleting a Tenant", func() {
 		BeforeEach(func() {
-			Expect(k8sClient.Delete(ctx, &crownlabsalpha2.Tenant{
+			Expect(k8sClient.Delete(ctx, &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: NameTenant1,
 				},

--- a/operators/pkg/bastion-controller/suite_test.go
+++ b/operators/pkg/bastion-controller/suite_test.go
@@ -28,8 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	crownlabsv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
 )
 
@@ -59,8 +59,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	Expect(crownlabsv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(crownlabsv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/operators/pkg/controller/common/auth.go
+++ b/operators/pkg/controller/common/auth.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
@@ -33,7 +33,7 @@ type KeycloakActor struct {
 	initialized    bool
 	Client         GoCloakIface
 	Realm          string
-	token          *gocloak.JWT
+	token          *gocloak13.JWT
 	tokenMutex     sync.RWMutex
 	tokenExpiresAt int64
 	credentials    struct {
@@ -65,7 +65,7 @@ func SetupKeycloakActor(
 	}
 
 	if actor.Client == nil {
-		actor.Client = gocloak.NewClient(url)
+		actor.Client = gocloak13.NewClient(url)
 	}
 
 	// login to keycloak
@@ -144,10 +144,10 @@ func (a *KeycloakActor) GetAccessToken(ctx context.Context) string {
 func (a *KeycloakActor) GetUser(
 	ctx context.Context,
 	username string,
-) (*gocloak.User, error) {
+) (*gocloak13.User, error) {
 	log := klog.FromContext(ctx)
 
-	users, err := a.Client.GetUsers(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.GetUsersParams{
+	users, err := a.Client.GetUsers(ctx, a.GetAccessToken(ctx), a.Realm, gocloak13.GetUsersParams{
 		Username: &username,
 	})
 	if err != nil {
@@ -162,7 +162,7 @@ func (a *KeycloakActor) GetUser(
 	}
 
 	// If there are multiple users, look for the one that exactly matches the searched username
-	var user *gocloak.User
+	var user *gocloak13.User
 	if *users[0].Username != username {
 		for _, u := range users {
 			if u.Username != nil && *u.Username == username {
@@ -189,13 +189,13 @@ func (a *KeycloakActor) CreateUser(
 	firstName string,
 	lastName string,
 ) (string, error) {
-	user := gocloak.User{
+	user := gocloak13.User{
 		Username:      &username,
 		Email:         &email,
 		FirstName:     &firstName,
 		LastName:      &lastName,
-		Enabled:       gocloak.BoolP(true),
-		EmailVerified: gocloak.BoolP(false),
+		Enabled:       gocloak13.BoolP(true),
+		EmailVerified: gocloak13.BoolP(false),
 	}
 
 	userID, err := a.Client.CreateUser(ctx, a.GetAccessToken(ctx), a.Realm, user)
@@ -207,7 +207,7 @@ func (a *KeycloakActor) CreateUser(
 	requiredActions := []string{"UPDATE_PASSWORD", "VERIFY_EMAIL"}
 	// user should do it in the next 30 days
 	lifespan := 60 * 60 * 24 * 30
-	err = a.Client.ExecuteActionsEmail(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.ExecuteActionsEmail{
+	err = a.Client.ExecuteActionsEmail(ctx, a.GetAccessToken(ctx), a.Realm, gocloak13.ExecuteActionsEmail{
 		UserID:   &userID,
 		Actions:  &requiredActions,
 		Lifespan: &lifespan,
@@ -243,7 +243,7 @@ func (a *KeycloakActor) getClientInternalIdentifierByClientID(
 	a.cacheMutex.RUnlock()
 
 	// If not in cache, fetch the client from Keycloak
-	clients, err := a.Client.GetClients(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.GetClientsParams{
+	clients, err := a.Client.GetClients(ctx, a.GetAccessToken(ctx), a.Realm, gocloak13.GetClientsParams{
 		ClientID: &clientID,
 	})
 	if err != nil {
@@ -267,7 +267,7 @@ func (a *KeycloakActor) getClientInternalIdentifierByClientID(
 func (a *KeycloakActor) GetRole(
 	ctx context.Context,
 	roleName string,
-) (*gocloak.Role, error) {
+) (*gocloak13.Role, error) {
 	log := klog.FromContext(ctx)
 
 	clientID, err := a.getClientInternalIdentifierByClientID(ctx, a.RolesClientID)
@@ -303,7 +303,7 @@ func (a *KeycloakActor) CreateRole(
 ) (string, error) {
 	log := klog.FromContext(ctx)
 
-	role := gocloak.Role{
+	role := gocloak13.Role{
 		Name:        &roleName,
 		Description: &roleDescription,
 	}
@@ -364,7 +364,7 @@ func (a *KeycloakActor) DeleteRole(
 func (a *KeycloakActor) GetUserRoles(
 	ctx context.Context,
 	userID string,
-) ([]*gocloak.Role, error) {
+) ([]*gocloak13.Role, error) {
 	log := klog.FromContext(ctx)
 
 	clientID, err := a.getClientInternalIdentifierByClientID(ctx, a.RolesClientID)
@@ -396,7 +396,7 @@ func (a *KeycloakActor) GetUserRoles(
 func (a *KeycloakActor) AddUserToRoles(
 	ctx context.Context,
 	userID string,
-	roles []*gocloak.Role,
+	roles []*gocloak13.Role,
 ) error {
 	log := klog.FromContext(ctx)
 
@@ -407,7 +407,7 @@ func (a *KeycloakActor) AddUserToRoles(
 	}
 
 	// Convert []*gocloak.Role to []gocloak.Role
-	rolesVal := make([]gocloak.Role, len(roles))
+	rolesVal := make([]gocloak13.Role, len(roles))
 	for i, r := range roles {
 		if r != nil {
 			rolesVal[i] = *r
@@ -435,7 +435,7 @@ func (a *KeycloakActor) AddUserToRoles(
 func (a *KeycloakActor) RemoveUserFromRoles(
 	ctx context.Context,
 	userID string,
-	roles []*gocloak.Role,
+	roles []*gocloak13.Role,
 ) error {
 	log := klog.FromContext(ctx)
 
@@ -446,7 +446,7 @@ func (a *KeycloakActor) RemoveUserFromRoles(
 	}
 
 	// Convert []*gocloak.Role to []gocloak.Role
-	rolesVal := make([]gocloak.Role, len(roles))
+	rolesVal := make([]gocloak13.Role, len(roles))
 	for i, r := range roles {
 		if r != nil {
 			rolesVal[i] = *r

--- a/operators/pkg/controller/common/auth_compatibility.go
+++ b/operators/pkg/controller/common/auth_compatibility.go
@@ -23,8 +23,8 @@ import (
 	"sync"
 	"time"
 
-	gk13 "github.com/Nerzal/gocloak/v13"
-	"github.com/Nerzal/gocloak/v7"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
+	gocloak7 "github.com/Nerzal/gocloak/v7"
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
@@ -32,9 +32,9 @@ import (
 // KeycloakActorCompatibility contains the functionality to interact with Keycloak.
 type KeycloakActorCompatibility struct {
 	initialized    bool
-	Client         gocloak.GoCloak
+	Client         gocloak7.GoCloak
 	Realm          string
-	token          *gocloak.JWT
+	token          *gocloak7.JWT
 	tokenMutex     sync.RWMutex
 	tokenExpiresAt int64
 	credentials    struct {
@@ -65,7 +65,7 @@ func SetupKeycloakActorCompatibility(
 	actorIface = &actorCompatibility
 
 	if actorCompatibility.Client == nil {
-		actorCompatibility.Client = gocloak.NewClient(url)
+		actorCompatibility.Client = gocloak7.NewClient(url)
 	}
 
 	// login to keycloak
@@ -139,10 +139,10 @@ func (a *KeycloakActorCompatibility) GetAccessToken(ctx context.Context) string 
 func (a *KeycloakActorCompatibility) GetUser(
 	ctx context.Context,
 	username string,
-) (*gk13.User, error) {
+) (*gocloak13.User, error) {
 	log := klog.FromContext(ctx)
 
-	users, err := a.Client.GetUsers(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.GetUsersParams{
+	users, err := a.Client.GetUsers(ctx, a.GetAccessToken(ctx), a.Realm, gocloak7.GetUsersParams{
 		Username: &username,
 	})
 	if err != nil {
@@ -157,7 +157,7 @@ func (a *KeycloakActorCompatibility) GetUser(
 	}
 
 	// If there are multiple users, look for the one that exactly matches the searched username
-	var user *gocloak.User
+	var user *gocloak7.User
 	if *users[0].Username != username {
 		for _, u := range users {
 			if u.Username != nil && *u.Username == username {
@@ -184,13 +184,13 @@ func (a *KeycloakActorCompatibility) CreateUser(
 	firstName string,
 	lastName string,
 ) (string, error) {
-	user := gocloak.User{
+	user := gocloak7.User{
 		Username:      &username,
 		Email:         &email,
 		FirstName:     &firstName,
 		LastName:      &lastName,
-		Enabled:       gocloak.BoolP(true),
-		EmailVerified: gocloak.BoolP(false),
+		Enabled:       gocloak7.BoolP(true),
+		EmailVerified: gocloak7.BoolP(false),
 	}
 
 	userID, err := a.Client.CreateUser(ctx, a.GetAccessToken(ctx), a.Realm, user)
@@ -202,7 +202,7 @@ func (a *KeycloakActorCompatibility) CreateUser(
 	requiredActions := []string{"UPDATE_PASSWORD", "VERIFY_EMAIL"}
 	// user should do it in the next 30 days
 	lifespan := 60 * 60 * 24 * 30
-	err = a.Client.ExecuteActionsEmail(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.ExecuteActionsEmail{
+	err = a.Client.ExecuteActionsEmail(ctx, a.GetAccessToken(ctx), a.Realm, gocloak7.ExecuteActionsEmail{
 		UserID:   &userID,
 		Actions:  &requiredActions,
 		Lifespan: &lifespan,
@@ -238,7 +238,7 @@ func (a *KeycloakActorCompatibility) getClientInternalIdentifierByClientID(
 	a.cacheMutex.RUnlock()
 
 	// If not in cache, fetch the client from Keycloak
-	clients, err := a.Client.GetClients(ctx, a.GetAccessToken(ctx), a.Realm, gocloak.GetClientsParams{
+	clients, err := a.Client.GetClients(ctx, a.GetAccessToken(ctx), a.Realm, gocloak7.GetClientsParams{
 		ClientID: &clientID,
 	})
 	if err != nil {
@@ -262,7 +262,7 @@ func (a *KeycloakActorCompatibility) getClientInternalIdentifierByClientID(
 func (a *KeycloakActorCompatibility) GetRole(
 	ctx context.Context,
 	roleName string,
-) (*gk13.Role, error) {
+) (*gocloak13.Role, error) {
 	log := klog.FromContext(ctx)
 
 	clientID, err := a.getClientInternalIdentifierByClientID(ctx, a.RolesClientID)
@@ -298,7 +298,7 @@ func (a *KeycloakActorCompatibility) CreateRole(
 ) (string, error) {
 	log := klog.FromContext(ctx)
 
-	role := gocloak.Role{
+	role := gocloak7.Role{
 		Name:        &roleName,
 		Description: &roleDescription,
 	}
@@ -359,7 +359,7 @@ func (a *KeycloakActorCompatibility) DeleteRole(
 func (a *KeycloakActorCompatibility) GetUserRoles(
 	ctx context.Context,
 	userID string,
-) ([]*gk13.Role, error) {
+) ([]*gocloak13.Role, error) {
 	log := klog.FromContext(ctx)
 
 	clientID, err := a.getClientInternalIdentifierByClientID(ctx, a.RolesClientID)
@@ -391,7 +391,7 @@ func (a *KeycloakActorCompatibility) GetUserRoles(
 func (a *KeycloakActorCompatibility) AddUserToRoles(
 	ctx context.Context,
 	userID string,
-	roles []*gk13.Role,
+	roles []*gocloak13.Role,
 ) error {
 	log := klog.FromContext(ctx)
 
@@ -402,7 +402,7 @@ func (a *KeycloakActorCompatibility) AddUserToRoles(
 	}
 
 	// Convert []*gocloak.Role to []gocloak.Role
-	rolesVal := make([]gocloak.Role, len(roles))
+	rolesVal := make([]gocloak7.Role, len(roles))
 	for i, r := range roles {
 		if r != nil {
 			rolesVal[i] = *a.convertRoleV13to7(r)
@@ -430,7 +430,7 @@ func (a *KeycloakActorCompatibility) AddUserToRoles(
 func (a *KeycloakActorCompatibility) RemoveUserFromRoles(
 	ctx context.Context,
 	userID string,
-	roles []*gk13.Role,
+	roles []*gocloak13.Role,
 ) error {
 	log := klog.FromContext(ctx)
 
@@ -441,7 +441,7 @@ func (a *KeycloakActorCompatibility) RemoveUserFromRoles(
 	}
 
 	// Convert []*gocloak.Role to []gocloak.Role
-	rolesVal := make([]gocloak.Role, len(roles))
+	rolesVal := make([]gocloak7.Role, len(roles))
 	for i, r := range roles {
 		if r != nil {
 			rolesVal[i] = *a.convertRoleV13to7(r)
@@ -465,8 +465,8 @@ func (a *KeycloakActorCompatibility) RemoveUserFromRoles(
 	return nil
 }
 
-func (a *KeycloakActorCompatibility) convertUserV7to13(v7 *gocloak.User) *gk13.User {
-	return &gk13.User{
+func (a *KeycloakActorCompatibility) convertUserV7to13(v7 *gocloak7.User) *gocloak13.User {
+	return &gocloak13.User{
 		ID:            v7.ID,
 		Username:      v7.Username,
 		Email:         v7.Email,
@@ -477,24 +477,24 @@ func (a *KeycloakActorCompatibility) convertUserV7to13(v7 *gocloak.User) *gk13.U
 	}
 }
 
-func (a *KeycloakActorCompatibility) convertRoleV7to13(v7 *gocloak.Role) *gk13.Role {
-	return &gk13.Role{
+func (a *KeycloakActorCompatibility) convertRoleV7to13(v7 *gocloak7.Role) *gocloak13.Role {
+	return &gocloak13.Role{
 		ID:          v7.ID,
 		Name:        v7.Name,
 		Description: v7.Description,
 	}
 }
 
-func (a *KeycloakActorCompatibility) convertRolesV7to13(v7 []*gocloak.Role) []*gk13.Role {
-	roles := make([]*gk13.Role, len(v7))
+func (a *KeycloakActorCompatibility) convertRolesV7to13(v7 []*gocloak7.Role) []*gocloak13.Role {
+	roles := make([]*gocloak13.Role, len(v7))
 	for i, role := range v7 {
 		roles[i] = a.convertRoleV7to13(role)
 	}
 	return roles
 }
 
-func (a *KeycloakActorCompatibility) convertRoleV13to7(v13 *gk13.Role) *gocloak.Role {
-	return &gocloak.Role{
+func (a *KeycloakActorCompatibility) convertRoleV13to7(v13 *gocloak13.Role) *gocloak7.Role {
+	return &gocloak7.Role{
 		ID:          v13.ID,
 		Name:        v13.Name,
 		Description: v13.Description,

--- a/operators/pkg/controller/common/auth_compatibility_test.go
+++ b/operators/pkg/controller/common/auth_compatibility_test.go
@@ -20,8 +20,8 @@ import (
 	"sync"
 	"time"
 
-	gk13 "github.com/Nerzal/gocloak/v13"
-	"github.com/Nerzal/gocloak/v7"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
+	gocloak7 "github.com/Nerzal/gocloak/v7"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -78,7 +78,7 @@ var _ = Describe("Auth Compatibility", func() {
 					Client: mKcClient,
 				}
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "clientID", "clientSecret", "realm").Return(&gocloak.JWT{}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "clientID", "clientSecret", "realm").Return(&gocloak7.JWT{}, nil)
 
 				err := SetupKeycloakActorCompatibility(context.Background(), "url", "clientID", "clientSecret", "realm", "rolesClientID", testLogger)
 				Expect(err).NotTo(HaveOccurred())
@@ -148,7 +148,7 @@ var _ = Describe("Auth Compatibility", func() {
 				initialized:    true,
 				Client:         mKcClient,
 				Realm:          "test-realm",
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: 12345,
 				credentials: struct {
 					ClientID     string
@@ -184,7 +184,7 @@ var _ = Describe("Auth Compatibility", func() {
 		Context("when token is valid and not expired", func() {
 			It("should return the existing token", func() {
 				now := time.Now().Unix()
-				actorCompatibility.token = &gocloak.JWT{AccessToken: "test-token", ExpiresIn: 300}
+				actorCompatibility.token = &gocloak7.JWT{AccessToken: "test-token", ExpiresIn: 300}
 				actorCompatibility.tokenExpiresAt = now + 300 // valid for 5 minutes
 
 				token := actorCompatibility.GetAccessToken(context.Background())
@@ -197,7 +197,7 @@ var _ = Describe("Auth Compatibility", func() {
 				actorCompatibility.token = nil
 				actorCompatibility.tokenExpiresAt = 0
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak7.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actorCompatibility.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -207,10 +207,10 @@ var _ = Describe("Auth Compatibility", func() {
 		Context("when token is expired", func() {
 			It("should refresh the token", func() {
 				now := time.Now().Unix()
-				actorCompatibility.token = &gocloak.JWT{AccessToken: "old-token", ExpiresIn: 300}
+				actorCompatibility.token = &gocloak7.JWT{AccessToken: "old-token", ExpiresIn: 300}
 				actorCompatibility.tokenExpiresAt = now - 100 // expired
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak7.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actorCompatibility.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -220,10 +220,10 @@ var _ = Describe("Auth Compatibility", func() {
 		Context("when token is about to expire", func() {
 			It("should refresh the token", func() {
 				now := time.Now().Unix()
-				actorCompatibility.token = &gocloak.JWT{AccessToken: "old-token", ExpiresIn: 300}
+				actorCompatibility.token = &gocloak7.JWT{AccessToken: "old-token", ExpiresIn: 300}
 				actorCompatibility.tokenExpiresAt = now + 10 // expires in 10 seconds
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak7.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actorCompatibility.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -238,7 +238,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -246,15 +246,15 @@ var _ = Describe("Auth Compatibility", func() {
 		Context("when user exists", func() {
 			It("should return the user", func() {
 				username := "test-user"
-				expectedUser := &gocloak.User{Username: &username}
-				expectedUserV13 := &gk13.User{Username: gocloak.StringP(username)}
+				expectedUser := &gocloak7.User{Username: &username}
+				expectedUserV13 := &gocloak13.User{Username: gocloak7.StringP(username)}
 
 				mKcClient.EXPECT().GetUsers(
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{expectedUser}, nil)
+					gocloak7.GetUsersParams{Username: &username},
+				).Return([]*gocloak7.User{expectedUser}, nil)
 
 				user, err := actorCompatibility.GetUser(context.Background(), username)
 				Expect(err).NotTo(HaveOccurred())
@@ -270,8 +270,8 @@ var _ = Describe("Auth Compatibility", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{}, nil)
+					gocloak7.GetUsersParams{Username: &username},
+				).Return([]*gocloak7.User{}, nil)
 
 				user, err := actorCompatibility.GetUser(context.Background(), username)
 				Expect(err).To(MatchError("404"))
@@ -287,7 +287,7 @@ var _ = Describe("Auth Compatibility", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
+					gocloak7.GetUsersParams{Username: &username},
 				).Return(nil, fmt.Errorf("error fetching user"))
 
 				user, err := actorCompatibility.GetUser(context.Background(), username)
@@ -299,16 +299,16 @@ var _ = Describe("Auth Compatibility", func() {
 		Context("when the username is a substring of another username", func() {
 			It("should return the right user", func() {
 				username := "test-user"
-				expectedUser := &gocloak.User{Username: &username}
-				expectedUserV13 := &gk13.User{Username: gocloak.StringP(username)}
-				otherUser := &gocloak.User{Username: gocloak.StringP("test-user-other")}
+				expectedUser := &gocloak7.User{Username: &username}
+				expectedUserV13 := &gocloak13.User{Username: gocloak7.StringP(username)}
+				otherUser := &gocloak7.User{Username: gocloak7.StringP("test-user-other")}
 
 				mKcClient.EXPECT().GetUsers(
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{expectedUser, otherUser}, nil)
+					gocloak7.GetUsersParams{Username: &username},
+				).Return([]*gocloak7.User{expectedUser, otherUser}, nil)
 
 				user, err := actorCompatibility.GetUser(context.Background(), username)
 				Expect(err).NotTo(HaveOccurred())
@@ -324,7 +324,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -336,13 +336,13 @@ var _ = Describe("Auth Compatibility", func() {
 			lastName := "User"
 			userID := "test-user-id"
 
-			expectedUser := gocloak.User{
+			expectedUser := gocloak7.User{
 				Username:      &username,
 				Email:         &email,
 				FirstName:     &firstName,
 				LastName:      &lastName,
-				Enabled:       gocloak.BoolP(true),
-				EmailVerified: gocloak.BoolP(false),
+				Enabled:       gocloak7.BoolP(true),
+				EmailVerified: gocloak7.BoolP(false),
 			}
 
 			mKcClient.EXPECT().CreateUser(
@@ -358,7 +358,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.ExecuteActionsEmail{
+				gocloak7.ExecuteActionsEmail{
 					UserID:   &userID,
 					Actions:  &requiredActions,
 					Lifespan: &lifespan,
@@ -376,13 +376,13 @@ var _ = Describe("Auth Compatibility", func() {
 				email := "test@example.com"
 				firstName := "Test"
 				lastName := "User"
-				expectedUser := gocloak.User{
+				expectedUser := gocloak7.User{
 					Username:      &username,
 					Email:         &email,
 					FirstName:     &firstName,
 					LastName:      &lastName,
-					Enabled:       gocloak.BoolP(true),
-					EmailVerified: gocloak.BoolP(false),
+					Enabled:       gocloak7.BoolP(true),
+					EmailVerified: gocloak7.BoolP(false),
 				}
 				mKcClient.EXPECT().CreateUser(
 					gomock.Any(),
@@ -402,13 +402,13 @@ var _ = Describe("Auth Compatibility", func() {
 				email := "test@example.com"
 				firstName := "Test"
 				lastName := "User"
-				expectedUser := gocloak.User{
+				expectedUser := gocloak7.User{
 					Username:      &username,
 					Email:         &email,
 					FirstName:     &firstName,
 					LastName:      &lastName,
-					Enabled:       gocloak.BoolP(true),
-					EmailVerified: gocloak.BoolP(false),
+					Enabled:       gocloak7.BoolP(true),
+					EmailVerified: gocloak7.BoolP(false),
 				}
 				userID := "test-user-id"
 				mKcClient.EXPECT().CreateUser(
@@ -423,7 +423,7 @@ var _ = Describe("Auth Compatibility", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.ExecuteActionsEmail{
+					gocloak7.ExecuteActionsEmail{
 						UserID:   &userID,
 						Actions:  &requiredActions,
 						Lifespan: &lifespan,
@@ -443,7 +443,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -470,7 +470,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				clientIDCache:  make(map[string]string),
 				cacheMutex:     sync.RWMutex{},
@@ -485,8 +485,8 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
+				gocloak7.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak7.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
 
 			result, err := actorCompatibility.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).NotTo(HaveOccurred())
@@ -500,8 +500,8 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{}, nil)
+				gocloak7.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak7.Client{}, nil)
 
 			result, err := actorCompatibility.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).To(HaveOccurred())
@@ -544,8 +544,8 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
+				gocloak7.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak7.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
 
 			result, err := actorCompatibility.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).NotTo(HaveOccurred())
@@ -565,7 +565,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
+				gocloak7.GetClientsParams{ClientID: &clientID},
 			).Return(nil, fmt.Errorf("keycloak error"))
 
 			result, err := actorCompatibility.getClientInternalIdentifierByClientID(context.Background(), clientID)
@@ -581,7 +581,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -592,7 +592,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should return the role for a given role name", func() {
 			roleName := "test-role"
-			expectedRole := &gocloak.Role{Name: &roleName}
+			expectedRole := &gocloak7.Role{Name: &roleName}
 
 			mKcClient.EXPECT().GetClientRole(
 				gomock.Any(),
@@ -652,7 +652,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			role, err := actorCompatibility.GetRole(context.Background(), roleName)
@@ -668,7 +668,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -686,7 +686,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak7.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -706,7 +706,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak7.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -727,7 +727,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak7.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -737,7 +737,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			roleID, err := actorCompatibility.CreateRole(context.Background(), roleName, roleDescription)
@@ -753,7 +753,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -808,7 +808,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actorCompatibility.DeleteRole(context.Background(), roleName)
@@ -838,7 +838,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -849,7 +849,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should return the roles for a given user ID", func() {
 			userID := "test-user-id"
-			expectedRoles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			expectedRoles := []*gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}}
 
 			mKcClient.EXPECT().GetClientRolesByUserID(
 				gomock.Any(),
@@ -880,7 +880,7 @@ var _ = Describe("Auth Compatibility", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			roles, err := actorCompatibility.GetUserRoles(context.Background(), userID)
@@ -928,7 +928,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -939,7 +939,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should add a user to multiple roles", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}}
 
 			mKcClient.EXPECT().AddClientRoleToUser(
 				gomock.Any(),
@@ -947,7 +947,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Return(nil)
 
 			err := actorCompatibility.AddUserToRoles(context.Background(), userID, roles)
@@ -956,7 +956,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should return an error if the client ID is not found", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}}
 			actorCompatibility.clientIDCache = make(map[string]string) // Clear cache to simulate missing client ID
 			mKcClient.EXPECT().AddClientRoleToUser(
 				gomock.Any(),
@@ -964,13 +964,13 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Times(0) // No call to Keycloak since client ID is missing
 			mKcClient.EXPECT().GetClients(
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actorCompatibility.AddUserToRoles(context.Background(), userID, roles)
@@ -979,7 +979,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should propagate errors from Keycloak", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}}
 
 			mKcClient.EXPECT().AddClientRoleToUser(
 				gomock.Any(),
@@ -987,7 +987,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Return(fmt.Errorf("keycloak error"))
 
 			err := actorCompatibility.AddUserToRoles(context.Background(), userID, roles)
@@ -1002,7 +1002,7 @@ var _ = Describe("Auth Compatibility", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak7.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -1013,7 +1013,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should remove a user from multiple roles", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gk13.StringP("role1")}, {Name: gk13.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().DeleteClientRoleFromUser(
 				gomock.Any(),
@@ -1021,7 +1021,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Return(nil)
 
 			err := actorCompatibility.RemoveUserFromRoles(context.Background(), userID, roles)
@@ -1030,7 +1030,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should return an error if the client ID is not found", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gk13.StringP("role1")}, {Name: gk13.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 			actorCompatibility.clientIDCache = make(map[string]string) // Clear cache to simulate missing client ID
 			mKcClient.EXPECT().DeleteClientRoleFromUser(
 				gomock.Any(),
@@ -1038,13 +1038,13 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Times(0) // No call to Keycloak since client ID is missing
 			mKcClient.EXPECT().GetClients(
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
+				gocloak7.GetClientsParams{ClientID: &actorCompatibility.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actorCompatibility.RemoveUserFromRoles(context.Background(), userID, roles)
@@ -1053,7 +1053,7 @@ var _ = Describe("Auth Compatibility", func() {
 
 		It("should propagate errors from Keycloak", func() {
 			userID := "test-user-id"
-			roles := []*gk13.Role{{Name: gk13.StringP("role1")}, {Name: gk13.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().DeleteClientRoleFromUser(
 				gomock.Any(),
@@ -1061,7 +1061,7 @@ var _ = Describe("Auth Compatibility", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak7.Role{{Name: gocloak7.StringP("role1")}, {Name: gocloak7.StringP("role2")}},
 			).Return(fmt.Errorf("keycloak error"))
 
 			err := actorCompatibility.RemoveUserFromRoles(context.Background(), userID, roles)

--- a/operators/pkg/controller/common/auth_compatibility_test.go
+++ b/operators/pkg/controller/common/auth_compatibility_test.go
@@ -23,9 +23,9 @@ import (
 	gocloak13 "github.com/Nerzal/gocloak/v13"
 	gocloak7 "github.com/Nerzal/gocloak/v7"
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 )

--- a/operators/pkg/controller/common/auth_test.go
+++ b/operators/pkg/controller/common/auth_test.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -76,7 +76,7 @@ var _ = Describe("Auth", func() {
 					Client: mKcClient,
 				}
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "clientID", "clientSecret", "realm").Return(&gocloak.JWT{}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "clientID", "clientSecret", "realm").Return(&gocloak13.JWT{}, nil)
 
 				err := SetupKeycloakActor(context.Background(), "url", "clientID", "clientSecret", "realm", "rolesClientID", testLogger)
 				Expect(err).NotTo(HaveOccurred())
@@ -145,7 +145,7 @@ var _ = Describe("Auth", func() {
 				initialized:    true,
 				Client:         mKcClient,
 				Realm:          "test-realm",
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: 12345,
 				credentials: struct {
 					ClientID     string
@@ -181,7 +181,7 @@ var _ = Describe("Auth", func() {
 		Context("when token is valid and not expired", func() {
 			It("should return the existing token", func() {
 				now := time.Now().Unix()
-				actor.token = &gocloak.JWT{AccessToken: "test-token", ExpiresIn: 300}
+				actor.token = &gocloak13.JWT{AccessToken: "test-token", ExpiresIn: 300}
 				actor.tokenExpiresAt = now + 300 // valid for 5 minutes
 
 				token := actor.GetAccessToken(context.Background())
@@ -194,7 +194,7 @@ var _ = Describe("Auth", func() {
 				actor.token = nil
 				actor.tokenExpiresAt = 0
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak13.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actor.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -204,10 +204,10 @@ var _ = Describe("Auth", func() {
 		Context("when token is expired", func() {
 			It("should refresh the token", func() {
 				now := time.Now().Unix()
-				actor.token = &gocloak.JWT{AccessToken: "old-token", ExpiresIn: 300}
+				actor.token = &gocloak13.JWT{AccessToken: "old-token", ExpiresIn: 300}
 				actor.tokenExpiresAt = now - 100 // expired
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak13.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actor.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -217,10 +217,10 @@ var _ = Describe("Auth", func() {
 		Context("when token is about to expire", func() {
 			It("should refresh the token", func() {
 				now := time.Now().Unix()
-				actor.token = &gocloak.JWT{AccessToken: "old-token", ExpiresIn: 300}
+				actor.token = &gocloak13.JWT{AccessToken: "old-token", ExpiresIn: 300}
 				actor.tokenExpiresAt = now + 10 // expires in 10 seconds
 
-				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
+				mKcClient.EXPECT().LoginClient(gomock.Any(), "test-client", "test-secret", "test-realm").Return(&gocloak13.JWT{AccessToken: "new-token", ExpiresIn: 300}, nil)
 
 				token := actor.GetAccessToken(context.Background())
 				Expect(token).To(Equal("new-token"))
@@ -235,7 +235,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -243,14 +243,14 @@ var _ = Describe("Auth", func() {
 		Context("when user exists", func() {
 			It("should return the user", func() {
 				username := "test-user"
-				expectedUser := &gocloak.User{Username: &username}
+				expectedUser := &gocloak13.User{Username: &username}
 
 				mKcClient.EXPECT().GetUsers(
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{expectedUser}, nil)
+					gocloak13.GetUsersParams{Username: &username},
+				).Return([]*gocloak13.User{expectedUser}, nil)
 
 				user, err := actor.GetUser(context.Background(), username)
 				Expect(err).NotTo(HaveOccurred())
@@ -266,8 +266,8 @@ var _ = Describe("Auth", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{}, nil)
+					gocloak13.GetUsersParams{Username: &username},
+				).Return([]*gocloak13.User{}, nil)
 
 				user, err := actor.GetUser(context.Background(), username)
 				Expect(err).To(MatchError("404"))
@@ -283,7 +283,7 @@ var _ = Describe("Auth", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
+					gocloak13.GetUsersParams{Username: &username},
 				).Return(nil, fmt.Errorf("error fetching user"))
 
 				user, err := actor.GetUser(context.Background(), username)
@@ -295,15 +295,15 @@ var _ = Describe("Auth", func() {
 		Context("when the username is a substring of another username", func() {
 			It("should return the right user", func() {
 				username := "test-user"
-				expectedUser := &gocloak.User{Username: &username}
-				otherUser := &gocloak.User{Username: gocloak.StringP("test-user-other")}
+				expectedUser := &gocloak13.User{Username: &username}
+				otherUser := &gocloak13.User{Username: gocloak13.StringP("test-user-other")}
 
 				mKcClient.EXPECT().GetUsers(
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.GetUsersParams{Username: &username},
-				).Return([]*gocloak.User{expectedUser, otherUser}, nil)
+					gocloak13.GetUsersParams{Username: &username},
+				).Return([]*gocloak13.User{expectedUser, otherUser}, nil)
 
 				user, err := actor.GetUser(context.Background(), username)
 				Expect(err).NotTo(HaveOccurred())
@@ -319,7 +319,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -331,13 +331,13 @@ var _ = Describe("Auth", func() {
 			lastName := "User"
 			userID := "test-user-id"
 
-			expectedUser := gocloak.User{
+			expectedUser := gocloak13.User{
 				Username:      &username,
 				Email:         &email,
 				FirstName:     &firstName,
 				LastName:      &lastName,
-				Enabled:       gocloak.BoolP(true),
-				EmailVerified: gocloak.BoolP(false),
+				Enabled:       gocloak13.BoolP(true),
+				EmailVerified: gocloak13.BoolP(false),
 			}
 
 			mKcClient.EXPECT().CreateUser(
@@ -353,7 +353,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.ExecuteActionsEmail{
+				gocloak13.ExecuteActionsEmail{
 					UserID:   &userID,
 					Actions:  &requiredActions,
 					Lifespan: &lifespan,
@@ -371,13 +371,13 @@ var _ = Describe("Auth", func() {
 				email := "test@example.com"
 				firstName := "Test"
 				lastName := "User"
-				expectedUser := gocloak.User{
+				expectedUser := gocloak13.User{
 					Username:      &username,
 					Email:         &email,
 					FirstName:     &firstName,
 					LastName:      &lastName,
-					Enabled:       gocloak.BoolP(true),
-					EmailVerified: gocloak.BoolP(false),
+					Enabled:       gocloak13.BoolP(true),
+					EmailVerified: gocloak13.BoolP(false),
 				}
 				mKcClient.EXPECT().CreateUser(
 					gomock.Any(),
@@ -397,13 +397,13 @@ var _ = Describe("Auth", func() {
 				email := "test@example.com"
 				firstName := "Test"
 				lastName := "User"
-				expectedUser := gocloak.User{
+				expectedUser := gocloak13.User{
 					Username:      &username,
 					Email:         &email,
 					FirstName:     &firstName,
 					LastName:      &lastName,
-					Enabled:       gocloak.BoolP(true),
-					EmailVerified: gocloak.BoolP(false),
+					Enabled:       gocloak13.BoolP(true),
+					EmailVerified: gocloak13.BoolP(false),
 				}
 				userID := "test-user-id"
 				mKcClient.EXPECT().CreateUser(
@@ -418,7 +418,7 @@ var _ = Describe("Auth", func() {
 					gomock.Any(),
 					"test-token",
 					"test-realm",
-					gocloak.ExecuteActionsEmail{
+					gocloak13.ExecuteActionsEmail{
 						UserID:   &userID,
 						Actions:  &requiredActions,
 						Lifespan: &lifespan,
@@ -438,7 +438,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 			}
 		})
@@ -465,7 +465,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				clientIDCache:  make(map[string]string),
 				cacheMutex:     sync.RWMutex{},
@@ -480,8 +480,8 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
+				gocloak13.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak13.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
 
 			result, err := actor.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).NotTo(HaveOccurred())
@@ -495,8 +495,8 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{}, nil)
+				gocloak13.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak13.Client{}, nil)
 
 			result, err := actor.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).To(HaveOccurred())
@@ -539,8 +539,8 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
-			).Return([]*gocloak.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
+				gocloak13.GetClientsParams{ClientID: &clientID},
+			).Return([]*gocloak13.Client{{ClientID: &clientID, ID: &expectedIdentifier}}, nil)
 
 			result, err := actor.getClientInternalIdentifierByClientID(context.Background(), clientID)
 			Expect(err).NotTo(HaveOccurred())
@@ -560,7 +560,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &clientID},
+				gocloak13.GetClientsParams{ClientID: &clientID},
 			).Return(nil, fmt.Errorf("keycloak error"))
 
 			result, err := actor.getClientInternalIdentifierByClientID(context.Background(), clientID)
@@ -576,7 +576,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -587,7 +587,7 @@ var _ = Describe("Auth", func() {
 
 		It("should return the role for a given role name", func() {
 			roleName := "test-role"
-			expectedRole := &gocloak.Role{Name: &roleName}
+			expectedRole := &gocloak13.Role{Name: &roleName}
 
 			mKcClient.EXPECT().GetClientRole(
 				gomock.Any(),
@@ -647,7 +647,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			role, err := actor.GetRole(context.Background(), roleName)
@@ -663,7 +663,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -681,7 +681,7 @@ var _ = Describe("Auth", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak13.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -701,7 +701,7 @@ var _ = Describe("Auth", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak13.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -722,7 +722,7 @@ var _ = Describe("Auth", func() {
 				"test-token",
 				"test-realm",
 				"internal-roles-client-id",
-				gocloak.Role{
+				gocloak13.Role{
 					Name:        &roleName,
 					Description: &roleDescription,
 				},
@@ -732,7 +732,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			roleID, err := actor.CreateRole(context.Background(), roleName, roleDescription)
@@ -748,7 +748,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -803,7 +803,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actor.DeleteRole(context.Background(), roleName)
@@ -833,7 +833,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -844,7 +844,7 @@ var _ = Describe("Auth", func() {
 
 		It("should return the roles for a given user ID", func() {
 			userID := "test-user-id"
-			expectedRoles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			expectedRoles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().GetClientRolesByUserID(
 				gomock.Any(),
@@ -875,7 +875,7 @@ var _ = Describe("Auth", func() {
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			roles, err := actor.GetUserRoles(context.Background(), userID)
@@ -923,7 +923,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -934,7 +934,7 @@ var _ = Describe("Auth", func() {
 
 		It("should add a user to multiple roles", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().AddClientRolesToUser(
 				gomock.Any(),
@@ -942,7 +942,7 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Return(nil)
 
 			err := actor.AddUserToRoles(context.Background(), userID, roles)
@@ -951,7 +951,7 @@ var _ = Describe("Auth", func() {
 
 		It("should return an error if the client ID is not found", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 			actor.clientIDCache = make(map[string]string) // Clear cache to simulate missing client ID
 			mKcClient.EXPECT().AddClientRolesToUser(
 				gomock.Any(),
@@ -959,13 +959,13 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Times(0) // No call to Keycloak since client ID is missing
 			mKcClient.EXPECT().GetClients(
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actor.AddUserToRoles(context.Background(), userID, roles)
@@ -974,7 +974,7 @@ var _ = Describe("Auth", func() {
 
 		It("should propagate errors from Keycloak", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().AddClientRolesToUser(
 				gomock.Any(),
@@ -982,7 +982,7 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Return(fmt.Errorf("keycloak error"))
 
 			err := actor.AddUserToRoles(context.Background(), userID, roles)
@@ -997,7 +997,7 @@ var _ = Describe("Auth", func() {
 				Realm:          "test-realm",
 				credentials:    struct{ ClientID, ClientSecret string }{ClientID: "test-client", ClientSecret: "test-secret"},
 				tokenMutex:     sync.RWMutex{},
-				token:          &gocloak.JWT{AccessToken: "test-token"},
+				token:          &gocloak13.JWT{AccessToken: "test-token"},
 				tokenExpiresAt: time.Now().Unix() + 3600, // valid for 1 hour
 				RolesClientID:  "roles-client-id",
 				clientIDCache: map[string]string{
@@ -1008,7 +1008,7 @@ var _ = Describe("Auth", func() {
 
 		It("should remove a user from multiple roles", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().DeleteClientRolesFromUser(
 				gomock.Any(),
@@ -1016,7 +1016,7 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Return(nil)
 
 			err := actor.RemoveUserFromRoles(context.Background(), userID, roles)
@@ -1025,7 +1025,7 @@ var _ = Describe("Auth", func() {
 
 		It("should return an error if the client ID is not found", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 			actor.clientIDCache = make(map[string]string) // Clear cache to simulate missing client ID
 			mKcClient.EXPECT().DeleteClientRolesFromUser(
 				gomock.Any(),
@@ -1033,13 +1033,13 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Times(0) // No call to Keycloak since client ID is missing
 			mKcClient.EXPECT().GetClients(
 				gomock.Any(),
 				"test-token",
 				"test-realm",
-				gocloak.GetClientsParams{ClientID: &actor.RolesClientID},
+				gocloak13.GetClientsParams{ClientID: &actor.RolesClientID},
 			).Return(nil, fmt.Errorf("error"))
 
 			err := actor.RemoveUserFromRoles(context.Background(), userID, roles)
@@ -1048,7 +1048,7 @@ var _ = Describe("Auth", func() {
 
 		It("should propagate errors from Keycloak", func() {
 			userID := "test-user-id"
-			roles := []*gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}}
+			roles := []*gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}}
 
 			mKcClient.EXPECT().DeleteClientRolesFromUser(
 				gomock.Any(),
@@ -1056,7 +1056,7 @@ var _ = Describe("Auth", func() {
 				"test-realm",
 				"internal-roles-client-id",
 				userID,
-				[]gocloak.Role{{Name: gocloak.StringP("role1")}, {Name: gocloak.StringP("role2")}},
+				[]gocloak13.Role{{Name: gocloak13.StringP("role1")}, {Name: gocloak13.StringP("role2")}},
 			).Return(fmt.Errorf("keycloak error"))
 
 			err := actor.RemoveUserFromRoles(context.Background(), userID, roles)

--- a/operators/pkg/controller/common/auth_test.go
+++ b/operators/pkg/controller/common/auth_test.go
@@ -22,9 +22,9 @@ import (
 
 	gocloak13 "github.com/Nerzal/gocloak/v13"
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 )

--- a/operators/pkg/controller/instance/webhook/suite_test.go
+++ b/operators/pkg/controller/instance/webhook/suite_test.go
@@ -19,8 +19,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var (
@@ -42,6 +42,6 @@ const (
 
 var _ = BeforeSuite(func() {
 	scheme = runtime.NewScheme()
-	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
-	Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+	Expect(clv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(clv1alpha2.AddToScheme(scheme)).To(Succeed())
 })

--- a/operators/pkg/controller/instance/webhook/validator.go
+++ b/operators/pkg/controller/instance/webhook/validator.go
@@ -25,9 +25,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -41,20 +41,20 @@ type InstanceValidator struct {
 	Client client.Client
 }
 
-func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.Client) (admission.Warnings, error) {
+func validateQuota(ctx context.Context, instance *clv1alpha2.Instance, cl client.Client) (admission.Warnings, error) {
 	var warnings admission.Warnings
 
 	tenantNamespace := instance.Namespace
 
 	// Get the instance's template
-	instanceTemplate := &v1alpha2.Template{}
+	instanceTemplate := &clv1alpha2.Template{}
 	if err := cl.Get(ctx, forge.NamespacedNameFromGenericRef(instance.Spec.Template), instanceTemplate); err != nil {
 		return warnings, fmt.Errorf("failed to get instance template: %w", err)
 	}
 
 	// Get the workspace details (quota, templates namespace)
 	wsName := instanceTemplate.Spec.WorkspaceRef.Name
-	wsQuota := common.WorkspaceResourceQuota{}
+	wsQuota := apicommon.WorkspaceResourceQuota{}
 	templatesNamespace := ""
 
 	if wsName == personalWorkspaceName {
@@ -63,7 +63,7 @@ func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.C
 			return warnings, fmt.Errorf("failed to get admission request from context: %w", err)
 		}
 
-		tenant := &v1alpha2.Tenant{}
+		tenant := &clv1alpha2.Tenant{}
 		if err := cl.Get(ctx, types.NamespacedName{Name: req.UserInfo.Username}, tenant); err != nil {
 			return warnings, fmt.Errorf("failed to get tenant %s: %w", req.UserInfo.Username, err)
 		}
@@ -71,7 +71,7 @@ func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.C
 		wsQuota = *tenant.Spec.PersonalWorkspace.DeepCopy()
 		templatesNamespace = tenantNamespace
 	} else {
-		ws := &v1alpha1.Workspace{}
+		ws := &clv1alpha1.Workspace{}
 		if err := cl.Get(ctx, types.NamespacedName{Name: wsName}, ws); err != nil {
 			return warnings, fmt.Errorf("failed to get workspace: %w", err)
 		}
@@ -82,7 +82,7 @@ func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.C
 
 	// Get all the templates in the workspace namespace, they are needed to calculate the resource usage.
 	// Instead of querying the cluster for each instance's template, we get them all at once and store them in a map.
-	wsTemplateList := &v1alpha2.TemplateList{}
+	wsTemplateList := &clv1alpha2.TemplateList{}
 	if err := cl.List(
 		ctx,
 		wsTemplateList,
@@ -91,13 +91,13 @@ func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.C
 		return warnings, fmt.Errorf("failed to list templates in workspace namespace: %w", err)
 	}
 
-	wsTemplates := make(map[string]v1alpha2.Template)
+	wsTemplates := make(map[string]clv1alpha2.Template)
 	for i := range wsTemplateList.Items {
 		wsTemplates[wsTemplateList.Items[i].Name] = wsTemplateList.Items[i]
 	}
 
 	// Find the other instances in the same workspace owned by the same user
-	workspaceInstances := &v1alpha2.InstanceList{}
+	workspaceInstances := &clv1alpha2.InstanceList{}
 	if err := cl.List(
 		ctx,
 		workspaceInstances,
@@ -168,7 +168,7 @@ func (iv *InstanceValidator) ValidateCreate(
 	var warnings admission.Warnings
 
 	// Get the instance being created
-	instance, ok := obj.(*v1alpha2.Instance)
+	instance, ok := obj.(*clv1alpha2.Instance)
 	if !ok {
 		return warnings, fmt.Errorf("expected Instance resource but got %T", obj)
 	}
@@ -184,12 +184,12 @@ func (iv *InstanceValidator) ValidateUpdate(
 	var warnings admission.Warnings
 
 	// Get the instance objects
-	oldInstance, ok := oldObj.(*v1alpha2.Instance)
+	oldInstance, ok := oldObj.(*clv1alpha2.Instance)
 	if !ok {
 		return warnings, fmt.Errorf("expected Instance resource but got %T", oldObj)
 	}
 
-	newInstance, ok := newObj.(*v1alpha2.Instance)
+	newInstance, ok := newObj.(*clv1alpha2.Instance)
 	if !ok {
 		return warnings, fmt.Errorf("expected Instance resource but got %T", newObj)
 	}

--- a/operators/pkg/controller/instance/webhook/validator_test.go
+++ b/operators/pkg/controller/instance/webhook/validator_test.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/instance/webhook"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
@@ -46,49 +46,49 @@ var _ = Describe("InstanceValidator", func() {
 	})
 
 	It("should allow creation when under quota", func() {
-		ws := &v1alpha1.Workspace{
+		ws := &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: testWorkspace},
-			Spec: v1alpha1.WorkspaceSpec{
-				Quota: common.WorkspaceResourceQuota{
+			Spec: clv1alpha1.WorkspaceSpec{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 2,
 					CPU:       resource.MustParse("4"),
 					Memory:    resource.MustParse("8Gi"),
 				},
 			},
 		}
-		tmpl := &v1alpha2.Template{
+		tmpl := &clv1alpha2.Template{
 			ObjectMeta: metav1.ObjectMeta{Name: testTemplate, Namespace: testWorkspaceNamespace},
-			Spec: v1alpha2.TemplateSpec{
-				EnvironmentList: []v1alpha2.Environment{{
+			Spec: clv1alpha2.TemplateSpec{
+				EnvironmentList: []clv1alpha2.Environment{{
 					Name: testEnvironment,
-					Resources: v1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:    2,
 						Memory: resource.MustParse("2Gi"),
 					},
 				}},
-				WorkspaceRef: v1alpha2.GenericRef{Name: testWorkspace},
+				WorkspaceRef: clv1alpha2.GenericRef{Name: testWorkspace},
 			},
 		}
-		inst := &v1alpha2.Instance{
+		inst := &clv1alpha2.Instance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testNewInstance,
 				Namespace: testTenantNamespace,
 				Labels:    map[string]string{forge.LabelWorkspaceKey: testWorkspace},
 			},
-			Spec: v1alpha2.InstanceSpec{
-				Template: v1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
+			Spec: clv1alpha2.InstanceSpec{
+				Template: clv1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
 				Running:  true,
 			},
 		}
 		// Add another instance to exceed quota
-		otherInst := &v1alpha2.Instance{
+		otherInst := &clv1alpha2.Instance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testExistingInstance,
 				Namespace: testTenantNamespace,
 				Labels:    map[string]string{forge.LabelWorkspaceKey: testWorkspace},
 			},
-			Spec: v1alpha2.InstanceSpec{
-				Template: v1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
+			Spec: clv1alpha2.InstanceSpec{
+				Template: clv1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
 				Running:  true,
 			},
 		}
@@ -100,49 +100,49 @@ var _ = Describe("InstanceValidator", func() {
 	})
 
 	It("should deny creation when quota exceeded", func() {
-		ws := &v1alpha1.Workspace{
+		ws := &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: testWorkspace},
-			Spec: v1alpha1.WorkspaceSpec{
-				Quota: common.WorkspaceResourceQuota{
+			Spec: clv1alpha1.WorkspaceSpec{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 1,
 					CPU:       resource.MustParse("2"),
 					Memory:    resource.MustParse("2Gi"),
 				},
 			},
 		}
-		tmpl := &v1alpha2.Template{
+		tmpl := &clv1alpha2.Template{
 			ObjectMeta: metav1.ObjectMeta{Name: testTemplate, Namespace: testWorkspaceNamespace},
-			Spec: v1alpha2.TemplateSpec{
-				EnvironmentList: []v1alpha2.Environment{{
+			Spec: clv1alpha2.TemplateSpec{
+				EnvironmentList: []clv1alpha2.Environment{{
 					Name: testEnvironment,
-					Resources: v1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:    2,
 						Memory: resource.MustParse("2Gi"),
 					},
 				}},
-				WorkspaceRef: v1alpha2.GenericRef{Name: testWorkspace},
+				WorkspaceRef: clv1alpha2.GenericRef{Name: testWorkspace},
 			},
 		}
-		inst := &v1alpha2.Instance{
+		inst := &clv1alpha2.Instance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testNewInstance,
 				Namespace: testTenantNamespace,
 				Labels:    map[string]string{forge.LabelWorkspaceKey: testWorkspace},
 			},
-			Spec: v1alpha2.InstanceSpec{
-				Template: v1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
+			Spec: clv1alpha2.InstanceSpec{
+				Template: clv1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
 				Running:  true,
 			},
 		}
 		// Add another instance to exceed quota
-		otherInst := &v1alpha2.Instance{
+		otherInst := &clv1alpha2.Instance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testExistingInstance,
 				Namespace: testTenantNamespace,
 				Labels:    map[string]string{forge.LabelWorkspaceKey: testWorkspace},
 			},
-			Spec: v1alpha2.InstanceSpec{
-				Template: v1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
+			Spec: clv1alpha2.InstanceSpec{
+				Template: clv1alpha2.GenericRef{Name: testTemplate, Namespace: testWorkspaceNamespace},
 				Running:  true,
 			},
 		}
@@ -155,24 +155,24 @@ var _ = Describe("InstanceValidator", func() {
 	})
 
 	It("should warn if template is missing for an instance", func() {
-		ws := &v1alpha1.Workspace{
+		ws := &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: testWorkspace},
-			Spec: v1alpha1.WorkspaceSpec{
-				Quota: common.WorkspaceResourceQuota{
+			Spec: clv1alpha1.WorkspaceSpec{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 2,
 					CPU:       resource.MustParse("4"),
 					Memory:    resource.MustParse("8Gi"),
 				},
 			},
 		}
-		inst := &v1alpha2.Instance{
+		inst := &clv1alpha2.Instance{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testNewInstance,
 				Namespace: testTenantNamespace,
 				Labels:    map[string]string{forge.LabelWorkspaceKey: testWorkspace},
 			},
-			Spec: v1alpha2.InstanceSpec{
-				Template: v1alpha2.GenericRef{Name: testMissingTemplate, Namespace: testWorkspaceNamespace},
+			Spec: clv1alpha2.InstanceSpec{
+				Template: clv1alpha2.GenericRef{Name: testMissingTemplate, Namespace: testWorkspaceNamespace},
 				Running:  true,
 			},
 		}

--- a/operators/pkg/controller/mock/gocloak.go
+++ b/operators/pkg/controller/mock/gocloak.go
@@ -17,7 +17,7 @@ import (
 	gocloak "github.com/Nerzal/gocloak/v13"
 	resty "github.com/go-resty/resty/v2"
 	jwt "github.com/golang-jwt/jwt/v5"
-	gomock "go.uber.org/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockGoCloakIface is a mock of GoCloakIface interface.

--- a/operators/pkg/controller/mock/gocloak.v7.go
+++ b/operators/pkg/controller/mock/gocloak.v7.go
@@ -12,7 +12,7 @@ import (
 	gocloak "github.com/Nerzal/gocloak/v7"
 	jwt "github.com/dgrijalva/jwt-go/v4"
 	resty "github.com/go-resty/resty/v2"
-	gomock "go.uber.org/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockGoCloak is a mock of GoCloak interface

--- a/operators/pkg/controller/mock/keycloakactoriface.go
+++ b/operators/pkg/controller/mock/keycloakactoriface.go
@@ -15,7 +15,7 @@ import (
 
 	gocloak "github.com/Nerzal/gocloak/v13"
 	logr "github.com/go-logr/logr"
-	gomock "go.uber.org/mock/gomock"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockKeycloakActorIface is a mock of KeycloakActorIface interface.

--- a/operators/pkg/controller/pmp/provisioner.go
+++ b/operators/pkg/controller/pmp/provisioner.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v13/controller"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -62,7 +62,7 @@ type PvcMirrorProvisioner struct {
 	Client                client.Client
 	Config                *rest.Config
 	Logger                logr.Logger
-	TargetLabel           common.KVLabel
+	TargetLabel           ctrlcommon.KVLabel
 	MirrorStorageClass    string
 	MirrorProvisionerName string
 }

--- a/operators/pkg/controller/pmp/provisioner_test.go
+++ b/operators/pkg/controller/pmp/provisioner_test.go
@@ -25,15 +25,15 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v13/controller"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/pmp"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
@@ -42,7 +42,7 @@ import (
 var _ = Describe("The PVC Mirror Provisioner methods", func() {
 	AddObject := func(obj client.Object) {
 		err := pmprov.Client.Create(ctx, obj)
-		if apierrors.IsAlreadyExists(err) {
+		if kerrors.IsAlreadyExists(err) {
 			Expect(pmprov.Client.Update(ctx, obj)).To(Succeed())
 		} else {
 			Expect(err).To(BeNil())
@@ -61,13 +61,13 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 	}
 
 	RemovePVC := func(pvc *corev1.PersistentVolumeClaim) {
-		ctrlUtil.RemoveFinalizer(pvc, "kubernetes.io/pvc-protection")
+		ctrlutil.RemoveFinalizer(pvc, "kubernetes.io/pvc-protection")
 		Expect(pmprov.Client.Update(ctx, pvc.DeepCopy())).To(Succeed())
 		RemoveObject(pvc)
 	}
 
 	RemovePV := func(pv *corev1.PersistentVolume) {
-		ctrlUtil.RemoveFinalizer(pv, "kubernetes.io/pv-protection")
+		ctrlutil.RemoveFinalizer(pv, "kubernetes.io/pv-protection")
 		Expect(pmprov.Client.Update(ctx, pv.DeepCopy())).To(Succeed())
 		RemoveObject(pv)
 	}
@@ -149,7 +149,7 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 		}
 
 		BeforeAll(func() {
-			pmprov.TargetLabel = common.NewLabel(targetLabelKey, targetLabelVal)
+			pmprov.TargetLabel = ctrlcommon.NewLabel(targetLabelKey, targetLabelVal)
 
 			nsOrigin = corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -269,7 +269,7 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 				nsTgtLabels = map[string]string{
 					targetLabelKey: targetLabelVal,
 				}
-				pmprov.TargetLabel = common.NewLabel(targetLabelKey, targetLabelVal)
+				pmprov.TargetLabel = ctrlcommon.NewLabel(targetLabelKey, targetLabelVal)
 			})
 
 			When("DataSourceRef is present", func() {

--- a/operators/pkg/controller/pmp/suite_test.go
+++ b/operators/pkg/controller/pmp/suite_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/pmp"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
 )
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func() {
 		Client:                k8sClient,
 		Config:                cfg,
 		Logger:                logger,
-		TargetLabel:           common.NewLabel("crownlabs.polito.it/operator-selector", "local"),
+		TargetLabel:           ctrlcommon.NewLabel("crownlabs.polito.it/operator-selector", "local"),
 		MirrorStorageClass:    mirrorStorageClassName,
 		MirrorProvisionerName: mirrorProvisionerName,
 	}

--- a/operators/pkg/controller/sharedvolume/reconciler.go
+++ b/operators/pkg/controller/sharedvolume/reconciler.go
@@ -32,11 +32,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	ctrlUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -48,7 +48,7 @@ const (
 // Reconciler reconciles a SharedVolume object.
 type Reconciler struct {
 	client.Client
-	TargetLabel     common.KVLabel
+	TargetLabel     ctrlcommon.KVLabel
 	EventsRecorder  record.EventRecorder
 	PVCStorageClass string
 
@@ -140,7 +140,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		log.Info("Processing delete request")
 		shvolume.Status.Phase = clv1alpha2.SharedVolumePhaseDeleting
 
-		if ctrlUtil.ContainsFinalizer(&shvolume, clv1alpha2.ShVolCtrlFinalizerName) {
+		if ctrlutil.ContainsFinalizer(&shvolume, clv1alpha2.ShVolCtrlFinalizerName) {
 			if err := r.handleDeletion(ctx, log, &shvolume); err != nil {
 				log.Error(err, "failed handling deletion request")
 				return ctrl.Result{}, err
@@ -237,7 +237,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			return ctrl.Result{}, err
 		} else if done {
 			original := shvolume.DeepCopy()
-			ctrlUtil.AddFinalizer(&shvolume, clv1alpha2.ShVolCtrlFinalizerName)
+			ctrlutil.AddFinalizer(&shvolume, clv1alpha2.ShVolCtrlFinalizerName)
 			if err := r.Patch(ctx, &shvolume, client.MergeFrom(original)); err != nil {
 				log.Error(err, "failed adding finalizer")
 				return ctrl.Result{}, err
@@ -285,7 +285,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, shvol 
 		r.EventsRecorder.Eventf(shvol, corev1.EventTypeWarning, EvDeletionBlocked, EvDeletionBlockedMsg, mountedList)
 		log.Info("blocked deletion, shvol is mounted on some templates")
 	} else {
-		ctrlUtil.RemoveFinalizer(shvol, clv1alpha2.ShVolCtrlFinalizerName)
+		ctrlutil.RemoveFinalizer(shvol, clv1alpha2.ShVolCtrlFinalizerName)
 		if err := r.Update(ctx, shvol); err != nil {
 			log.Error(err, "failed removing finalizer")
 			return err

--- a/operators/pkg/controller/sharedvolume/reconciler.go
+++ b/operators/pkg/controller/sharedvolume/reconciler.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,7 +75,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, concurrency int) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clv1alpha2.SharedVolume{}).
-		Owns(&v1.PersistentVolumeClaim{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&batchv1.Job{}).
 		Watches(&clv1alpha2.Template{},
 			handler.EnqueueRequestsFromMapFunc(r.getDeletingSharedVolumes)).
@@ -166,7 +166,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	shvolume.Status.Phase = clv1alpha2.SharedVolumePhaseError
 
 	// Create or Update the PVC, reconciling it with the SharedVolume spec.
-	pvc := v1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+	pvc := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 		Name:      forge.ShVolPVCName(shvolume.GetName()),
 		Namespace: shvolume.GetNamespace(),
 	}}
@@ -188,14 +188,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 
 		// Set Error phase if ShVol size is forbidden (less than previous)
 		if sizeDiff := shvolume.Spec.Size.Cmp(oldSize); sizeDiff > 0 || oldSize.IsZero() {
-			pvc.Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: shvolume.Spec.Size}
+			pvc.Spec.Resources.Requests = corev1.ResourceList{corev1.ResourceStorage: shvolume.Spec.Size}
 
 			log.V(utils.LogDebugLevel).Info("Size updated",
 				"previous", oldSize, "current", shvolume.Spec.Size)
 		} else if sizeDiff < 0 {
 			shvolume.Status.Phase = clv1alpha2.SharedVolumePhaseError
 			log.Error(fmt.Errorf("forbidden: size smaller than previous"), "Phase transitioned to Error")
-			r.EventsRecorder.Eventf(&shvolume, v1.EventTypeWarning, EvPVCSmaller, EvPVCSmallerMsg)
+			r.EventsRecorder.Eventf(&shvolume, corev1.EventTypeWarning, EvPVCSmaller, EvPVCSmallerMsg)
 
 			// Must return now (do not add code below or add return here).
 		}
@@ -206,7 +206,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		if isResourceQuotaExceeded(err) {
 			shvolume.Status.Phase = clv1alpha2.SharedVolumePhaseResourceQuotaExceeded
 			log.Error(fmt.Errorf("forbidden: resource quota exceeded"), "Phase transitioned to ResourceQuotaExceeded")
-			r.EventsRecorder.Eventf(&shvolume, v1.EventTypeWarning, EvPVCResQuotaExceeded, EvPVCResQuotaExceededMsg)
+			r.EventsRecorder.Eventf(&shvolume, corev1.EventTypeWarning, EvPVCResQuotaExceeded, EvPVCResQuotaExceededMsg)
 			err = nil
 		} else {
 			log.Error(err, "Unable to create or update PVC")
@@ -222,8 +222,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 	}
 
 	// Update SharedVolume Status and start provisioning if PVC is Bound
-	if pvc.Status.Phase == v1.ClaimBound {
-		pv := v1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: pvc.Spec.VolumeName}}
+	if pvc.Status.Phase == corev1.ClaimBound {
+		pv := corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: pvc.Spec.VolumeName}}
 		if err := r.Get(ctx, types.NamespacedName{Name: pv.Name}, &pv); err != nil {
 			log.Error(err, "Unable to get PV")
 			return ctrl.Result{}, err
@@ -282,7 +282,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, log logr.Logger, shvol 
 	}
 
 	if found {
-		r.EventsRecorder.Eventf(shvol, v1.EventTypeWarning, EvDeletionBlocked, EvDeletionBlockedMsg, mountedList)
+		r.EventsRecorder.Eventf(shvol, corev1.EventTypeWarning, EvDeletionBlocked, EvDeletionBlockedMsg, mountedList)
 		log.Info("blocked deletion, shvol is mounted on some templates")
 	} else {
 		ctrlUtil.RemoveFinalizer(shvol, clv1alpha2.ShVolCtrlFinalizerName)

--- a/operators/pkg/controller/sharedvolume/reconciler_test.go
+++ b/operators/pkg/controller/sharedvolume/reconciler_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	ctrlUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
@@ -226,7 +226,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 
 					// Labels and Finalizers on ShVol
 					Expect(shvol.Labels[forge.LabelManagedByKey]).To(Equal("sharedvolume"))
-					Expect(ctrlUtil.ContainsFinalizer(&shvol, clv1alpha2.ShVolCtrlFinalizerName))
+					Expect(ctrlutil.ContainsFinalizer(&shvol, clv1alpha2.ShVolCtrlFinalizerName))
 				})
 
 				Context("The shared volume deletion should be handled correctly", func() {
@@ -329,7 +329,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 
 			AfterEach(func() {
 				Expect(k8sClient.Get(ctx, PVCNamespacedName(&shvol), &pv)).To(Succeed())
-				ctrlUtil.RemoveFinalizer(&pv, "kubernetes.io/pv-protection")
+				ctrlutil.RemoveFinalizer(&pv, "kubernetes.io/pv-protection")
 				_ = k8sClient.Update(ctx, &pv)
 				_ = k8sClient.Delete(ctx, &pv)
 			})
@@ -337,7 +337,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 
 		AfterEach(func() {
 			Expect(k8sClient.Get(ctx, PVCNamespacedName(&shvol), &pvc)).To(Succeed())
-			ctrlUtil.RemoveFinalizer(&pvc, "kubernetes.io/pvc-protection")
+			ctrlutil.RemoveFinalizer(&pvc, "kubernetes.io/pvc-protection")
 			_ = k8sClient.Update(ctx, &pvc)
 			_ = k8sClient.Delete(ctx, &pvc)
 		})

--- a/operators/pkg/controller/sharedvolume/suite_test.go
+++ b/operators/pkg/controller/sharedvolume/suite_test.go
@@ -32,7 +32,7 @@ import (
 
 	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/sharedvolume"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
 )
@@ -51,7 +51,7 @@ var (
 		ErrorIfCRDPathMissing: true,
 	}
 
-	targetLabel = common.NewLabel("production", "true")
+	targetLabel = ctrlcommon.NewLabel("production", "true")
 	labelMap    = map[string]string{
 		targetLabel.GetKey(): targetLabel.GetValue(),
 	}

--- a/operators/pkg/controller/tenant/authentication.go
+++ b/operators/pkg/controller/tenant/authentication.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // CheckKeycloakUserVerified checks if the Tenant has already been created in Keycloak
@@ -36,7 +36,7 @@ import (
 func (r *Reconciler) CheckKeycloakUserVerified(
 	ctx context.Context,
 	log logr.Logger,
-	tenant *v1alpha2.Tenant,
+	tenant *clv1alpha2.Tenant,
 ) (bool, error) {
 	if !r.KeycloakActor.IsInitialized() {
 		log.Info("Keycloak actor not initialized, skipping Keycloak status check")
@@ -71,7 +71,7 @@ func (r *Reconciler) CheckKeycloakUserVerified(
 	} else if tenant.Status.Keycloak.UserCreated.Name != *user.ID {
 		log.Info("Tenant exists in Keycloak but with a different ID, updating status", "id", *user.ID)
 		// Update the tenant status in the cluster
-		tenant.Status.Keycloak.UserCreated = v1alpha2.NameCreated{
+		tenant.Status.Keycloak.UserCreated = clv1alpha2.NameCreated{
 			Name:    *user.ID,
 			Created: true,
 		}
@@ -90,7 +90,7 @@ func (r *Reconciler) CheckKeycloakUserVerified(
 func (r *Reconciler) createTenantInKeycloak(
 	ctx context.Context,
 	log logr.Logger,
-	tenant *v1alpha2.Tenant,
+	tenant *clv1alpha2.Tenant,
 ) error {
 	if !r.KeycloakActor.IsInitialized() {
 		log.Info("Keycloak actor not initialized, skipping Keycloak creation")
@@ -110,8 +110,8 @@ func (r *Reconciler) createTenantInKeycloak(
 		return err
 	}
 
-	tenant.Status.Keycloak = v1alpha2.KeycloakStatus{
-		UserCreated: v1alpha2.NameCreated{
+	tenant.Status.Keycloak = clv1alpha2.KeycloakStatus{
+		UserCreated: clv1alpha2.NameCreated{
 			Name:    userID,
 			Created: true,
 		},
@@ -124,7 +124,7 @@ func (r *Reconciler) createTenantInKeycloak(
 func (r *Reconciler) deleteTenantInKeycloak(
 	ctx context.Context,
 	log logr.Logger,
-	tenant *v1alpha2.Tenant,
+	tenant *clv1alpha2.Tenant,
 ) error {
 	if !r.KeycloakActor.IsInitialized() {
 		log.Info("Keycloak actor not initialized, skipping Keycloak deletion")
@@ -144,8 +144,8 @@ func (r *Reconciler) deleteTenantInKeycloak(
 	log.Info("Tenant deleted in Keycloak")
 
 	// Reset the Keycloak status in the tenant
-	tenant.Status.Keycloak = v1alpha2.KeycloakStatus{
-		UserCreated: v1alpha2.NameCreated{
+	tenant.Status.Keycloak = clv1alpha2.KeycloakStatus{
+		UserCreated: clv1alpha2.NameCreated{
 			Name:    "",
 			Created: false,
 		},
@@ -180,7 +180,7 @@ func (r *Reconciler) KeycloakEventHandler(
 	}
 
 	r.TriggerReconcileChannel <- event.GenericEvent{
-		Object: &v1alpha2.Tenant{
+		Object: &clv1alpha2.Tenant{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: username,
 			},

--- a/operators/pkg/controller/tenant/authentication_test.go
+++ b/operators/pkg/controller/tenant/authentication_test.go
@@ -22,9 +22,9 @@ import (
 	"time"
 
 	gocloak13 "github.com/Nerzal/gocloak/v13"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"

--- a/operators/pkg/controller/tenant/authentication_test.go
+++ b/operators/pkg/controller/tenant/authentication_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 )
 
@@ -60,15 +60,15 @@ var _ = Describe("Authentication Unit", func() {
 			})
 
 			It("should return true and no error if user is created and email is confirmed", func() {
-				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-					ID:            gocloak.StringP("user-id"),
-					EmailVerified: gocloak.BoolP(true),
+				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+					ID:            gocloak13.StringP("user-id"),
+					EmailVerified: gocloak13.BoolP(true),
 				}, nil)
 
 				verified, err := tenantReconciler.CheckKeycloakUserVerified(ctx, log, tnResource)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(verified).To(BeTrue())
-				Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "user-id",
 					Created: true,
 				}))
@@ -76,15 +76,15 @@ var _ = Describe("Authentication Unit", func() {
 			})
 
 			It("should return false and no error if user is created but email is not confirmed", func() {
-				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-					ID:            gocloak.StringP("user-id"),
-					EmailVerified: gocloak.BoolP(false),
+				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+					ID:            gocloak13.StringP("user-id"),
+					EmailVerified: gocloak13.BoolP(false),
 				}, nil)
 
 				verified, err := tenantReconciler.CheckKeycloakUserVerified(ctx, log, tnResource)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(verified).To(BeFalse())
-				Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "user-id",
 					Created: true,
 				}))
@@ -93,7 +93,7 @@ var _ = Describe("Authentication Unit", func() {
 
 			Context("When there is an error retrieving the user", func() {
 				It("should return an error ", func() {
-					keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(nil, gocloak.APIError{
+					keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(nil, gocloak13.APIError{
 						Message: "error retrieving user",
 						Code:    500,
 					})
@@ -110,16 +110,16 @@ var _ = Describe("Authentication Unit", func() {
 					gomock.InOrder(
 						keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(nil, fmt.Errorf("404")),
 						keycloakActor.EXPECT().CreateUser(gomock.Any(), tnName, tnResource.Spec.Email, tnResource.Spec.FirstName, tnResource.Spec.LastName).Return("user-id", nil),
-						keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-							ID:            gocloak.StringP("user-id"),
-							EmailVerified: gocloak.BoolP(false),
+						keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+							ID:            gocloak13.StringP("user-id"),
+							EmailVerified: gocloak13.BoolP(false),
 						}, nil),
 					)
 
 					verified, err := tenantReconciler.CheckKeycloakUserVerified(ctx, log, tnResource)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(verified).To(BeFalse())
-					Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+					Expect(tnResource.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 						Name:    "user-id",
 						Created: true,
 					}))
@@ -174,7 +174,7 @@ var _ = Describe("Authentication Unit", func() {
 				tenantReconciler.KeycloakEventHandler(log, w, r)
 				Expect(w.statusCode).To(Equal(http.StatusOK))
 				Eventually(ch, timeout, interval).Should(Receive(WithTransform(func(e event.GenericEvent) string {
-					return e.Object.(*v1alpha2.Tenant).Name
+					return e.Object.(*clv1alpha2.Tenant).Name
 				}, Equal(tnName))))
 			})
 		})
@@ -224,7 +224,7 @@ var _ = Describe("Authentication Unit", func() {
 				tenantReconciler.KeycloakEventHandler(log, w, r)
 				Expect(w.statusCode).To(Equal(http.StatusOK))
 				Eventually(ch, timeout, interval).Should(Receive(WithTransform(func(e event.GenericEvent) string {
-					return e.Object.(*v1alpha2.Tenant).Name
+					return e.Object.(*clv1alpha2.Tenant).Name
 				}, Equal(tnName))))
 			})
 		})
@@ -317,17 +317,17 @@ var _ = Describe("Authentication Reconciler", func() {
 						tnResource.Spec.FirstName,
 						tnResource.Spec.LastName,
 					).Return("test-user-id", nil),
-					keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-						ID:            gocloak.StringP("test-user-id"),
-						EmailVerified: gocloak.BoolP(false),
+					keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+						ID:            gocloak13.StringP("test-user-id"),
+						EmailVerified: gocloak13.BoolP(false),
 					}, nil),
 				)
 			})
 
 			It("Should set Tenant keycloak status as created but not confirmed", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
-				Expect(tn.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tn.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "test-user-id",
 					Created: true,
 				}))
@@ -342,16 +342,16 @@ var _ = Describe("Authentication Reconciler", func() {
 
 		Context("When the Tenant is created but not confirmed in Keycloak", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-					ID:            gocloak.StringP("test-user-id"),
-					EmailVerified: gocloak.BoolP(false),
+				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+					ID:            gocloak13.StringP("test-user-id"),
+					EmailVerified: gocloak13.BoolP(false),
 				}, nil)
 			})
 
 			It("Should set Tenant keycloak status as created but not confirmed", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
-				Expect(tn.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tn.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "test-user-id",
 					Created: true,
 				}))
@@ -366,16 +366,16 @@ var _ = Describe("Authentication Reconciler", func() {
 
 		Context("When the Tenant is created and confirmed in Keycloak", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-					ID:            gocloak.StringP("test-user-id"),
-					EmailVerified: gocloak.BoolP(true),
+				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+					ID:            gocloak13.StringP("test-user-id"),
+					EmailVerified: gocloak13.BoolP(true),
 				}, nil)
 			})
 
 			It("Should set Tenant keycloak status as confirmed", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
-				Expect(tn.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tn.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "test-user-id",
 					Created: true,
 				}))
@@ -391,7 +391,7 @@ var _ = Describe("Authentication Reconciler", func() {
 		Context("When the Tenant is deleted", func() {
 			BeforeEach(func() {
 				tenantBeingDeleted()
-				tnResource.Status.Keycloak.UserCreated = v1alpha2.NameCreated{
+				tnResource.Status.Keycloak.UserCreated = clv1alpha2.NameCreated{
 					Name:    "test-user-id",
 					Created: true,
 				}
@@ -401,7 +401,7 @@ var _ = Describe("Authentication Reconciler", func() {
 			})
 
 			It("Should delete the Tenant keycloak user", func() {
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &v1alpha2.Tenant{}, BeFalse(), 10*time.Second, 250*time.Millisecond)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &clv1alpha2.Tenant{}, BeFalse(), 10*time.Second, 250*time.Millisecond)
 			})
 		})
 
@@ -411,7 +411,7 @@ var _ = Describe("Authentication Reconciler", func() {
 			})
 
 			It("Should make the Tenant keycloak user sync to false", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
 				Expect(tn.Status.Ready).To(BeFalse())
 				Expect(tn.Status.Keycloak.UserSynchronized).To(BeFalse())
@@ -420,20 +420,20 @@ var _ = Describe("Authentication Reconciler", func() {
 
 		Context("When the user-id in Keycloak does not match the one in Tenant status", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-					ID:            gocloak.StringP("different-user-id"),
-					EmailVerified: gocloak.BoolP(true),
+				keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+					ID:            gocloak13.StringP("different-user-id"),
+					EmailVerified: gocloak13.BoolP(true),
 				}, nil)
-				tnResource.Status.Keycloak.UserCreated = v1alpha2.NameCreated{
+				tnResource.Status.Keycloak.UserCreated = clv1alpha2.NameCreated{
 					Name:    "test-user-id",
 					Created: true,
 				}
 			})
 
 			It("Should update the Tenant keycloak status with the new user-id", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
-				Expect(tn.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+				Expect(tn.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 					Name:    "different-user-id",
 					Created: true,
 				}))
@@ -447,9 +447,9 @@ var _ = Describe("Authentication Reconciler", func() {
 		})
 
 		It("Should set Tenant keycloak status as not confirmed", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), 10*time.Second, 250*time.Millisecond)
-			Expect(tn.Status.Keycloak.UserCreated).To(Equal(v1alpha2.NameCreated{
+			Expect(tn.Status.Keycloak.UserCreated).To(Equal(clv1alpha2.NameCreated{
 				Name:    "",
 				Created: false,
 			}))

--- a/operators/pkg/controller/tenant/authorization.go
+++ b/operators/pkg/controller/tenant/authorization.go
@@ -20,17 +20,17 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 func (r *Reconciler) syncWorkspacesAuthorizationRoles(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	if !r.KeycloakActor.IsInitialized() {
 		log.Info("Keycloak actor is not initialized, skipping workspace authorization roles update")
@@ -79,7 +79,7 @@ func (r *Reconciler) syncWorkspacesAuthorizationRoles(
 }
 
 func (r *Reconciler) obtainWantedRoles(
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) []string {
 	wantedRoles := make([]string, 0, len(tn.Spec.Workspaces))
 
@@ -93,8 +93,8 @@ func (r *Reconciler) obtainWantedRoles(
 func (r *Reconciler) obtainCurrentRoles(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
-) ([]*gocloak.Role, error) {
+	tn *clv1alpha2.Tenant,
+) ([]*gocloak13.Role, error) {
 	currentRoles, err := r.KeycloakActor.GetUserRoles(ctx, tn.Status.Keycloak.UserCreated.Name)
 	if err != nil {
 		log.Error(err, "Error getting roles from Keycloak")
@@ -102,7 +102,7 @@ func (r *Reconciler) obtainCurrentRoles(
 	}
 
 	// filter roles to only those related to workspaces
-	filteredRoles := make([]*gocloak.Role, 0)
+	filteredRoles := make([]*gocloak13.Role, 0)
 	for _, role := range currentRoles {
 		if strings.HasPrefix(*role.Name, "workspace-") {
 			filteredRoles = append(filteredRoles, role)
@@ -115,12 +115,12 @@ func (r *Reconciler) obtainCurrentRoles(
 func (r *Reconciler) getRolesToAdd(
 	ctx context.Context,
 	wantedRoles []string,
-	currentRoles []*gocloak.Role,
-) ([]*gocloak.Role, error) {
+	currentRoles []*gocloak13.Role,
+) ([]*gocloak13.Role, error) {
 	rolesToAdd := make([]string, 0)
 
 	for _, wantedRole := range wantedRoles {
-		if !slices.ContainsFunc(currentRoles, func(role *gocloak.Role) bool {
+		if !slices.ContainsFunc(currentRoles, func(role *gocloak13.Role) bool {
 			return *role.Name == wantedRole
 		}) {
 			rolesToAdd = append(rolesToAdd, wantedRole)
@@ -133,8 +133,8 @@ func (r *Reconciler) getRolesToAdd(
 func (r *Reconciler) convertRoleNamesToRoles(
 	ctx context.Context,
 	roles []string,
-) ([]*gocloak.Role, error) {
-	gocloakRoles := make([]*gocloak.Role, len(roles))
+) ([]*gocloak13.Role, error) {
+	gocloakRoles := make([]*gocloak13.Role, len(roles))
 	for i, roleName := range roles {
 		role, err := r.KeycloakActor.GetRole(ctx, roleName)
 		if err != nil {
@@ -147,9 +147,9 @@ func (r *Reconciler) convertRoleNamesToRoles(
 
 func (r *Reconciler) getRolesToDelete(
 	wantedRoles []string,
-	currentRoles []*gocloak.Role,
-) []*gocloak.Role {
-	rolesToDelete := make([]*gocloak.Role, 0)
+	currentRoles []*gocloak13.Role,
+) []*gocloak13.Role {
+	rolesToDelete := make([]*gocloak13.Role, 0)
 
 	for _, currentRole := range currentRoles {
 		if !slices.Contains(wantedRoles, *currentRole.Name) {
@@ -161,6 +161,6 @@ func (r *Reconciler) getRolesToDelete(
 	return rolesToDelete
 }
 
-func workspaceRoleName(data v1alpha2.TenantWorkspaceEntry) string {
+func workspaceRoleName(data clv1alpha2.TenantWorkspaceEntry) string {
 	return forge.WorkspaceRoleName(data.Name, data.Role)
 }

--- a/operators/pkg/controller/tenant/authorization_test.go
+++ b/operators/pkg/controller/tenant/authorization_test.go
@@ -17,15 +17,15 @@ package tenant_test
 import (
 	"fmt"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 )
 
@@ -35,12 +35,12 @@ var _ = Describe("Authorization", func() {
 	})
 
 	Context("When Keycloak actor is initialized", func() {
-		ws1 := v1alpha1.Workspace{
+		ws1 := clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ws1",
 			},
 		}
-		ws2 := v1alpha1.Workspace{
+		ws2 := clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ws2",
 			},
@@ -48,18 +48,18 @@ var _ = Describe("Authorization", func() {
 
 		BeforeEach(func() {
 			keycloakActor.EXPECT().IsInitialized().Return(true).AnyTimes()
-			keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak.User{
-				Username:      gocloak.StringP(tnName),
-				ID:            gocloak.StringP("user-id"),
-				EmailVerified: gocloak.BoolP(true),
+			keycloakActor.EXPECT().GetUser(gomock.Any(), tnName).Return(&gocloak13.User{
+				Username:      gocloak13.StringP(tnName),
+				ID:            gocloak13.StringP("user-id"),
+				EmailVerified: gocloak13.BoolP(true),
 			}, nil).AnyTimes()
 
-			tnResource.Status = v1alpha2.TenantStatus{
-				Subscriptions: map[string]v1alpha2.SubscriptionStatus{
-					"keycloak": v1alpha2.SubscrOk,
+			tnResource.Status = clv1alpha2.TenantStatus{
+				Subscriptions: map[string]clv1alpha2.SubscriptionStatus{
+					"keycloak": clv1alpha2.SubscrOk,
 				},
-				Keycloak: v1alpha2.KeycloakStatus{
-					UserCreated: v1alpha2.NameCreated{
+				Keycloak: clv1alpha2.KeycloakStatus{
+					UserCreated: clv1alpha2.NameCreated{
 						Name:    "user-id",
 						Created: true,
 					},
@@ -78,7 +78,7 @@ var _ = Describe("Authorization", func() {
 
 		Context("When no workspaces are present in tenant and no roles in Keycloak", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{}, nil).AnyTimes()
 			})
 
 			It("Should not add/update/delete any roles to Keycloak", func() {
@@ -88,29 +88,29 @@ var _ = Describe("Authorization", func() {
 
 		Context("When no workspaces are present in tenant but roles in Keycloak", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 					{
-						ID:   gocloak.StringP("no-ws-role"),
-						Name: gocloak.StringP("no-ws-role"),
+						ID:   gocloak13.StringP("no-ws-role"),
+						Name: gocloak13.StringP("no-ws-role"),
 					},
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 				}).Return(nil).Times(1)
 			})
@@ -122,29 +122,29 @@ var _ = Describe("Authorization", func() {
 
 		Context("When workspaces are present in tenant and roles in Keycloak", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.Manager,
+						Role: clv1alpha2.Manager,
 					},
 					{
 						Name: "ws2",
-						Role: v1alpha2.User,
+						Role: clv1alpha2.User,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 					{
-						ID:   gocloak.StringP("no-ws-role"),
-						Name: gocloak.StringP("no-ws-role"),
+						ID:   gocloak13.StringP("no-ws-role"),
+						Name: gocloak13.StringP("no-ws-role"),
 					},
 				}, nil).AnyTimes()
 			})
@@ -156,33 +156,33 @@ var _ = Describe("Authorization", func() {
 
 		Context("When workspaces are present in tenant and roles in Keycloak are missing", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.Manager,
+						Role: clv1alpha2.Manager,
 					},
 					{
 						Name: "ws2",
-						Role: v1alpha2.User,
+						Role: clv1alpha2.User,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws2:user").Return(&gocloak.Role{
-					ID:   gocloak.StringP("workspace-ws2:user"),
-					Name: gocloak.StringP("workspace-ws2:user"),
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws2:user").Return(&gocloak13.Role{
+					ID:   gocloak13.StringP("workspace-ws2:user"),
+					Name: gocloak13.StringP("workspace-ws2:user"),
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 				}).Return(nil).Times(1)
 			})
@@ -194,57 +194,57 @@ var _ = Describe("Authorization", func() {
 
 		Context("When workspaces are present in tenant and roles in Keycloak have different function (manager/user)", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.User, // Changed from Manager to User
+						Role: clv1alpha2.User, // Changed from Manager to User
 					},
 					{
 						Name: "ws2",
-						Role: v1alpha2.Manager, // Changed from User to Manager
+						Role: clv1alpha2.Manager, // Changed from User to Manager
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws1:user").Return(&gocloak.Role{
-					ID:   gocloak.StringP("workspace-ws1:user"),
-					Name: gocloak.StringP("workspace-ws1:user"),
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws1:user").Return(&gocloak13.Role{
+					ID:   gocloak13.StringP("workspace-ws1:user"),
+					Name: gocloak13.StringP("workspace-ws1:user"),
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws2:manager").Return(&gocloak.Role{
-					ID:   gocloak.StringP("workspace-ws2:manager"),
-					Name: gocloak.StringP("workspace-ws2:manager"),
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws2:manager").Return(&gocloak13.Role{
+					ID:   gocloak13.StringP("workspace-ws2:manager"),
+					Name: gocloak13.StringP("workspace-ws2:manager"),
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:user"),
-						Name: gocloak.StringP("workspace-ws1:user"),
+						ID:   gocloak13.StringP("workspace-ws1:user"),
+						Name: gocloak13.StringP("workspace-ws1:user"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:manager"),
-						Name: gocloak.StringP("workspace-ws2:manager"),
+						ID:   gocloak13.StringP("workspace-ws2:manager"),
+						Name: gocloak13.StringP("workspace-ws2:manager"),
 					},
 				}).Return(nil).Times(1)
 
-				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 					{
-						ID:   gocloak.StringP("workspace-ws2:user"),
-						Name: gocloak.StringP("workspace-ws2:user"),
+						ID:   gocloak13.StringP("workspace-ws2:user"),
+						Name: gocloak13.StringP("workspace-ws2:user"),
 					},
 				}).Return(nil).Times(1)
 			})
@@ -256,14 +256,14 @@ var _ = Describe("Authorization", func() {
 
 		Context("When a workspace is not valid", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "invalid-ws",
-						Role: v1alpha2.User,
+						Role: clv1alpha2.User,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{}, nil).AnyTimes()
 			})
 
 			It("Should not add roles for invalid workspaces", func() {
@@ -273,14 +273,14 @@ var _ = Describe("Authorization", func() {
 
 		Context("When tenant has candidate status in workspace", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.Candidate,
+						Role: clv1alpha2.Candidate,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{}, nil).AnyTimes()
 			})
 
 			It("Should not add roles for candidate workspaces", func() {
@@ -294,7 +294,7 @@ var _ = Describe("Authorization", func() {
 			})
 
 			It("Should set Keycloak user sync to false", func() {
-				var tn v1alpha2.Tenant
+				var tn clv1alpha2.Tenant
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Keycloak.UserSynchronized).To(BeFalse())
@@ -303,19 +303,19 @@ var _ = Describe("Authorization", func() {
 
 		Context("When there is an error retrieving role information from Keycloak", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.Manager,
+						Role: clv1alpha2.Manager,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{}, nil).AnyTimes()
 				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws1:manager").Return(nil, fmt.Errorf("some error")).AnyTimes()
 			})
 
 			It("Should set Keycloak user sync to false", func() {
-				var tn v1alpha2.Tenant
+				var tn clv1alpha2.Tenant
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Keycloak.UserSynchronized).To(BeFalse())
@@ -324,29 +324,29 @@ var _ = Describe("Authorization", func() {
 
 		Context("When there is an error adding roles to Keycloak", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{
 					{
 						Name: "ws1",
-						Role: v1alpha2.Manager,
+						Role: clv1alpha2.Manager,
 					},
 				}
 
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{}, nil).AnyTimes()
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws1:manager").Return(&gocloak.Role{
-					ID:   gocloak.StringP("workspace-ws1:manager"),
-					Name: gocloak.StringP("workspace-ws1:manager"),
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-ws1:manager").Return(&gocloak13.Role{
+					ID:   gocloak13.StringP("workspace-ws1:manager"),
+					Name: gocloak13.StringP("workspace-ws1:manager"),
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().AddUserToRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 				}).Return(fmt.Errorf("some error")).Times(1)
 			})
 
 			It("Should set Keycloak user sync to false", func() {
-				var tn v1alpha2.Tenant
+				var tn clv1alpha2.Tenant
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Keycloak.UserSynchronized).To(BeFalse())
@@ -355,23 +355,23 @@ var _ = Describe("Authorization", func() {
 
 		Context("When there is an error removing roles from Keycloak", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak.Role{
+				keycloakActor.EXPECT().GetUserRoles(gomock.Any(), "user-id").Return([]*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 				}, nil).AnyTimes()
 
-				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak.Role{
+				keycloakActor.EXPECT().RemoveUserFromRoles(gomock.Any(), "user-id", []*gocloak13.Role{
 					{
-						ID:   gocloak.StringP("workspace-ws1:manager"),
-						Name: gocloak.StringP("workspace-ws1:manager"),
+						ID:   gocloak13.StringP("workspace-ws1:manager"),
+						Name: gocloak13.StringP("workspace-ws1:manager"),
 					},
 				}).Return(fmt.Errorf("some error")).Times(1)
 			})
 
 			It("Should set Keycloak user sync to false", func() {
-				var tn v1alpha2.Tenant
+				var tn clv1alpha2.Tenant
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, &tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Keycloak.UserSynchronized).To(BeFalse())

--- a/operators/pkg/controller/tenant/clusterresources.go
+++ b/operators/pkg/controller/tenant/clusterresources.go
@@ -21,9 +21,9 @@ import (
 	"github.com/go-logr/logr"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -32,7 +32,7 @@ import (
 func (r *Reconciler) enforceTenantClusterResources(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	// Create ClusterRole for tenant access
 	if err := r.enforceTenantClusterRole(ctx, log, tn); err != nil {
@@ -53,7 +53,7 @@ func (r *Reconciler) enforceTenantClusterResources(
 func (r *Reconciler) enforceTenantClusterResourcesAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	// Delete ClusterRoleBinding
 	if err := r.enforceTenantClusterRoleBindingAbsence(ctx, log, tn); err != nil {
@@ -74,7 +74,7 @@ func (r *Reconciler) enforceTenantClusterResourcesAbsence(
 func (r *Reconciler) enforceTenantClusterRole(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	crName := forge.GetTenantClusterRoleResourceName(tn)
 
@@ -84,11 +84,11 @@ func (r *Reconciler) enforceTenantClusterRole(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &cr, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &cr, func() error {
 		// Configure the cluster role
 		forge.ConfigureTenantClusterRole(&cr, tn, forge.UpdateTenantResourceCommonLabels(nil, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &cr, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &cr, r.Scheme)
 	})
 
 	if err != nil {
@@ -104,7 +104,7 @@ func (r *Reconciler) enforceTenantClusterRole(
 func (r *Reconciler) enforceTenantClusterRoleBinding(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	crbName := forge.GetTenantClusterRoleResourceName(tn)
 
@@ -114,11 +114,11 @@ func (r *Reconciler) enforceTenantClusterRoleBinding(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &crb, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &crb, func() error {
 		// Configure the cluster role binding
 		forge.ConfigureTenantClusterRoleBinding(&crb, tn, forge.UpdateTenantResourceCommonLabels(nil, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &crb, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &crb, r.Scheme)
 	})
 
 	if err != nil {
@@ -134,7 +134,7 @@ func (r *Reconciler) enforceTenantClusterRoleBinding(
 func (r *Reconciler) enforceTenantClusterRoleAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	crName := forge.GetTenantClusterRoleResourceName(tn)
 
@@ -156,7 +156,7 @@ func (r *Reconciler) enforceTenantClusterRoleAbsence(
 func (r *Reconciler) enforceTenantClusterRoleBindingAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	crbName := forge.GetTenantClusterRoleResourceName(tn)
 

--- a/operators/pkg/controller/tenant/clusterresources_test.go
+++ b/operators/pkg/controller/tenant/clusterresources_test.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Cluster Resources", func() {
@@ -81,7 +81,7 @@ var _ = Describe("Cluster Resources", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -107,7 +107,7 @@ var _ = Describe("Cluster Resources", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -170,17 +170,17 @@ var _ = Describe("Cluster Resources", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
 			})
 
 			It("Should prevent the deletion of the tenant", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
-				Expect(tn.Finalizers).To(ContainElement(v1alpha2.TnOperatorFinalizerName))
+				Expect(tn.Finalizers).To(ContainElement(clv1alpha2.TnOperatorFinalizerName))
 			})
 		})
 
@@ -203,17 +203,17 @@ var _ = Describe("Cluster Resources", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
 			})
 
 			It("Should prevent the deletion of the tenant", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
-				Expect(tn.Finalizers).To(ContainElement(v1alpha2.TnOperatorFinalizerName))
+				Expect(tn.Finalizers).To(ContainElement(clv1alpha2.TnOperatorFinalizerName))
 			})
 		})
 	})

--- a/operators/pkg/controller/tenant/common.go
+++ b/operators/pkg/controller/tenant/common.go
@@ -19,15 +19,15 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) enforcePreservingStatus(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
-	mutating func(*v1alpha2.Tenant) *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
+	mutating func(*clv1alpha2.Tenant) *clv1alpha2.Tenant,
 ) error {
 	// the update function will overwrite the status, so we need to save it
 	// and restore it after the update

--- a/operators/pkg/controller/tenant/labels.go
+++ b/operators/pkg/controller/tenant/labels.go
@@ -20,21 +20,21 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 func (r *Reconciler) enforceTenantBaseLabels(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	labels := make(map[string]string)
 	maps.Copy(labels, tn.Labels)
 
 	labels = forge.TenantLabels(labels, tn, r.TargetLabel)
 
-	if err := r.enforcePreservingStatus(ctx, log, tn, func(t *v1alpha2.Tenant) *v1alpha2.Tenant {
+	if err := r.enforcePreservingStatus(ctx, log, tn, func(t *clv1alpha2.Tenant) *clv1alpha2.Tenant {
 		t.Labels = labels
 		return t
 	}); err != nil {

--- a/operators/pkg/controller/tenant/labels_test.go
+++ b/operators/pkg/controller/tenant/labels_test.go
@@ -23,19 +23,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Labels", func() {
 	It("Should add the operator target label", func() {
-		tn := &v1alpha2.Tenant{}
+		tn := &clv1alpha2.Tenant{}
 
 		DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 		Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/operator-selector", "test"))
 	})
 
 	It("Should add the first and last name labels", func() {
-		tn := &v1alpha2.Tenant{}
+		tn := &clv1alpha2.Tenant{}
 
 		DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 		Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/first-name", "Test"))
@@ -46,7 +46,7 @@ var _ = Describe("Labels", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					if tn, ok := obj.(*v1alpha2.Tenant); ok && tn.Name == tnName && len(tn.Labels) > 1 {
+					if tn, ok := obj.(*clv1alpha2.Tenant); ok && tn.Name == tnName && len(tn.Labels) > 1 {
 						return fmt.Errorf("error updating labels")
 					}
 					return nil
@@ -61,7 +61,7 @@ var _ = Describe("Labels", func() {
 		})
 
 		It("Should set status to not ready", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 			Expect(tn.Status.Ready).To(BeFalse())

--- a/operators/pkg/controller/tenant/mydrive.go
+++ b/operators/pkg/controller/tenant/mydrive.go
@@ -22,15 +22,15 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 // enforcePersonalStorage creates the MyDrive PVC (and connected resources) for tenant's personal storage in cross-namespace.
-func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger, tn *v1alpha2.Tenant) error {
+func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger, tn *clv1alpha2.Tenant) error {
 	// If the personal namespace does not exist, skip the PVC creation
 	if !tn.Status.PersonalNamespace.Created {
 		log.Info("Tenant namespace does not exist, skipping PVC creation")
@@ -75,7 +75,7 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 }
 
 // enforceMyDrivePVCAbsence deletes the PVC for tenant's personal storage.
-func (r *Reconciler) enforceMyDrivePVCAbsence(ctx context.Context, log logr.Logger, tn *v1alpha2.Tenant) error {
+func (r *Reconciler) enforceMyDrivePVCAbsence(ctx context.Context, log logr.Logger, tn *clv1alpha2.Tenant) error {
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      forge.MyDrivePVCName(tn.Name),
@@ -94,7 +94,7 @@ func (r *Reconciler) enforceMyDrivePVCAbsence(ctx context.Context, log logr.Logg
 
 func (r *Reconciler) enforceMyDrivePVC(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) (*corev1.PersistentVolumeClaim, error) {
 	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -103,7 +103,7 @@ func (r *Reconciler) enforceMyDrivePVC(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
 		// Configure the PVC
 		if pvc.CreationTimestamp.IsZero() {
 			pvc.Spec = forge.MyDrivePVCSpec(r.MyDrivePVCsStorageClassName, r.MyDrivePVCsSize)
@@ -117,7 +117,7 @@ func (r *Reconciler) enforceMyDrivePVC(
 			pvc.Spec.Resources.Requests = corev1.ResourceList{corev1.ResourceStorage: r.MyDrivePVCsSize}
 		}
 
-		return controllerutil.SetControllerReference(tn, &pvc, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &pvc, r.Scheme)
 	})
 
 	if err != nil {
@@ -129,7 +129,7 @@ func (r *Reconciler) enforceMyDrivePVC(
 
 func (r *Reconciler) enforceMyDrivePVCMirror(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 	pvc *corev1.PersistentVolumeClaim,
 ) (bool, error) {
 	// if the personal namespace does not exist, skip the secret creation
@@ -143,14 +143,14 @@ func (r *Reconciler) enforceMyDrivePVCMirror(
 			Namespace: tn.Status.PersonalNamespace.Name,
 		},
 	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &mirrPvc, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &mirrPvc, func() error {
 		// Configure the mirror PVC
 		if mirrPvc.CreationTimestamp.IsZero() {
 			mirrPvc.Spec = forge.MirrorPVCSpec(pvc, r.MirrorPVCStorageClassName)
 		}
 		mirrPvc.SetLabels(forge.UpdateMyDriveMirrorPVCLabels(mirrPvc.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &mirrPvc, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &mirrPvc, r.Scheme)
 	})
 	if err != nil {
 		return false, fmt.Errorf("unable to create or update mirror PVC for tenant %s: %w", tn.Name, err)
@@ -162,7 +162,7 @@ func (r *Reconciler) enforceMyDrivePVCMirror(
 func (r *Reconciler) launchPVCProvisionJob(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
 	chownJob := batchv1.Job{
@@ -173,7 +173,7 @@ func (r *Reconciler) launchPVCProvisionJob(
 	}
 	labelToSet := forge.ProvisionJobValuePending
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &chownJob, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &chownJob, func() error {
 		if chownJob.CreationTimestamp.IsZero() {
 			log.Info("PVC Provisioning Job created for tenant")
 			// Configure the provisioning job
@@ -187,7 +187,7 @@ func (r *Reconciler) launchPVCProvisionJob(
 			}
 		}
 
-		return controllerutil.SetControllerReference(tn, &chownJob, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &chownJob, r.Scheme)
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create or update PVC Provisioning Job: %w", err)

--- a/operators/pkg/controller/tenant/mydrive.go
+++ b/operators/pkg/controller/tenant/mydrive.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -46,7 +46,7 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 	log.Info("PVC created/updated")
 
 	switch pvc.Status.Phase {
-	case v1.ClaimBound:
+	case corev1.ClaimBound:
 		// Authorize the user to access the PVC by creating a Mirror inside their namespace
 		if created, err := r.enforceMyDrivePVCMirror(ctx, tn, pvc); err != nil {
 			log.Error(err, "Unable to create or update PVC Mirror for tenant")
@@ -65,7 +65,7 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 				return err
 			}
 		}
-	case v1.ClaimPending:
+	case corev1.ClaimPending:
 		log.Info("PVC pending for tenant")
 	default:
 		log.Info("PVC for tenant is in unexpected phase", "phase", pvc.Status.Phase)
@@ -76,7 +76,7 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 
 // enforceMyDrivePVCAbsence deletes the PVC for tenant's personal storage.
 func (r *Reconciler) enforceMyDrivePVCAbsence(ctx context.Context, log logr.Logger, tn *v1alpha2.Tenant) error {
-	pvc := v1.PersistentVolumeClaim{
+	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      forge.MyDrivePVCName(tn.Name),
 			Namespace: r.MyDrivePVCsNamespace,
@@ -95,8 +95,8 @@ func (r *Reconciler) enforceMyDrivePVCAbsence(ctx context.Context, log logr.Logg
 func (r *Reconciler) enforceMyDrivePVC(
 	ctx context.Context,
 	tn *v1alpha2.Tenant,
-) (*v1.PersistentVolumeClaim, error) {
-	pvc := v1.PersistentVolumeClaim{
+) (*corev1.PersistentVolumeClaim, error) {
+	pvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      forge.MyDrivePVCName(tn.Name),
 			Namespace: r.MyDrivePVCsNamespace,
@@ -114,7 +114,7 @@ func (r *Reconciler) enforceMyDrivePVC(
 		// Update size only if it needs to be bigger
 		oldSize := *pvc.Spec.Resources.Requests.Storage()
 		if sizeDiff := r.MyDrivePVCsSize.Cmp(oldSize); sizeDiff > 0 || oldSize.IsZero() {
-			pvc.Spec.Resources.Requests = v1.ResourceList{v1.ResourceStorage: r.MyDrivePVCsSize}
+			pvc.Spec.Resources.Requests = corev1.ResourceList{corev1.ResourceStorage: r.MyDrivePVCsSize}
 		}
 
 		return controllerutil.SetControllerReference(tn, &pvc, r.Scheme)
@@ -130,14 +130,14 @@ func (r *Reconciler) enforceMyDrivePVC(
 func (r *Reconciler) enforceMyDrivePVCMirror(
 	ctx context.Context,
 	tn *v1alpha2.Tenant,
-	pvc *v1.PersistentVolumeClaim,
+	pvc *corev1.PersistentVolumeClaim,
 ) (bool, error) {
 	// if the personal namespace does not exist, skip the secret creation
 	if !tn.Status.PersonalNamespace.Created {
 		return false, nil
 	}
 
-	mirrPvc := v1.PersistentVolumeClaim{
+	mirrPvc := corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      forge.MyDrivePVCMirrorName(tn.Name),
 			Namespace: tn.Status.PersonalNamespace.Name,
@@ -163,7 +163,7 @@ func (r *Reconciler) launchPVCProvisionJob(
 	ctx context.Context,
 	log logr.Logger,
 	tn *v1alpha2.Tenant,
-	pvc *v1.PersistentVolumeClaim,
+	pvc *corev1.PersistentVolumeClaim,
 ) error {
 	chownJob := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -195,7 +195,7 @@ func (r *Reconciler) launchPVCProvisionJob(
 	log.Info("PVC Provisioning Job launched")
 
 	// Update the PVC label
-	if err := utils.PatchObject(ctx, r.Client, pvc, func(p *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
+	if err := utils.PatchObject(ctx, r.Client, pvc, func(p *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
 		forge.UpdatePVCProvisioningJobLabel(p, labelToSet)
 		return p
 	}); err != nil {

--- a/operators/pkg/controller/tenant/mydrive_test.go
+++ b/operators/pkg/controller/tenant/mydrive_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -48,7 +48,7 @@ var _ = Describe("MyDrive management", func() {
 
 	BeforeEach(func() {
 		// Set namespace status to created
-		tnResource.Status.PersonalNamespace = v1alpha2.NameCreated{
+		tnResource.Status.PersonalNamespace = clv1alpha2.NameCreated{
 			Name:    "tenant-" + tnName,
 			Created: true,
 		}
@@ -334,7 +334,7 @@ var _ = Describe("MyDrive management", func() {
 	Context("When tenant namespace does not exist", func() {
 		BeforeEach(func() {
 			// Set namespace status to not created
-			tnResource.Status.PersonalNamespace = v1alpha2.NameCreated{
+			tnResource.Status.PersonalNamespace = clv1alpha2.NameCreated{
 				Created: false,
 			}
 			tnResource.Spec.LastLogin = timePtr(metav1.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))

--- a/operators/pkg/controller/tenant/mydrive_test.go
+++ b/operators/pkg/controller/tenant/mydrive_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,13 +31,13 @@ import (
 )
 
 var _ = Describe("MyDrive management", func() {
-	pvcNs := &v1.Namespace{
+	pvcNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "mydrive-pvcs",
 		},
 	}
 
-	personalNs := &v1.Namespace{
+	personalNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "tenant-" + tnName,
 			Labels: map[string]string{
@@ -65,7 +65,7 @@ var _ = Describe("MyDrive management", func() {
 
 	Context("When tenant needs MyDrive resources", func() {
 		It("Should create the PVC in the MyDrive namespace", func() {
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{
 				Name:      forge.MyDrivePVCName(tnName),
 				Namespace: "mydrive-pvcs",
@@ -73,20 +73,20 @@ var _ = Describe("MyDrive management", func() {
 
 			Expect(pvc.Labels).To(HaveKeyWithValue("crownlabs.polito.it/operator-selector", "test"))
 			Expect(pvc.Annotations).To(HaveKeyWithValue(forge.AuthorizationAnnotationKey, strings.ReplaceAll(forge.MyDriveAuthorizationAnnotationValue, "{tenant-id}", tnName)))
-			Expect(pvc.Spec.AccessModes).To(ContainElement(v1.ReadWriteMany))
+			Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteMany))
 			Expect(pvc.Spec.StorageClassName).ToNot(BeNil())
 			Expect(*pvc.Spec.StorageClassName).To(Equal("nfs"))
 
 			// Verify resource requests
 			Expect(pvc.Spec.Resources.Requests).ToNot(BeEmpty())
-			storageRequest := pvc.Spec.Resources.Requests[v1.ResourceStorage]
+			storageRequest := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 			expectedStorage := resource.MustParse("5Gi")
 			Expect(storageRequest).To(Equal(expectedStorage))
 		})
 
 		Context("When PVC is bound", func() {
 			// Create a PVC and set it to bound status
-			pvc := &v1.PersistentVolumeClaim{
+			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      forge.MyDrivePVCName(tnName),
 					Namespace: "mydrive-pvcs",
@@ -94,22 +94,22 @@ var _ = Describe("MyDrive management", func() {
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Status: v1.PersistentVolumeClaimStatus{
-					Phase: v1.ClaimBound,
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: corev1.ClaimBound,
 				},
-				Spec: v1.PersistentVolumeClaimSpec{
+				Spec: corev1.PersistentVolumeClaimSpec{
 					VolumeName: "pv-" + tnName,
 				},
 			}
 
 			// Create a PV with NFS information
-			pv := &v1.PersistentVolume{
+			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv-" + tnName,
 				},
-				Spec: v1.PersistentVolumeSpec{
-					PersistentVolumeSource: v1.PersistentVolumeSource{
-						CSI: &v1.CSIPersistentVolumeSource{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
 							Driver: "nfs.csi.k8s.io",
 							VolumeAttributes: map[string]string{
 								"server":    "nfs.example.com",
@@ -132,7 +132,7 @@ var _ = Describe("MyDrive management", func() {
 			})
 
 			It("Should create the PVC Mirror in the tenant namespace", func() {
-				mirror := &v1.PersistentVolumeClaim{}
+				mirror := &corev1.PersistentVolumeClaim{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{
 					Name:      forge.MyDrivePVCMirrorName(tnName),
 					Namespace: "tenant-" + tnName,
@@ -155,7 +155,7 @@ var _ = Describe("MyDrive management", func() {
 				Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 
 				// Check for the updated PVC label
-				pvc := &v1.PersistentVolumeClaim{}
+				pvc := &corev1.PersistentVolumeClaim{}
 				Expect(cl.Get(ctx, client.ObjectKey{
 					Name:      forge.MyDrivePVCName(tnName),
 					Namespace: "mydrive-pvcs",
@@ -166,7 +166,7 @@ var _ = Describe("MyDrive management", func() {
 
 			Context("When provisioning job succeeds", func() {
 				// Create a PVC with provisioning label already set to pending
-				pvc := &v1.PersistentVolumeClaim{
+				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      forge.MyDrivePVCName(tnName),
 						Namespace: "mydrive-pvcs",
@@ -175,10 +175,10 @@ var _ = Describe("MyDrive management", func() {
 							forge.ProvisionJobLabel:                 forge.ProvisionJobValuePending,
 						},
 					},
-					Status: v1.PersistentVolumeClaimStatus{
-						Phase: v1.ClaimBound,
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
+					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-" + tnName,
 					},
 				}
@@ -210,7 +210,7 @@ var _ = Describe("MyDrive management", func() {
 				})
 
 				It("Should update the PVC label to ok", func() {
-					pvc := &v1.PersistentVolumeClaim{}
+					pvc := &corev1.PersistentVolumeClaim{}
 					Eventually(func() string {
 						err := cl.Get(ctx, client.ObjectKey{
 							Name:      forge.MyDrivePVCName(tnName),
@@ -226,7 +226,7 @@ var _ = Describe("MyDrive management", func() {
 
 			Context("When provisioning job fails", func() {
 				// Create a PVC with provisioning label already set to pending
-				pvc := &v1.PersistentVolumeClaim{
+				pvc := &corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      forge.MyDrivePVCName(tnName),
 						Namespace: "mydrive-pvcs",
@@ -235,10 +235,10 @@ var _ = Describe("MyDrive management", func() {
 							forge.ProvisionJobLabel:                 forge.ProvisionJobValuePending,
 						},
 					},
-					Status: v1.PersistentVolumeClaimStatus{
-						Phase: v1.ClaimBound,
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
 					},
-					Spec: v1.PersistentVolumeClaimSpec{
+					Spec: corev1.PersistentVolumeClaimSpec{
 						VolumeName: "pv-" + tnName,
 					},
 				}
@@ -270,7 +270,7 @@ var _ = Describe("MyDrive management", func() {
 				})
 
 				It("Should keep the PVC label as pending", func() {
-					pvc := &v1.PersistentVolumeClaim{}
+					pvc := &corev1.PersistentVolumeClaim{}
 					Consistently(func() string {
 						err := cl.Get(ctx, client.ObjectKey{
 							Name:      forge.MyDrivePVCName(tnName),
@@ -287,7 +287,7 @@ var _ = Describe("MyDrive management", func() {
 
 		Context("When PVC is pending", func() {
 			// Create a PVC and set it to pending status
-			pvc := &v1.PersistentVolumeClaim{
+			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      forge.MyDrivePVCName(tnName),
 					Namespace: "mydrive-pvcs",
@@ -295,8 +295,8 @@ var _ = Describe("MyDrive management", func() {
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Status: v1.PersistentVolumeClaimStatus{
-					Phase: v1.ClaimPending,
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: corev1.ClaimPending,
 				},
 			}
 
@@ -310,7 +310,7 @@ var _ = Describe("MyDrive management", func() {
 			})
 
 			It("Should not create any PVC Mirror or provisioning job", func() {
-				mirror := &v1.PersistentVolumeClaim{}
+				mirror := &corev1.PersistentVolumeClaim{}
 				Consistently(func() bool {
 					err := cl.Get(ctx, client.ObjectKey{
 						Name:      forge.MyDrivePVCMirrorName(tnName),
@@ -341,7 +341,7 @@ var _ = Describe("MyDrive management", func() {
 		})
 
 		It("Should not create the PVC", func() {
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{
 				Name:      forge.MyDrivePVCName(tnName),
 				Namespace: "mydrive-pvcs",
@@ -351,7 +351,7 @@ var _ = Describe("MyDrive management", func() {
 
 	Context("When tenant is being deleted", func() {
 		// Create a PVC to be deleted
-		pvc := &v1.PersistentVolumeClaim{
+		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      forge.MyDrivePVCName(tnName),
 				Namespace: "mydrive-pvcs",
@@ -359,8 +359,8 @@ var _ = Describe("MyDrive management", func() {
 					"crownlabs.polito.it/operator-selector": "test",
 				},
 			},
-			Status: v1.PersistentVolumeClaimStatus{
-				Phase: v1.ClaimBound,
+			Status: corev1.PersistentVolumeClaimStatus{
+				Phase: corev1.ClaimBound,
 			},
 		}
 
@@ -377,7 +377,7 @@ var _ = Describe("MyDrive management", func() {
 		})
 
 		It("Should delete the PVC", func() {
-			pvc := &v1.PersistentVolumeClaim{}
+			pvc := &corev1.PersistentVolumeClaim{}
 			Eventually(func() bool {
 				err := cl.Get(ctx, client.ObjectKey{
 					Name:      forge.MyDrivePVCName(tnName),

--- a/operators/pkg/controller/tenant/namespace.go
+++ b/operators/pkg/controller/tenant/namespace.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,7 +113,7 @@ func (r *Reconciler) enforcePersonalNamespace(
 	ctx context.Context,
 	tn *v1alpha2.Tenant,
 ) error {
-	ns := v1.Namespace{
+	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: forge.GetTenantNamespaceName(tn),
 		},
@@ -140,7 +140,7 @@ func (r *Reconciler) enforcePersonalNamespaceAbsence(
 	log logr.Logger,
 	tn *v1alpha2.Tenant,
 ) error {
-	ns := v1.Namespace{
+	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: forge.GetTenantNamespaceName(tn),
 		},
@@ -224,7 +224,7 @@ func (r *Reconciler) enforceResourceQuota(
 
 	// update or create the resource quota
 	nsName := forge.GetTenantNamespaceName(tn)
-	rq := v1.ResourceQuota{
+	rq := corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "crownlabs-resource-quota",
 			Namespace: nsName,
@@ -248,7 +248,7 @@ func (r *Reconciler) enforceResourceQuotaAbsence(
 	tn *v1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
-	rq := v1.ResourceQuota{
+	rq := corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "crownlabs-resource-quota",
 			Namespace: nsName,

--- a/operators/pkg/controller/tenant/namespace.go
+++ b/operators/pkg/controller/tenant/namespace.go
@@ -25,9 +25,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -35,7 +35,7 @@ import (
 func (r *Reconciler) enforceResourcesRelatedToPersonalNamespace(
 	ctx context.Context,
 	extlog logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	log := extlog.WithValues("namespace", forge.GetTenantNamespaceName(tn))
 
@@ -74,7 +74,7 @@ func (r *Reconciler) enforceResourcesRelatedToPersonalNamespace(
 func (r *Reconciler) enforceResourcesRelatedToPersonalNamespaceAbsence(
 	ctx context.Context,
 	extlog logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	log := extlog.WithValues("namespace", forge.GetTenantNamespaceName(tn))
 
@@ -111,7 +111,7 @@ func (r *Reconciler) enforceResourcesRelatedToPersonalNamespaceAbsence(
 
 func (r *Reconciler) enforcePersonalNamespace(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -119,11 +119,11 @@ func (r *Reconciler) enforcePersonalNamespace(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &ns, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &ns, func() error {
 		// Configure the namespace
 		forge.ConfigureTenantNamespace(&ns, tn, forge.UpdateTenantResourceCommonLabels(ns.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &ns, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &ns, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error when creating namespace for tenant %s: %w", tn.Name, err)
 	}
@@ -138,7 +138,7 @@ func (r *Reconciler) enforcePersonalNamespace(
 func (r *Reconciler) enforcePersonalNamespaceAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ func (r *Reconciler) enforcePersonalNamespaceAbsence(
 }
 
 // checkNamespaceKeepAlive checks to see if the namespace should be deleted.
-func (r *Reconciler) checkNamespaceKeepAlive(ctx context.Context, log logr.Logger, tn *v1alpha2.Tenant) (keepNsOpen bool, err error) {
+func (r *Reconciler) checkNamespaceKeepAlive(ctx context.Context, log logr.Logger, tn *clv1alpha2.Tenant) (keepNsOpen bool, err error) {
 	// We check to see if last login was more than r.TenantNSKeepAlive in the past:
 	// if so, temporarily delete the namespace. The lastLogin field is omitted when a user is first created
 
@@ -174,7 +174,7 @@ func (r *Reconciler) checkNamespaceKeepAlive(ctx context.Context, log logr.Logge
 	}
 
 	// Attempt to get instances in current namespace
-	list := &v1alpha2.InstanceList{}
+	list := &clv1alpha2.InstanceList{}
 
 	if err := r.List(ctx, list, client.InNamespace(forge.GetTenantNamespaceName(tn))); err != nil {
 		return true, err
@@ -207,7 +207,7 @@ func (r *Reconciler) checkNamespaceKeepAlive(ctx context.Context, log logr.Logge
 func (r *Reconciler) enforceResourceQuota(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	// get the enrolled workspaces
 	wss, err := r.getWorkspacesList(
@@ -231,11 +231,11 @@ func (r *Reconciler) enforceResourceQuota(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &rq, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &rq, func() error {
 		// Configure the resource quota
 		forge.ConfigureTenantResourceQuota(&rq, &quota, forge.UpdateTenantResourceCommonLabels(rq.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &rq, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &rq, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error when creating resource quota for tenant %s: %w", tn.Name, err)
 	}
@@ -245,7 +245,7 @@ func (r *Reconciler) enforceResourceQuota(
 
 func (r *Reconciler) enforceResourceQuotaAbsence(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	rq := corev1.ResourceQuota{
@@ -260,7 +260,7 @@ func (r *Reconciler) enforceResourceQuotaAbsence(
 
 func (r *Reconciler) enforceInstanceRoleBinding(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	rb := rbacv1.RoleBinding{
@@ -270,11 +270,11 @@ func (r *Reconciler) enforceInstanceRoleBinding(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, &rb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &rb, func() error {
 		// Configure the role binding
 		forge.ConfigureTenantInstancesRoleBinding(&rb, tn, forge.UpdateTenantResourceCommonLabels(rb.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, &rb, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, &rb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error when creating role binding for tenant %s: %w", tn.Name, err)
 	}
@@ -284,7 +284,7 @@ func (r *Reconciler) enforceInstanceRoleBinding(
 
 func (r *Reconciler) enforceInstanceRoleBindingAbsence(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	rb := rbacv1.RoleBinding{
@@ -299,7 +299,7 @@ func (r *Reconciler) enforceInstanceRoleBindingAbsence(
 
 func (r *Reconciler) enforceDenyNetworkPolicy(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	netPolDeny := &netv1.NetworkPolicy{
@@ -309,11 +309,11 @@ func (r *Reconciler) enforceDenyNetworkPolicy(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, netPolDeny, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, netPolDeny, func() error {
 		// Configure the network policy
 		forge.ConfigureTenantDenyNetworkPolicy(netPolDeny, forge.UpdateTenantResourceCommonLabels(netPolDeny.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, netPolDeny, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, netPolDeny, r.Scheme)
 	})
 
 	return err
@@ -321,7 +321,7 @@ func (r *Reconciler) enforceDenyNetworkPolicy(
 
 func (r *Reconciler) enforceAllowNetworkPolicy(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	netPolAllow := &netv1.NetworkPolicy{
@@ -331,11 +331,11 @@ func (r *Reconciler) enforceAllowNetworkPolicy(
 		},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, netPolAllow, func() error {
+	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, netPolAllow, func() error {
 		// Configure the network policy
 		forge.ConfigureTenantAllowNetworkPolicy(netPolAllow, forge.UpdateTenantResourceCommonLabels(netPolAllow.Labels, r.TargetLabel))
 
-		return controllerutil.SetControllerReference(tn, netPolAllow, r.Scheme)
+		return ctrlutil.SetControllerReference(tn, netPolAllow, r.Scheme)
 	})
 
 	return err
@@ -343,7 +343,7 @@ func (r *Reconciler) enforceAllowNetworkPolicy(
 
 func (r *Reconciler) enforceDenyNetworkPolicyAbsence(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	netPolDeny := &netv1.NetworkPolicy{
@@ -358,7 +358,7 @@ func (r *Reconciler) enforceDenyNetworkPolicyAbsence(
 
 func (r *Reconciler) enforceAllowNetworkPolicyAbsence(
 	ctx context.Context,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	nsName := forge.GetTenantNamespaceName(tn)
 	netPolAllow := &netv1.NetworkPolicy{

--- a/operators/pkg/controller/tenant/namespace_test.go
+++ b/operators/pkg/controller/tenant/namespace_test.go
@@ -29,14 +29,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var (
@@ -44,8 +44,8 @@ var (
 )
 
 func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
-	utilruntime.Must(v1alpha2.AddToScheme(testScheme))
+	utilruntime.Must(scheme.AddToScheme(testScheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(testScheme))
 }
 
 var _ = Describe("Namespace management", func() {
@@ -128,7 +128,7 @@ var _ = Describe("Namespace management", func() {
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -189,7 +189,7 @@ var _ = Describe("Namespace management", func() {
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
-			instance := &v1alpha2.Instance{
+			instance := &clv1alpha2.Instance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-instance",
 					Namespace: "tenant-" + tnName,
@@ -197,7 +197,7 @@ var _ = Describe("Namespace management", func() {
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.InstanceSpec{
+				Spec: clv1alpha2.InstanceSpec{
 					Running: true,
 				},
 			}
@@ -205,7 +205,7 @@ var _ = Describe("Namespace management", func() {
 			err := cl.Create(ctx, instance)
 			Expect(err).ToNot(HaveOccurred())
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err = cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -263,7 +263,7 @@ var _ = Describe("Namespace management", func() {
 	Context("When testing edge cases and error scenarios", func() {
 		It("Should handle tenant with LastLogin field unset correctly", func() {
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -283,14 +283,14 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should handle namespace with dots in tenant name", func() {
-			tenantWithDots := &v1alpha2.Tenant{
+			tenantWithDots := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test.tenant.with.dots",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "Test",
 					LastName:  "TenantDots",
 					Email:     "test.dots@tenant.example",
@@ -320,7 +320,7 @@ var _ = Describe("Namespace management", func() {
 				WithObjects(tnResource).
 				WithInterceptorFuncs(interceptor.Funcs{
 					List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-						if _, ok := list.(*v1alpha2.InstanceList); ok {
+						if _, ok := list.(*clv1alpha2.InstanceList); ok {
 							return fmt.Errorf("simulated list error")
 						}
 						return client.List(ctx, list, opts...)
@@ -328,7 +328,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := interceptorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -359,7 +359,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := errorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -377,12 +377,12 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should handle multiple instances in namespace", func() {
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
 			for i := 0; i < 3; i++ {
-				instance := &v1alpha2.Instance{
+				instance := &clv1alpha2.Instance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("test-instance-%d", i),
 						Namespace: "tenant-" + tnName,
@@ -390,7 +390,7 @@ var _ = Describe("Namespace management", func() {
 							"crownlabs.polito.it/operator-selector": "test",
 						},
 					},
-					Spec: v1alpha2.InstanceSpec{Running: true},
+					Spec: clv1alpha2.InstanceSpec{Running: true},
 				}
 				err := cl.Create(ctx, instance)
 				Expect(err).ToNot(HaveOccurred())
@@ -411,7 +411,7 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should test recent login time", func() {
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -449,14 +449,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForError := &v1alpha2.Tenant{
+			tenantForError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "Error",
 					LastName:  "Tenant",
 					Email:     "error@tenant.example",
@@ -495,7 +495,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err = errorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -532,14 +532,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForNetpolError := &v1alpha2.Tenant{
+			tenantForNetpolError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "netpol-error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "NetPol",
 					LastName:  "Error",
 					Email:     "netpol@error.example",
@@ -579,14 +579,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForNsError := &v1alpha2.Tenant{
+			tenantForNsError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns-error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "Namespace",
 					LastName:  "Error",
 					Email:     "ns@error.example",
@@ -626,14 +626,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForRbError := &v1alpha2.Tenant{
+			tenantForRbError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "rb-error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "RoleBinding",
 					LastName:  "Error",
 					Email:     "rb@error.example",
@@ -673,14 +673,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForDenyError := &v1alpha2.Tenant{
+			tenantForDenyError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "deny-error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "Deny",
 					LastName:  "Error",
 					Email:     "deny@error.example",
@@ -720,14 +720,14 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			tenantForAllowError := &v1alpha2.Tenant{
+			tenantForAllowError := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "allow-error-tenant",
 					Labels: map[string]string{
 						"crownlabs.polito.it/operator-selector": "test",
 					},
 				},
-				Spec: v1alpha2.TenantSpec{
+				Spec: clv1alpha2.TenantSpec{
 					FirstName: "Allow",
 					LastName:  "Error",
 					Email:     "allow@error.example",
@@ -767,7 +767,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err = errorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -804,7 +804,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err = errorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -841,7 +841,7 @@ var _ = Describe("Namespace management", func() {
 				}).
 				Build()
 
-			updatedTenant := &v1alpha2.Tenant{}
+			updatedTenant := &clv1alpha2.Tenant{}
 			err = errorClient.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -873,16 +873,16 @@ var _ = Describe("Namespace management", func() {
 		})
 		When("Personal workspace is enabled", func() {
 			BeforeEach(func() {
-				tnResource.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+				tnResource.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 					Instances: 2,
 					CPU:       resource.MustParse("4"),
 					Memory:    resource.MustParse("8Gi"),
 				}
 			})
 			When("Personal workspace has templates", func() {
-				var testTemplate *v1alpha2.Template
+				var testTemplate *clv1alpha2.Template
 				BeforeEach(func() {
-					testTemplate = &v1alpha2.Template{
+					testTemplate = &clv1alpha2.Template{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test-template",
 							Namespace: tnPersonalNamespace,
@@ -908,7 +908,7 @@ var _ = Describe("Namespace management", func() {
 				BeforeEach(func() {
 					builder = *builder.WithInterceptorFuncs(interceptor.Funcs{
 						List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-							if _, ok := list.(*v1alpha2.TemplateList); ok {
+							if _, ok := list.(*clv1alpha2.TemplateList); ok {
 								return fmt.Errorf("simulated error on template list")
 							}
 							return client.List(ctx, list, opts...)
@@ -935,7 +935,7 @@ var _ = Describe("Namespace management", func() {
 	When("Namespace is present", func() {
 		When("Personal workspace is enabled", func() {
 			BeforeEach(func() {
-				tnResource.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+				tnResource.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 					Instances: 2,
 					CPU:       resource.MustParse("4"),
 					Memory:    resource.MustParse("8Gi"),

--- a/operators/pkg/controller/tenant/namespace_test.go
+++ b/operators/pkg/controller/tenant/namespace_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -51,7 +51,7 @@ func init() {
 var _ = Describe("Namespace management", func() {
 	Context("When tenant needs namespace resources", func() {
 		It("Should create the personal namespace", func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
@@ -63,7 +63,7 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should create the resource quota", func() {
-			rq := &v1.ResourceQuota{}
+			rq := &corev1.ResourceQuota{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{
 				Name:      "crownlabs-resource-quota",
 				Namespace: "tenant-" + tnName,
@@ -124,7 +124,7 @@ var _ = Describe("Namespace management", func() {
 
 	Context("When tenant namespace should be deleted", func() {
 		JustBeforeEach(func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
@@ -145,13 +145,13 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should delete the namespace resources", func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeFalse(), 10*time.Second, 250*time.Millisecond)
 		})
 
 		It("Should delete the resource quota", func() {
-			rq := &v1.ResourceQuota{}
+			rq := &corev1.ResourceQuota{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{
 				Name:      "crownlabs-resource-quota",
 				Namespace: "tenant-" + tnName,
@@ -185,7 +185,7 @@ var _ = Describe("Namespace management", func() {
 
 	Context("When tenant has instances running", func() {
 		JustBeforeEach(func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
@@ -222,13 +222,13 @@ var _ = Describe("Namespace management", func() {
 		})
 
 		It("Should keep the namespace when instances are running", func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 		})
 
 		It("Should keep the resource quota when instances are running", func() {
-			rq := &v1.ResourceQuota{}
+			rq := &corev1.ResourceQuota{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{
 				Name:      "crownlabs-resource-quota",
 				Namespace: "tenant-" + tnName,
@@ -276,7 +276,7 @@ var _ = Describe("Namespace management", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			Consistently(func() error {
 				return cl.Get(ctx, client.ObjectKey{Name: "tenant-" + tnName}, namespace)
 			}, 2*time.Second, 250*time.Millisecond).Should(HaveOccurred())
@@ -306,7 +306,7 @@ var _ = Describe("Namespace management", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-test-tenant-with-dots"},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 
@@ -351,7 +351,7 @@ var _ = Describe("Namespace management", func() {
 				WithObjects(tnResource).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-						if _, ok := obj.(*v1.Namespace); ok {
+						if _, ok := obj.(*corev1.Namespace); ok {
 							return fmt.Errorf("simulated delete error for Namespace")
 						}
 						return client.Delete(ctx, obj, opts...)
@@ -405,7 +405,7 @@ var _ = Describe("Namespace management", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 		})
@@ -424,7 +424,7 @@ var _ = Describe("Namespace management", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName},
 				namespace, BeTrue(), 10*time.Second, 250*time.Millisecond)
 		})
@@ -435,13 +435,13 @@ var _ = Describe("Namespace management", func() {
 				WithObjects().
 				WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-						if _, ok := obj.(*v1.ResourceQuota); ok {
+						if _, ok := obj.(*corev1.ResourceQuota); ok {
 							return fmt.Errorf("simulated create error for ResourceQuota")
 						}
 						return client.Create(ctx, obj, opts...)
 					},
 					Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-						if _, ok := obj.(*v1.ResourceQuota); ok {
+						if _, ok := obj.(*corev1.ResourceQuota); ok {
 							return fmt.Errorf("simulated update error for ResourceQuota")
 						}
 						return client.Update(ctx, obj, opts...)
@@ -565,13 +565,13 @@ var _ = Describe("Namespace management", func() {
 				WithObjects().
 				WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-						if _, ok := obj.(*v1.Namespace); ok {
+						if _, ok := obj.(*corev1.Namespace); ok {
 							return fmt.Errorf("simulated create error for Namespace")
 						}
 						return client.Create(ctx, obj, opts...)
 					},
 					Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-						if _, ok := obj.(*v1.Namespace); ok {
+						if _, ok := obj.(*corev1.Namespace); ok {
 							return fmt.Errorf("simulated update error for Namespace")
 						}
 						return client.Update(ctx, obj, opts...)
@@ -833,7 +833,7 @@ var _ = Describe("Namespace management", func() {
 				WithObjects(tnResource).
 				WithInterceptorFuncs(interceptor.Funcs{
 					Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-						if _, ok := obj.(*v1.ResourceQuota); ok {
+						if _, ok := obj.(*corev1.ResourceQuota); ok {
 							return fmt.Errorf("simulated delete error for ResourceQuota")
 						}
 						return client.Delete(ctx, obj, opts...)
@@ -860,11 +860,11 @@ var _ = Describe("Namespace management", func() {
 
 	})
 	When("Namespace is absent", func() {
-		var testNamespace *v1.Namespace
+		var testNamespace *corev1.Namespace
 		BeforeEach(func() {
 			tnResource.Status.PersonalNamespace.Created = true
 			tnResource.Status.PersonalNamespace.Name = tnPersonalNamespace
-			testNamespace = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tnPersonalNamespace}}
+			testNamespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tnPersonalNamespace}}
 			addObjToObjectsList(testNamespace)
 			tnResource.Spec.LastLogin = timePtr(metav1.NewTime(time.Now().Add(-(tenantReconciler.TenantNSKeepAlive + time.Second))))
 		})
@@ -894,13 +894,13 @@ var _ = Describe("Namespace management", func() {
 					removeObjFromObjectsList(testTemplate)
 				})
 				It("Should keep the namespace", func() {
-					ns := &v1.Namespace{}
+					ns := &corev1.Namespace{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeTrue(), timeout, interval)
 				})
 			})
 			When("Personal workspace does not have templates", func() {
 				It("Should delete the namespace", func() {
-					ns := &v1.Namespace{}
+					ns := &corev1.Namespace{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeFalse(), timeout, interval)
 				})
 			})
@@ -917,7 +917,7 @@ var _ = Describe("Namespace management", func() {
 					tnReconcileErrExpected = HaveOccurred()
 				})
 				It("Should keep the namespace", func() {
-					ns := &v1.Namespace{}
+					ns := &corev1.Namespace{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeTrue(), timeout, interval)
 				})
 			})
@@ -927,7 +927,7 @@ var _ = Describe("Namespace management", func() {
 				tnResource.Spec.PersonalWorkspace = nil
 			})
 			It("Should delete the namespace", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeFalse(), timeout, interval)
 			})
 		})
@@ -942,7 +942,7 @@ var _ = Describe("Namespace management", func() {
 				}
 			})
 			It("Should keep the namespace", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeTrue(), timeout, interval)
 			})
 		})
@@ -951,7 +951,7 @@ var _ = Describe("Namespace management", func() {
 				tnResource.Spec.PersonalWorkspace = nil
 			})
 			It("Should keep the namespace", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, ns, BeTrue(), timeout, interval)
 			})
 		})

--- a/operators/pkg/controller/tenant/personal_workspace.go
+++ b/operators/pkg/controller/tenant/personal_workspace.go
@@ -23,13 +23,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 // handlePersonalWorkspace handles the personal workspace for the tenant.
-func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *v1alpha2.Tenant) error {
+func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *clv1alpha2.Tenant) error {
 	log := ctrl.LoggerFrom(ctx)
 	if !tn.Status.PersonalNamespace.Created {
 		// if the personal namespace is not created skip the rest.
@@ -60,9 +60,9 @@ func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *v1alpha2.T
 }
 
 // checkPersonalWorkspaceKeepAlive checks if the personal workspace should be kept alive because it has templates.
-func (r *Reconciler) checkPersonalWorkspaceKeepAlive(ctx context.Context, tn *v1alpha2.Tenant) (bool, error) {
+func (r *Reconciler) checkPersonalWorkspaceKeepAlive(ctx context.Context, tn *clv1alpha2.Tenant) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
-	templates := &v1alpha2.TemplateList{}
+	templates := &clv1alpha2.TemplateList{}
 	if tn.Spec.PersonalWorkspace == nil {
 		return false, nil
 	}

--- a/operators/pkg/controller/tenant/personal_workspace_test.go
+++ b/operators/pkg/controller/tenant/personal_workspace_test.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Personal workspace handling", func() {
@@ -41,7 +41,7 @@ var _ = Describe("Personal workspace handling", func() {
 		})
 		When("Personal workspace is enabled", func() {
 			BeforeEach(func() {
-				tnResource.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+				tnResource.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 					Instances: 2,
 					CPU:       resource.MustParse("4"),
 					Memory:    resource.MustParse("8Gi"),
@@ -58,7 +58,7 @@ var _ = Describe("Personal workspace handling", func() {
 				Expect(len(rb.Subjects)).To(Equal(1))
 				Expect(rb.Subjects[0].Kind).To(Equal("User"))
 				Expect(rb.Subjects[0].Name).To(Equal(tnName))
-				updatedTenant := &v1alpha2.Tenant{}
+				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeTrue())
@@ -77,7 +77,7 @@ var _ = Describe("Personal workspace handling", func() {
 					tnReconcileErrExpected = HaveOccurred()
 				})
 				It("Should mark the personal workspace as failing", func() {
-					updatedTenant := &v1alpha2.Tenant{}
+					updatedTenant := &clv1alpha2.Tenant{}
 					Expect(cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)).To(Succeed())
 					Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeFalse())
 					Expect(updatedTenant.Status.FailingWorkspaces).To(HaveLen(1))
@@ -89,7 +89,7 @@ var _ = Describe("Personal workspace handling", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
-				updatedTenant := &v1alpha2.Tenant{}
+				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeFalse())
@@ -108,7 +108,7 @@ var _ = Describe("Personal workspace handling", func() {
 					tnReconcileErrExpected = HaveOccurred()
 				})
 				It("Should mark the personal workspace as not created", func() {
-					updatedTenant := &v1alpha2.Tenant{}
+					updatedTenant := &clv1alpha2.Tenant{}
 					Expect(cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)).To(Succeed())
 					Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeFalse())
 					Expect(updatedTenant.Status.FailingWorkspaces).To(BeEmpty())
@@ -128,7 +128,7 @@ var _ = Describe("Personal workspace handling", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
-				updatedTenant := &v1alpha2.Tenant{}
+				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeFalse())
@@ -139,7 +139,7 @@ var _ = Describe("Personal workspace handling", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
-				updatedTenant := &v1alpha2.Tenant{}
+				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedTenant.Status.PersonalWorkspaceCreated).To(BeFalse())

--- a/operators/pkg/controller/tenant/personal_workspace_test.go
+++ b/operators/pkg/controller/tenant/personal_workspace_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +36,7 @@ import (
 var _ = Describe("Personal workspace handling", func() {
 	When("Tenant namespace exists", func() {
 		JustBeforeEach(func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, namespace, BeTrue(), timeout, interval)
 		})
 		When("Personal workspace is enabled", func() {
@@ -121,7 +121,7 @@ var _ = Describe("Personal workspace handling", func() {
 			tnResource.Spec.LastLogin = timePtr(metav1.NewTime(time.Now().Add(-(tenantReconciler.TenantNSKeepAlive + time.Second))))
 		})
 		JustBeforeEach(func() {
-			namespace := &v1.Namespace{}
+			namespace := &corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnPersonalNamespace}, namespace, BeFalse(), timeout, interval)
 		})
 		When("Personal workspace is enabled", func() {

--- a/operators/pkg/controller/tenant/reconciler.go
+++ b/operators/pkg/controller/tenant/reconciler.go
@@ -33,14 +33,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -49,19 +49,19 @@ import (
 type Reconciler struct {
 	client.Client
 	Scheme                      *runtime.Scheme
-	TargetLabel                 common.KVLabel
+	TargetLabel                 ctrlcommon.KVLabel
 	TenantNSKeepAlive           time.Duration
 	TriggerReconcileChannel     chan event.GenericEvent // Channel to trigger a reconciliation of the tenant resource.
 	MyDrivePVCsSize             resource.Quantity
 	MyDrivePVCsStorageClassName string
 	MyDrivePVCsNamespace        string
 	MirrorPVCStorageClassName   string
-	KeycloakActor               common.KeycloakActorIface
+	KeycloakActor               ctrlcommon.KeycloakActorIface
 	WaitUserVerification        bool // If true, the reconciliation will wait for the user to be verified in Keycloak before creating resources.
 	SandboxClusterRole          string
 	BaseWorkspaces              []string
 	Concurrency                 int
-	Reschedule                  common.Rescheduler
+	Reschedule                  ctrlcommon.Rescheduler
 }
 
 // Reconcile reconciles the state of a tenant resource.
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log := ctrl.LoggerFrom(ctx).WithValues("tenant", req.Name)
 	ctx = ctrl.LoggerInto(ctx, log)
 
-	var tn v1alpha2.Tenant
+	var tn clv1alpha2.Tenant
 	if err := r.Get(ctx, req.NamespacedName, &tn); client.IgnoreNotFound(err) != nil {
 		log.Error(err, "Error when getting tenant before starting reconcile")
 		return ctrl.Result{}, err
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Info("Reconciling tenant")
 
 	avoidStatusUpdate := false
-	defer func(original, updated *v1alpha2.Tenant) {
+	defer func(original, updated *clv1alpha2.Tenant) {
 		if avoidStatusUpdate {
 			return
 		}
@@ -117,9 +117,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// add the finalizer if it is not already present
-	if !controllerutil.ContainsFinalizer(&tn, v1alpha2.TnOperatorFinalizerName) {
-		if err := utils.PatchObject(ctx, r.Client, &tn, func(t *v1alpha2.Tenant) *v1alpha2.Tenant {
-			controllerutil.AddFinalizer(t, v1alpha2.TnOperatorFinalizerName)
+	if !ctrlutil.ContainsFinalizer(&tn, clv1alpha2.TnOperatorFinalizerName) {
+		if err := utils.PatchObject(ctx, r.Client, &tn, func(t *clv1alpha2.Tenant) *clv1alpha2.Tenant {
+			ctrlutil.AddFinalizer(t, clv1alpha2.TnOperatorFinalizerName)
 			return t
 		}); err != nil {
 			log.Error(err, "Error adding finalizer to tenant", "tenant", tn.Name)
@@ -238,7 +238,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha2.Tenant{}, builder.WithPredicates(pred)).
+		For(&clv1alpha2.Tenant{}, builder.WithPredicates(pred)).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Namespace{}).
@@ -269,7 +269,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 				},
 			),
 		).
-		Watches(&v1alpha1.Workspace{},
+		Watches(&clv1alpha1.Workspace{},
 			handler.EnqueueRequestsFromMapFunc(r.workspaceToEnrolledTenants)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Concurrency,
@@ -281,7 +281,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 func (r *Reconciler) deleteTenantDependencies(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	// delete the personal namespace
 	if err := r.enforceResourcesRelatedToPersonalNamespaceAbsence(ctx, log, tn); err != nil {
@@ -323,9 +323,9 @@ func (r *Reconciler) deleteTenantDependencies(
 	log.Info("Deleted tenant in Keycloak", "tenant", tn.Name)
 
 	// delete the finalizer
-	if controllerutil.ContainsFinalizer(tn, v1alpha2.TnOperatorFinalizerName) {
-		if err := utils.PatchObject(ctx, r.Client, tn, func(t *v1alpha2.Tenant) *v1alpha2.Tenant {
-			controllerutil.RemoveFinalizer(t, v1alpha2.TnOperatorFinalizerName)
+	if ctrlutil.ContainsFinalizer(tn, clv1alpha2.TnOperatorFinalizerName) {
+		if err := utils.PatchObject(ctx, r.Client, tn, func(t *clv1alpha2.Tenant) *clv1alpha2.Tenant {
+			ctrlutil.RemoveFinalizer(t, clv1alpha2.TnOperatorFinalizerName)
 			return t
 		}); err != nil {
 			log.Error(err, "Error removing finalizer from tenant", "tenant", tn.Name)
@@ -350,9 +350,9 @@ func (r *Reconciler) WorkspaceNameToEnrolledTenants(
 	wsName string,
 ) []ctrl.Request {
 	var enqueues []ctrl.Request
-	var tenants v1alpha2.TenantList
+	var tenants clv1alpha2.TenantList
 	if err := r.List(ctx, &tenants, client.HasLabels{
-		fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, wsName),
+		fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, wsName),
 	}); err != nil {
 		log := ctrl.LoggerFrom(ctx)
 		log.Error(err, "Error when retrieving tenants enrolled", "workspace", wsName)

--- a/operators/pkg/controller/tenant/reconciler.go
+++ b/operators/pkg/controller/tenant/reconciler.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -239,10 +239,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha2.Tenant{}, builder.WithPredicates(pred)).
-		Owns(&v1.Secret{}).
-		Owns(&v1.PersistentVolumeClaim{}).
-		Owns(&v1.Namespace{}).
-		Owns(&v1.ResourceQuota{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&corev1.Namespace{}).
+		Owns(&corev1.ResourceQuota{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).

--- a/operators/pkg/controller/tenant/reconciler_test.go
+++ b/operators/pkg/controller/tenant/reconciler_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -71,13 +71,13 @@ var _ = Describe("TenantReconciler", func() {
 		})
 
 		It("Should not create any resources", func() {
-			ns := &v1.Namespace{}
+			ns := &corev1.Namespace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName}, ns, BeFalse(), timeout, interval)
 		})
 
 		Context("When there are resources associated with the tenant", func() {
-			namespaceResource := &v1.Namespace{
+			namespaceResource := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "tenant-" + tnName,
 					Labels: map[string]string{
@@ -95,7 +95,7 @@ var _ = Describe("TenantReconciler", func() {
 			})
 
 			It("Should not delete the resources", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "tenant-" + tnName}, ns, BeTrue(), timeout, interval)
 

--- a/operators/pkg/controller/tenant/reconciler_test.go
+++ b/operators/pkg/controller/tenant/reconciler_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("TenantReconciler", func() {
@@ -51,7 +51,7 @@ var _ = Describe("TenantReconciler", func() {
 
 	Context("When the resource is not found in the cluster", func() {
 		BeforeEach(func() {
-			tnResource = &v1alpha2.Tenant{}
+			tnResource = &clv1alpha2.Tenant{}
 		})
 
 		It("Should not return an error", func() {
@@ -105,7 +105,7 @@ var _ = Describe("TenantReconciler", func() {
 	})
 
 	It("Should add the finalizer to the tenant resource", func() {
-		tn := &v1alpha2.Tenant{}
+		tn := &clv1alpha2.Tenant{}
 
 		DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
@@ -116,7 +116,7 @@ var _ = Describe("TenantReconciler", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					if tn, ok := obj.(*v1alpha2.Tenant); ok && tn.Name == tnName {
+					if tn, ok := obj.(*clv1alpha2.Tenant); ok && tn.Name == tnName {
 						return fmt.Errorf("failed to add finalizer")
 					}
 					return nil
@@ -140,7 +140,7 @@ var _ = Describe("TenantReconciler", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						if tn, ok := obj.(*v1alpha2.Tenant); ok && tn.Name == tnName {
+						if tn, ok := obj.(*clv1alpha2.Tenant); ok && tn.Name == tnName {
 							return fmt.Errorf("failed to remove finalizer")
 						}
 						return nil
@@ -155,7 +155,7 @@ var _ = Describe("TenantReconciler", func() {
 			})
 
 			It("Should prevent the deletion of the tenant resource", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 			})
@@ -165,14 +165,14 @@ var _ = Describe("TenantReconciler", func() {
 	Context("Testing WorkspaceToEnrolledTenants functionality", func() {
 		var (
 			workspaceName      string
-			workspace          *v1alpha1.Workspace
-			enrolledTenants    []*v1alpha2.Tenant
-			notEnrolledTenants []*v1alpha2.Tenant
+			workspace          *clv1alpha1.Workspace
+			enrolledTenants    []*clv1alpha2.Tenant
+			notEnrolledTenants []*clv1alpha2.Tenant
 		)
 
 		workspaceName = "test-workspace"
 
-		workspace = &v1alpha1.Workspace{
+		workspace = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: workspaceName,
 				Labels: map[string]string{
@@ -182,12 +182,12 @@ var _ = Describe("TenantReconciler", func() {
 		}
 
 		// Create enrolled tenants
-		enrolledTenants = []*v1alpha2.Tenant{
+		enrolledTenants = []*clv1alpha2.Tenant{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "enrolled-tenant-1",
 					Labels: map[string]string{
-						fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, workspaceName): "true",
+						fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, workspaceName): "true",
 					},
 				},
 			},
@@ -195,14 +195,14 @@ var _ = Describe("TenantReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "enrolled-tenant-2",
 					Labels: map[string]string{
-						fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, workspaceName): "true",
+						fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, workspaceName): "true",
 					},
 				},
 			},
 		}
 
 		// Create not enrolled tenants
-		notEnrolledTenants = []*v1alpha2.Tenant{
+		notEnrolledTenants = []*clv1alpha2.Tenant{
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "not-enrolled-tenant-1",
@@ -213,7 +213,7 @@ var _ = Describe("TenantReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "not-enrolled-tenant-2",
 					Labels: map[string]string{
-						fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, "other-workspace"): "true",
+						fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, "other-workspace"): "true",
 					},
 				},
 			},
@@ -264,7 +264,7 @@ var _ = Describe("TenantReconciler", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
-						if _, ok := list.(*v1alpha2.TenantList); ok {
+						if _, ok := list.(*clv1alpha2.TenantList); ok {
 							return fmt.Errorf("error listing tenants")
 						}
 						return nil

--- a/operators/pkg/controller/tenant/sandbox.go
+++ b/operators/pkg/controller/tenant/sandbox.go
@@ -23,13 +23,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 // EnforceSandboxResources ensures the presence/absence of a sandbox.
-func (r *Reconciler) enforceSandboxResources(ctx context.Context, tenant *v1alpha2.Tenant) error {
+func (r *Reconciler) enforceSandboxResources(ctx context.Context, tenant *clv1alpha2.Tenant) error {
 	if tenant.Spec.CreateSandbox {
 		return r.enforceSandboxResourcesPresence(ctx, tenant)
 	}
@@ -37,7 +37,7 @@ func (r *Reconciler) enforceSandboxResources(ctx context.Context, tenant *v1alph
 }
 
 // enforceSandboxResourcesPresence ensures the presence of a sandbox.
-func (r *Reconciler) enforceSandboxResourcesPresence(ctx context.Context, tenant *v1alpha2.Tenant) error {
+func (r *Reconciler) enforceSandboxResourcesPresence(ctx context.Context, tenant *clv1alpha2.Tenant) error {
 	sandboxnsName := forge.CanonicalSandboxName(tenant.Name)
 	log := ctrl.LoggerFrom(ctx, "environment", "sandbox")
 
@@ -119,7 +119,7 @@ func (r *Reconciler) enforceSandboxResourcesPresence(ctx context.Context, tenant
 }
 
 // enforceInstanceExpositionAbsence ensures the sandbox's absence.
-func (r *Reconciler) enforceSandboxResourcesAbsence(ctx context.Context, tenant *v1alpha2.Tenant) error {
+func (r *Reconciler) enforceSandboxResourcesAbsence(ctx context.Context, tenant *clv1alpha2.Tenant) error {
 	sandboxnsName := forge.CanonicalSandboxName(tenant.Name)
 
 	// Enforce namespace absence

--- a/operators/pkg/controller/tenant/sandbox_test.go
+++ b/operators/pkg/controller/tenant/sandbox_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +36,7 @@ var _ = Describe("Sandbox", func() {
 		})
 
 		It("Should create a sandbox namespace for the tenant", func() {
-			sbNs := v1.Namespace{}
+			sbNs := corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "sandbox-" + tnName}, &sbNs, BeTrue(), timeout, interval)
 		})
 
@@ -54,13 +54,13 @@ var _ = Describe("Sandbox", func() {
 		})
 
 		It("Should enforce resource quotas", func() {
-			quota := &v1.ResourceQuota{}
+			quota := &corev1.ResourceQuota{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "sandbox-resource-quota", Namespace: "sandbox-" + tnName}, quota, BeTrue(), timeout, interval)
 		})
 
 		It("Should enforce limit ranges", func() {
-			limitRange := &v1.LimitRange{}
+			limitRange := &corev1.LimitRange{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "sandbox-limit-range", Namespace: "sandbox-" + tnName}, limitRange, BeTrue(), timeout, interval)
 		})
@@ -69,7 +69,7 @@ var _ = Describe("Sandbox", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
-						if ns, ok := obj.(*v1.Namespace); ok && ns.Name == "sandbox-"+tnName {
+						if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "sandbox-"+tnName {
 							return fmt.Errorf("error creating sandbox namespace")
 						}
 						return nil
@@ -121,7 +121,7 @@ var _ = Describe("Sandbox", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
-						if quota, ok := obj.(*v1.ResourceQuota); ok && quota.Name == "sandbox-resource-quota" && quota.Namespace == "sandbox-"+tnName {
+						if quota, ok := obj.(*corev1.ResourceQuota); ok && quota.Name == "sandbox-resource-quota" && quota.Namespace == "sandbox-"+tnName {
 							return fmt.Errorf("error creating resource quota")
 						}
 						return nil
@@ -147,7 +147,7 @@ var _ = Describe("Sandbox", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
-						if lr, ok := obj.(*v1.LimitRange); ok && lr.Name == "sandbox-limit-range" && lr.Namespace == "sandbox-"+tnName {
+						if lr, ok := obj.(*corev1.LimitRange); ok && lr.Name == "sandbox-limit-range" && lr.Namespace == "sandbox-"+tnName {
 							return fmt.Errorf("error creating limit range")
 						}
 						return nil
@@ -170,7 +170,7 @@ var _ = Describe("Sandbox", func() {
 		})
 
 		Context("When the tenant is being deleted", func() {
-			sbNs := &v1.Namespace{
+			sbNs := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "sandbox-" + tnName,
 				},
@@ -188,7 +188,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should delete the sandbox namespace", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "sandbox-" + tnName}, ns, BeFalse(), timeout, interval)
 			})
 		})
@@ -196,12 +196,12 @@ var _ = Describe("Sandbox", func() {
 
 	Context("When the tenant sandbox is not required", func() {
 		It("Should not create a sandbox for the tenant", func() {
-			sbNs := v1.Namespace{}
+			sbNs := corev1.Namespace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "sandbox-" + tnName}, &sbNs, BeFalse(), timeout, interval)
 		})
 
 		Context("When the sandbox namespace exists", func() {
-			sbNs := &v1.Namespace{
+			sbNs := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "sandbox-" + tnName,
 				},
@@ -226,7 +226,7 @@ var _ = Describe("Sandbox", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
-						if ns, ok := obj.(*v1.Namespace); ok && ns.Name == "sandbox-"+tnName {
+						if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "sandbox-"+tnName {
 							return fmt.Errorf("error deleting sandbox namespace")
 						}
 						return nil

--- a/operators/pkg/controller/tenant/sandbox_test.go
+++ b/operators/pkg/controller/tenant/sandbox_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Sandbox", func() {
@@ -84,7 +84,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -110,7 +110,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -136,7 +136,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -162,7 +162,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())
@@ -241,7 +241,7 @@ var _ = Describe("Sandbox", func() {
 			})
 
 			It("Should set the tenant status to not ready", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Status.Ready).To(BeFalse())

--- a/operators/pkg/controller/tenant/suite_test.go
+++ b/operators/pkg/controller/tenant/suite_test.go
@@ -22,10 +22,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegaTypes "github.com/onsi/gomega/types"
-	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/operators/pkg/controller/tenant/suite_test.go
+++ b/operators/pkg/controller/tenant/suite_test.go
@@ -35,9 +35,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/tenant"
 )
@@ -59,7 +59,7 @@ var (
 	keycloakActor    *mock.MockKeycloakActorIface
 	tenantReconciler tenant.Reconciler
 
-	tnResource             *v1alpha2.Tenant
+	tnResource             *clv1alpha2.Tenant
 	tnReconcileErrExpected gomegaTypes.GomegaMatcher
 
 	objects []client.Object
@@ -73,8 +73,8 @@ func TestTenant(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(v1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 })
 
 var _ = BeforeEach(func() {
@@ -87,14 +87,14 @@ var _ = BeforeEach(func() {
 
 	keycloakActor.EXPECT().IsInitialized().Return(false).AnyTimes()
 
-	tnResource = &v1alpha2.Tenant{
+	tnResource = &clv1alpha2.Tenant{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: tnName,
 			Labels: map[string]string{
 				"crownlabs.polito.it/operator-selector": "test",
 			},
 		},
-		Spec: v1alpha2.TenantSpec{
+		Spec: clv1alpha2.TenantSpec{
 			FirstName: "Test",
 			LastName:  "Tenant",
 			Email:     "test@tenant.example",
@@ -118,7 +118,7 @@ var _ = JustBeforeEach(func() {
 		Client:                      cl,
 		Scheme:                      scheme.Scheme,
 		KeycloakActor:               keycloakActor,
-		TargetLabel:                 common.NewLabel("crownlabs.polito.it/operator-selector", "test"),
+		TargetLabel:                 ctrlcommon.NewLabel("crownlabs.polito.it/operator-selector", "test"),
 		TenantNSKeepAlive:           24 * time.Hour,
 		WaitUserVerification:        true,
 		SandboxClusterRole:          "test-sandbox-editor",
@@ -166,7 +166,7 @@ func removeObjFromObjectsList(obj client.Object) {
 }
 
 func tenantBeingDeleted() {
-	tnResource.Finalizers = append(tnResource.Finalizers, v1alpha2.TnOperatorFinalizerName)
+	tnResource.Finalizers = append(tnResource.Finalizers, clv1alpha2.TnOperatorFinalizerName)
 	tnResource.DeletionTimestamp = &metav1.Time{Time: time.Now().Add(10 * time.Second)}
 }
 

--- a/operators/pkg/controller/tenant/webhook/common.go
+++ b/operators/pkg/controller/tenant/webhook/common.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -37,8 +37,8 @@ func (twh *TenantWebhook) CheckWebhookOverride(req *admission.Request) bool {
 }
 
 // GetClusterTenant retrieves the tenant from the cluster given the name.
-func (twh *TenantWebhook) GetClusterTenant(ctx context.Context, name string) (tenant *v1alpha2.Tenant, err error) {
-	tenant = &v1alpha2.Tenant{}
+func (twh *TenantWebhook) GetClusterTenant(ctx context.Context, name string) (tenant *clv1alpha2.Tenant, err error) {
+	tenant = &clv1alpha2.Tenant{}
 	err = twh.Client.Get(ctx, types.NamespacedName{Name: name}, tenant)
 	return
 }

--- a/operators/pkg/controller/tenant/webhook/defaulter.go
+++ b/operators/pkg/controller/tenant/webhook/defaulter.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -37,7 +37,7 @@ type TenantDefaulter struct {
 	TenantWebhook
 
 	Decoder         admission.Decoder
-	OpSelectorLabel common.KVLabel
+	OpSelectorLabel ctrlcommon.KVLabel
 	BaseWorkspaces  []string
 }
 
@@ -54,9 +54,9 @@ func (tm *TenantDefaulter) Default(ctx context.Context, obj runtime.Object) erro
 
 	log.V(utils.LogDebugLevel).Info("processing mutation request", "groups", strings.Join(req.UserInfo.Groups, ","))
 
-	tenant, ok := obj.(*v1alpha2.Tenant)
+	tenant, ok := obj.(*clv1alpha2.Tenant)
 	if !ok {
-		err := errors.NewBadRequest("expected a Tenant object")
+		err := kerrors.NewBadRequest("expected a Tenant object")
 		log.Error(err, "object is not a Tenant")
 	}
 
@@ -74,11 +74,11 @@ func (tm *TenantDefaulter) Default(ctx context.Context, obj runtime.Object) erro
 }
 
 // DecodeTenant decodes the tenant from the incoming request.
-func (tm *TenantDefaulter) DecodeTenant(obj runtime.RawExtension) (tenant *v1alpha2.Tenant, err error) {
+func (tm *TenantDefaulter) DecodeTenant(obj runtime.RawExtension) (tenant *clv1alpha2.Tenant, err error) {
 	if tm.Decoder == nil {
-		return nil, errors.NewInternalError(fmt.Errorf("decoder is not set"))
+		return nil, kerrors.NewInternalError(fmt.Errorf("decoder is not set"))
 	}
-	tenant = &v1alpha2.Tenant{}
+	tenant = &clv1alpha2.Tenant{}
 	err = tm.Decoder.DecodeRaw(obj, tenant)
 	return
 }
@@ -94,7 +94,7 @@ func (tm *TenantDefaulter) EnforceTenantLabels(ctx context.Context, req *admissi
 	}
 
 	// enforce empty operator on svc tenant
-	if req.Name == v1alpha2.SVCTenantName {
+	if req.Name == clv1alpha2.SVCTenantName {
 		if !tm.OpSelectorLabel.IsIncluded(labels) {
 			labels[tm.OpSelectorLabel.GetKey()] = ""
 			log.Info("attempted adding operator selector labels to svc tenant")
@@ -144,7 +144,7 @@ func (tm *TenantDefaulter) EnforceTenantLabels(ctx context.Context, req *admissi
 }
 
 // EnforceTenantBaseWorkspaces ensure base workspaces are present in the given tenant.
-func (tm *TenantDefaulter) EnforceTenantBaseWorkspaces(ctx context.Context, tenant *v1alpha2.Tenant) {
+func (tm *TenantDefaulter) EnforceTenantBaseWorkspaces(ctx context.Context, tenant *clv1alpha2.Tenant) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("enforcing base workspaces")
 
@@ -157,9 +157,9 @@ func (tm *TenantDefaulter) EnforceTenantBaseWorkspaces(ctx context.Context, tena
 			}
 		}
 		if !found {
-			tenant.Spec.Workspaces = append(tenant.Spec.Workspaces, v1alpha2.TenantWorkspaceEntry{
+			tenant.Spec.Workspaces = append(tenant.Spec.Workspaces, clv1alpha2.TenantWorkspaceEntry{
 				Name: baseWs,
-				Role: v1alpha2.User,
+				Role: clv1alpha2.User,
 			})
 			log.Info("base workspace added", "workspace", baseWs)
 		}

--- a/operators/pkg/controller/tenant/webhook/defaulter_test.go
+++ b/operators/pkg/controller/tenant/webhook/defaulter_test.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/tenant/webhook"
 )
 
@@ -45,18 +45,18 @@ var _ = Describe("Defaulter webhook", func() {
 		baseWorkspaces = []string{}
 	)
 
-	opSelector := common.NewLabel("crownlabs.polito.it/op-sel", "test")
+	opSelector := ctrlcommon.NewLabel("crownlabs.polito.it/op-sel", "test")
 
 	forgeOpSelectorMap := func(opSel string) map[string]string {
 		return map[string]string{opSelector.GetKey(): opSel}
 	}
 
-	forgeTenantWithLabels := func(name string, labels map[string]string) *v1alpha2.Tenant {
-		return &v1alpha2.Tenant{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+	forgeTenantWithLabels := func(name string, labels map[string]string) *clv1alpha2.Tenant {
+		return &clv1alpha2.Tenant{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
 	}
 
-	forgeTenantWithWorkspaces := func(name string, workspaces []v1alpha2.TenantWorkspaceEntry) *v1alpha2.Tenant {
-		return &v1alpha2.Tenant{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: v1alpha2.TenantSpec{Workspaces: workspaces}}
+	forgeTenantWithWorkspaces := func(name string, workspaces []clv1alpha2.TenantWorkspaceEntry) *clv1alpha2.Tenant {
+		return &clv1alpha2.Tenant{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: clv1alpha2.TenantSpec{Workspaces: workspaces}}
 	}
 
 	JustBeforeEach(func() {
@@ -75,7 +75,7 @@ var _ = Describe("Defaulter webhook", func() {
 
 	Describe("The TenantMutator.Default method", func() {
 		var (
-			tenant *v1alpha2.Tenant
+			tenant *clv1alpha2.Tenant
 			obj    runtime.Object
 			ctx    context.Context
 		)
@@ -101,7 +101,7 @@ var _ = Describe("Defaulter webhook", func() {
 
 		Context("when creating the service tenant", func() {
 			BeforeEach(func() {
-				tenant = forgeTenantWithLabels(v1alpha2.SVCTenantName, map[string]string{opSelector.GetKey(): "should-be-removed"})
+				tenant = forgeTenantWithLabels(clv1alpha2.SVCTenantName, map[string]string{opSelector.GetKey(): "should-be-removed"})
 				obj = tenant
 				request = forgeRequest(admissionv1.Create, tenant, nil)
 				ctx = admission.NewContextWithRequest(ctx, request)
@@ -140,7 +140,7 @@ var _ = Describe("Defaulter webhook", func() {
 
 	Describe("The TenantMutator.EnforceTenantLabels method", func() {
 		type EnforceLabelsCase struct {
-			newTenant, oldTenant *v1alpha2.Tenant
+			newTenant, oldTenant *clv1alpha2.Tenant
 			operation            admissionv1.Operation
 			expectedLabels       map[string]string
 			expectedError        error
@@ -176,7 +176,7 @@ var _ = Describe("Defaulter webhook", func() {
 			When("operation is issued against the service tenant", func() {
 				WhenBody(EnforceLabelsCase{
 					operation:      admissionv1.Create,
-					newTenant:      forgeTenantWithLabels(v1alpha2.SVCTenantName, map[string]string{opSelector.GetKey(): "something-not-nil"}),
+					newTenant:      forgeTenantWithLabels(clv1alpha2.SVCTenantName, map[string]string{opSelector.GetKey(): "something-not-nil"}),
 					expectedLabels: map[string]string{opSelector.GetKey(): ""},
 				})
 			})
@@ -221,7 +221,7 @@ var _ = Describe("Defaulter webhook", func() {
 				var expectedErr error
 				WhenBody(EnforceLabelsCase{
 					operation:     admissionv1.Update,
-					newTenant:     &v1alpha2.Tenant{},
+					newTenant:     &clv1alpha2.Tenant{},
 					oldTenant:     nil,
 					expectedError: expectedErr,
 					beforeEach:    func(elc *EnforceLabelsCase) { _, elc.expectedError = mutatingWH.DecodeTenant(runtime.RawExtension{}) },
@@ -270,12 +270,12 @@ var _ = Describe("Defaulter webhook", func() {
 
 	Describe("The TenantMutator.EnforceTenantBaseWorkspaces method", func() {
 		type EnforceTenantBaseWorkspacesCase struct {
-			testTenant         *v1alpha2.Tenant
+			testTenant         *clv1alpha2.Tenant
 			testBaseWorkspaces []string
-			expectedWorkspaces []v1alpha2.TenantWorkspaceEntry
+			expectedWorkspaces []clv1alpha2.TenantWorkspaceEntry
 		}
 
-		exampleWs1 := v1alpha2.TenantWorkspaceEntry{Name: "workspace", Role: v1alpha2.Manager}
+		exampleWs1 := clv1alpha2.TenantWorkspaceEntry{Name: "workspace", Role: clv1alpha2.Manager}
 		testWsName := "utilities"
 
 		WhenBody := func(elc EnforceTenantBaseWorkspacesCase) {
@@ -292,38 +292,38 @@ var _ = Describe("Defaulter webhook", func() {
 
 		When("the tenant has no workspaces", func() {
 			WhenBody(EnforceTenantBaseWorkspacesCase{
-				testTenant:         forgeTenantWithWorkspaces(v1alpha2.SVCTenantName, nil),
+				testTenant:         forgeTenantWithWorkspaces(clv1alpha2.SVCTenantName, nil),
 				testBaseWorkspaces: []string{testWsName},
-				expectedWorkspaces: []v1alpha2.TenantWorkspaceEntry{{
+				expectedWorkspaces: []clv1alpha2.TenantWorkspaceEntry{{
 					Name: testWsName,
-					Role: v1alpha2.User,
+					Role: clv1alpha2.User,
 				}},
 			})
 		})
 
 		When("the tenant has some workspaces", func() {
 			WhenBody(EnforceTenantBaseWorkspacesCase{
-				testTenant:         forgeTenantWithWorkspaces(v1alpha2.SVCTenantName, []v1alpha2.TenantWorkspaceEntry{exampleWs1}),
+				testTenant:         forgeTenantWithWorkspaces(clv1alpha2.SVCTenantName, []clv1alpha2.TenantWorkspaceEntry{exampleWs1}),
 				testBaseWorkspaces: []string{testWsName},
-				expectedWorkspaces: []v1alpha2.TenantWorkspaceEntry{
+				expectedWorkspaces: []clv1alpha2.TenantWorkspaceEntry{
 					exampleWs1, {
 						Name: testWsName,
-						Role: v1alpha2.User,
+						Role: clv1alpha2.User,
 					}},
 			})
 		})
 
 		When("the tenant already has the base workspaces already set", func() {
 			WhenBody(EnforceTenantBaseWorkspacesCase{
-				testTenant: forgeTenantWithWorkspaces(v1alpha2.SVCTenantName, []v1alpha2.TenantWorkspaceEntry{exampleWs1, {
+				testTenant: forgeTenantWithWorkspaces(clv1alpha2.SVCTenantName, []clv1alpha2.TenantWorkspaceEntry{exampleWs1, {
 					Name: testWsName,
-					Role: v1alpha2.Manager,
+					Role: clv1alpha2.Manager,
 				}}),
 				testBaseWorkspaces: []string{testWsName},
-				expectedWorkspaces: []v1alpha2.TenantWorkspaceEntry{
+				expectedWorkspaces: []clv1alpha2.TenantWorkspaceEntry{
 					exampleWs1, {
 						Name: testWsName,
-						Role: v1alpha2.Manager,
+						Role: clv1alpha2.Manager,
 					}},
 			})
 		})

--- a/operators/pkg/controller/tenant/webhook/suite_test.go
+++ b/operators/pkg/controller/tenant/webhook/suite_test.go
@@ -24,13 +24,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var (
@@ -51,17 +51,17 @@ func TestTenantWebhook(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	scheme = runtime.NewScheme()
-	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
-	Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+	Expect(clv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(clv1alpha2.AddToScheme(scheme)).To(Succeed())
 })
 
-func serializeTenant(t *v1alpha2.Tenant) runtime.RawExtension {
+func serializeTenant(t *clv1alpha2.Tenant) runtime.RawExtension {
 	data, err := json.Marshal(t)
 	Expect(err).ToNot(HaveOccurred())
 	return runtime.RawExtension{Raw: data}
 }
 
-func forgeRequest(op admissionv1.Operation, newTenant, oldTenant *v1alpha2.Tenant) admission.Request {
+func forgeRequest(op admissionv1.Operation, newTenant, oldTenant *clv1alpha2.Tenant) admission.Request {
 	req := admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Operation: op}}
 	if newTenant != nil {
 		req.Object = serializeTenant(newTenant)
@@ -75,7 +75,7 @@ func forgeRequest(op admissionv1.Operation, newTenant, oldTenant *v1alpha2.Tenan
 
 func forgeResponse(warnings []string, err error) admission.Response {
 	if err != nil {
-		var apiStatus apierrors.APIStatus
+		var apiStatus kerrors.APIStatus
 		if errors.As(err, &apiStatus) {
 			sta := apiStatus.Status()
 			return admission.Response{

--- a/operators/pkg/controller/tenant/webhook/validator.go
+++ b/operators/pkg/controller/tenant/webhook/validator.go
@@ -22,15 +22,15 @@ import (
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -45,7 +45,7 @@ type TenantValidator struct {
 
 // ValidatePreflightResult is a struct that holds the result of the preflight validation.
 type ValidatePreflightResult struct {
-	newTenant, oldTenant *v1alpha2.Tenant
+	newTenant, oldTenant *clv1alpha2.Tenant
 	warnings             admission.Warnings
 	req                  admission.Request
 	newCtx               context.Context
@@ -60,8 +60,8 @@ func (tv *TenantValidator) ValidatePreflight(
 	op admissionv1.Operation,
 ) ValidatePreflightResult {
 	var ok bool
-	var oldTenant *v1alpha2.Tenant
-	newTenant, ok := newObj.(*v1alpha2.Tenant)
+	var oldTenant *clv1alpha2.Tenant
+	newTenant, ok := newObj.(*clv1alpha2.Tenant)
 	warnings := admission.Warnings{}
 
 	log := ctrl.LoggerFrom(ctx).WithValues("tenant", newTenant.Name, "operation", op)
@@ -81,9 +81,9 @@ func (tv *TenantValidator) ValidatePreflight(
 	}
 
 	if op != admissionv1.Update {
-		oldTenant = &v1alpha2.Tenant{}
+		oldTenant = &clv1alpha2.Tenant{}
 	} else {
-		oldTenant, ok = oldObj.(*v1alpha2.Tenant)
+		oldTenant, ok = oldObj.(*clv1alpha2.Tenant)
 		if !ok && op != admissionv1.Create {
 			return ValidatePreflightResult{
 				newTenant: nil,
@@ -215,7 +215,7 @@ func (tv *TenantValidator) ValidateDelete(
 	ctx context.Context,
 	obj runtime.Object,
 ) (admission.Warnings, error) {
-	tenant, ok := obj.(*v1alpha2.Tenant)
+	tenant, ok := obj.(*clv1alpha2.Tenant)
 	if !ok {
 		return nil, fmt.Errorf("expected a Tenant object, got %T", obj)
 	}
@@ -230,7 +230,7 @@ func (tv *TenantValidator) ValidateDelete(
 // - Other fields must be unchanged.
 func (tv *TenantValidator) HandleSelfEdit(
 	ctx context.Context,
-	newTenant, oldTenant *v1alpha2.Tenant,
+	newTenant, oldTenant *clv1alpha2.Tenant,
 ) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx)
 	newTenant.Spec.PublicKeys = nil
@@ -240,7 +240,7 @@ func (tv *TenantValidator) HandleSelfEdit(
 	if newTenant.Spec.LastLogin != nil {
 		lastLoginDelta := time.Until(newTenant.Spec.LastLogin.Time).Abs()
 		if lastLoginDelta > LastLoginToleration {
-			return nil, errors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not allowed to change the LastLogin field in the owned tenant, or the change is not valid: %s", lastLoginDelta))
+			return nil, kerrors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not allowed to change the LastLogin field in the owned tenant, or the change is not valid: %s", lastLoginDelta))
 		}
 	}
 
@@ -255,7 +255,7 @@ func (tv *TenantValidator) HandleSelfEdit(
 
 	if !reflect.DeepEqual(newTenant.Spec, oldTenant.Spec) {
 		log.Info("denied: unexpected tenant spec change")
-		return nil, errors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("unexpected tenant spec change, only lastLogintime and self-enrolling workspaces are allowed to change"))
+		return nil, kerrors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("unexpected tenant spec change, only lastLogintime and self-enrolling workspaces are allowed to change"))
 	}
 
 	newTenant.Spec.Workspaces = newWorkspaces
@@ -264,11 +264,11 @@ func (tv *TenantValidator) HandleSelfEdit(
 	res, err := tv.checkValidWorkspaces(ctx, newTenant, oldTenant)
 	if err != nil {
 		log.Error(err, "failed to check workspace changes")
-		return nil, errors.NewInternalError(fmt.Errorf("failed to check workspace changes: %w", err))
+		return nil, kerrors.NewInternalError(fmt.Errorf("failed to check workspace changes: %w", err))
 	}
 	if !res {
 		log.Info("denied: workspaces validation failed")
-		return nil, errors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not allowed to change your own workspaces"))
+		return nil, kerrors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not allowed to change your own workspaces"))
 	}
 
 	log.Info("allowed")
@@ -278,7 +278,7 @@ func (tv *TenantValidator) HandleSelfEdit(
 // checkValidWorkspaces checks that the user is not changing workspaces they are not allowed to change.
 func (tv *TenantValidator) checkValidWorkspaces(
 	ctx context.Context,
-	newTenant, oldTenant *v1alpha2.Tenant,
+	newTenant, oldTenant *clv1alpha2.Tenant,
 ) (bool, error) {
 	workspaceDiff := CalculateWorkspacesDiff(newTenant, oldTenant)
 	newWorkspacesMap := mapFromWorkspacesList(newTenant)
@@ -288,7 +288,7 @@ func (tv *TenantValidator) checkValidWorkspaces(
 			// it's always ok to keep the same role
 			continue
 		}
-		wsObj := v1alpha1.Workspace{}
+		wsObj := clv1alpha1.Workspace{}
 		err := tv.Client.Get(ctx, client.ObjectKey{Name: ws}, &wsObj)
 		if err != nil {
 			return false, fmt.Errorf("failed to fetch workspace %s: %w", ws, err)
@@ -301,11 +301,11 @@ func (tv *TenantValidator) checkValidWorkspaces(
 			// it's always possible to remove a Workspace from the Tenant if the target Workspace has autoenroll enabled
 			continue
 		}
-		if wsObj.Spec.AutoEnroll == v1alpha1.AutoenrollImmediate && newWorkspacesMap[ws] != v1alpha2.User {
+		if wsObj.Spec.AutoEnroll == clv1alpha1.AutoenrollImmediate && newWorkspacesMap[ws] != clv1alpha2.User {
 			// if AutoEnroll is Immediate, then the user has to enroll with User role
 			return false, nil
 		}
-		if wsObj.Spec.AutoEnroll == v1alpha1.AutoenrollWithApproval && newWorkspacesMap[ws] != v1alpha2.Candidate {
+		if wsObj.Spec.AutoEnroll == clv1alpha1.AutoenrollWithApproval && newWorkspacesMap[ws] != clv1alpha2.Candidate {
 			// if AutoEnroll is WithApproval, then the user has to enroll with Candidate role (to be approved by a Manager)
 			return false, nil
 		}
@@ -318,7 +318,7 @@ func (tv *TenantValidator) checkValidWorkspaces(
 func (tv *TenantValidator) HandleWorkspaceEdit(
 	ctx context.Context,
 	newTenant, oldTenant,
-	manager *v1alpha2.Tenant,
+	manager *clv1alpha2.Tenant,
 	operation admissionv1.Operation,
 ) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -327,9 +327,9 @@ func (tv *TenantValidator) HandleWorkspaceEdit(
 	managerWorkspaces := mapFromWorkspacesList(manager)
 
 	for ws, changed := range workspacesDiff {
-		if changed && managerWorkspaces[ws] != v1alpha2.Manager {
+		if changed && managerWorkspaces[ws] != clv1alpha2.Manager {
 			log.Info("denied: unexpected tenant spec change", "not-a-manager-for", ws)
-			return nil, errors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not a manager for workspace %s, so you cannot change it in the tenant", ws))
+			return nil, kerrors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("you are not a manager for workspace %s, so you cannot change it in the tenant", ws))
 		}
 	}
 
@@ -337,14 +337,14 @@ func (tv *TenantValidator) HandleWorkspaceEdit(
 	oldTenant.Spec.Workspaces = nil
 	if operation != admissionv1.Create && !reflect.DeepEqual(newTenant.Spec, oldTenant.Spec) {
 		log.Info("denied: unexpected tenant spec change")
-		return nil, errors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("only changes to workspaces are allowed in the tenant"))
+		return nil, kerrors.NewForbidden(schema.GroupResource{}, newTenant.Name, fmt.Errorf("only changes to workspaces are allowed in the tenant"))
 	}
 
 	log.Info("allowed")
 	return nil, nil
 }
 
-func calculateWorkspacesOneWayDiff(a, b *v1alpha2.Tenant, changes map[string]bool) map[string]bool {
+func calculateWorkspacesOneWayDiff(a, b *clv1alpha2.Tenant, changes map[string]bool) map[string]bool {
 	aAsMap := mapFromWorkspacesList(a)
 	for _, v := range b.Spec.Workspaces {
 		if aAsMap[v.Name] != v.Role {
@@ -355,14 +355,14 @@ func calculateWorkspacesOneWayDiff(a, b *v1alpha2.Tenant, changes map[string]boo
 }
 
 // CalculateWorkspacesDiff returns the list of workspaces that are different between two tenants.
-func CalculateWorkspacesDiff(a, b *v1alpha2.Tenant) map[string]bool {
+func CalculateWorkspacesDiff(a, b *clv1alpha2.Tenant) map[string]bool {
 	changes := calculateWorkspacesOneWayDiff(a, b, map[string]bool{})
 
 	return calculateWorkspacesOneWayDiff(b, a, changes)
 }
 
-func mapFromWorkspacesList(tenant *v1alpha2.Tenant) map[string]v1alpha2.WorkspaceUserRole {
-	wss := make(map[string]v1alpha2.WorkspaceUserRole, len(tenant.Spec.Workspaces))
+func mapFromWorkspacesList(tenant *clv1alpha2.Tenant) map[string]clv1alpha2.WorkspaceUserRole {
+	wss := make(map[string]clv1alpha2.WorkspaceUserRole, len(tenant.Spec.Workspaces))
 
 	for _, v := range tenant.Spec.Workspaces {
 		wss[v.Name] = v.Role
@@ -372,7 +372,7 @@ func mapFromWorkspacesList(tenant *v1alpha2.Tenant) map[string]v1alpha2.Workspac
 }
 
 // HandlePersonalWorkspaceModification checks if the personal workspace is being disabled while it has templates with active instances.
-func (tv *TenantValidator) HandlePersonalWorkspaceModification(ctx context.Context, newTenant, oldTenant *v1alpha2.Tenant) (admission.Warnings, error) {
+func (tv *TenantValidator) HandlePersonalWorkspaceModification(ctx context.Context, newTenant, oldTenant *clv1alpha2.Tenant) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx)
 	// if the personal workspace was disabled before then there is nothing to check
 	if oldTenant.Spec.PersonalWorkspace == nil {
@@ -380,15 +380,15 @@ func (tv *TenantValidator) HandlePersonalWorkspaceModification(ctx context.Conte
 	}
 	// personal workspace was enabled, and is being disabled
 	if newTenant.Spec.PersonalWorkspace == nil {
-		instances := &v1alpha2.InstanceList{}
+		instances := &clv1alpha2.InstanceList{}
 		if err := tv.Client.List(ctx, instances, client.InNamespace(oldTenant.Status.PersonalNamespace.Name)); err != nil {
 			log.Error(err, "failed to list instances in personal namespace")
-			return nil, errors.NewInternalError(err)
+			return nil, kerrors.NewInternalError(err)
 		}
 		for i := 0; i < len(instances.Items); i++ {
 			if instances.Items[i].Spec.Template.Namespace == oldTenant.Status.PersonalNamespace.Name {
 				log.Info("denied: cannot disable personal workspace, there are instances of personal workspace templates in the namespace")
-				return nil, errors.NewConflict(schema.GroupResource{}, oldTenant.Name, fmt.Errorf("cannot disable personal workspace, there are instances of personal workspace templates in the namespace"))
+				return nil, kerrors.NewConflict(schema.GroupResource{}, oldTenant.Name, fmt.Errorf("cannot disable personal workspace, there are instances of personal workspace templates in the namespace"))
 			}
 		}
 	}

--- a/operators/pkg/controller/tenant/webhook/validator_test.go
+++ b/operators/pkg/controller/tenant/webhook/validator_test.go
@@ -30,25 +30,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/tenant/webhook"
 )
 
 var _ = Describe("Validator webhook", func() {
-	forgeTenantWithWorkspace := func(ws v1alpha2.TenantWorkspaceEntry) *v1alpha2.Tenant {
-		return &v1alpha2.Tenant{
-			Spec: v1alpha2.TenantSpec{
-				Workspaces: []v1alpha2.TenantWorkspaceEntry{ws},
+	forgeTenantWithWorkspace := func(ws clv1alpha2.TenantWorkspaceEntry) *clv1alpha2.Tenant {
+		return &clv1alpha2.Tenant{
+			Spec: clv1alpha2.TenantSpec{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{ws},
 			},
 		}
 	}
 
-	forgeTenantWithWorkspaceUser := func(wsName string) *v1alpha2.Tenant {
-		return forgeTenantWithWorkspace(v1alpha2.TenantWorkspaceEntry{
+	forgeTenantWithWorkspaceUser := func(wsName string) *clv1alpha2.Tenant {
+		return forgeTenantWithWorkspace(clv1alpha2.TenantWorkspaceEntry{
 			Name: wsName,
-			Role: v1alpha2.User,
+			Role: clv1alpha2.User,
 		})
 	}
 
@@ -57,62 +57,62 @@ var _ = Describe("Validator webhook", func() {
 		tnWebhook   *admission.Webhook
 		request     admission.Request
 		response    admission.Response
-		manager     *v1alpha2.Tenant
-		fakeManager *v1alpha2.Tenant
+		manager     *clv1alpha2.Tenant
+		fakeManager *clv1alpha2.Tenant
 
-		workspaceWA     *v1alpha1.Workspace
+		workspaceWA     *clv1alpha1.Workspace
 		workspaceWAName = "test-workspace-withApproval"
-		workspaceNA     *v1alpha1.Workspace
+		workspaceNA     *clv1alpha1.Workspace
 		workspaceNAName = "test-workspace-noAutoenroll"
-		workspaceIM     *v1alpha1.Workspace
+		workspaceIM     *clv1alpha1.Workspace
 		workspaceIMName = "test-workspace-immediate"
 	)
 
 	BeforeEach(func() {
 
-		manager = &v1alpha2.Tenant{
+		manager = &clv1alpha2.Tenant{
 			ObjectMeta: metav1.ObjectMeta{Name: "some-manager"},
-			Spec: v1alpha2.TenantSpec{
-				Workspaces: []v1alpha2.TenantWorkspaceEntry{{
+			Spec: clv1alpha2.TenantSpec{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{{
 					Name: testWorkspace,
-					Role: v1alpha2.Manager,
+					Role: clv1alpha2.Manager,
 				}},
 			},
 		}
 
-		fakeManager = &v1alpha2.Tenant{
+		fakeManager = &clv1alpha2.Tenant{
 			ObjectMeta: metav1.ObjectMeta{Name: "some-fake-manager"},
 		}
 
-		workspaceWA = &v1alpha1.Workspace{
+		workspaceWA = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: workspaceWAName},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "test-workspace",
-				Quota: common.WorkspaceResourceQuota{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 1,
 				},
-				AutoEnroll: v1alpha1.AutoenrollWithApproval,
+				AutoEnroll: clv1alpha1.AutoenrollWithApproval,
 			},
 		}
 
-		workspaceNA = &v1alpha1.Workspace{
+		workspaceNA = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: workspaceNAName},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "test-workspace",
-				Quota: common.WorkspaceResourceQuota{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 1,
 				},
 			},
 		}
 
-		workspaceIM = &v1alpha1.Workspace{
+		workspaceIM = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{Name: workspaceIMName},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "test-workspace",
-				Quota: common.WorkspaceResourceQuota{
+				Quota: apicommon.WorkspaceResourceQuota{
 					Instances: 1,
 				},
-				AutoEnroll: v1alpha1.AutoenrollImmediate,
+				AutoEnroll: clv1alpha1.AutoenrollImmediate,
 			},
 		}
 
@@ -132,7 +132,7 @@ var _ = Describe("Validator webhook", func() {
 
 		tnWebhook = admission.WithCustomValidator(
 			scheme,
-			&v1alpha2.Tenant{},
+			&clv1alpha2.Tenant{},
 			tnValidator,
 		)
 	})
@@ -144,7 +144,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("the user is an admin/operator", func() {
 			BeforeEach(func() {
-				request = forgeRequest(admissionv1.Create, &v1alpha2.Tenant{}, nil)
+				request = forgeRequest(admissionv1.Create, &clv1alpha2.Tenant{}, nil)
 				request.UserInfo.Groups = bypassGroups
 			})
 			It("Should admit the request", func() {
@@ -165,7 +165,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("the old tenant is invalid", func() {
 			BeforeEach(func() {
-				request = forgeRequest(admissionv1.Update, &v1alpha2.Tenant{}, nil)
+				request = forgeRequest(admissionv1.Update, &clv1alpha2.Tenant{}, nil)
 			})
 			It("Should return an error response", func() {
 				Expect(response.Allowed).To(BeFalse())
@@ -176,7 +176,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("Tenant is being edited by a non-existent user", func() {
 			BeforeEach(func() {
-				request = forgeRequest(admissionv1.Update, &v1alpha2.Tenant{}, &v1alpha2.Tenant{})
+				request = forgeRequest(admissionv1.Update, &clv1alpha2.Tenant{}, &clv1alpha2.Tenant{})
 				request.UserInfo.Username = "invalid-manager"
 			})
 			It("Should return an error response", func() {
@@ -188,13 +188,13 @@ var _ = Describe("Validator webhook", func() {
 
 		When("Tenant is being edited by a non-manager user", func() {
 			BeforeEach(func() {
-				request = forgeRequest(admissionv1.Update, &v1alpha2.Tenant{
-					Spec: v1alpha2.TenantSpec{
-						Workspaces: []v1alpha2.TenantWorkspaceEntry{{
+				request = forgeRequest(admissionv1.Update, &clv1alpha2.Tenant{
+					Spec: clv1alpha2.TenantSpec{
+						Workspaces: []clv1alpha2.TenantWorkspaceEntry{{
 							Name: testWorkspace,
-							Role: v1alpha2.User,
+							Role: clv1alpha2.User,
 						}},
-					}}, &v1alpha2.Tenant{})
+					}}, &clv1alpha2.Tenant{})
 				request.UserInfo.Username = fakeManager.Name
 				request.UserInfo.Groups = []string{"other-group"}
 			})
@@ -208,15 +208,15 @@ var _ = Describe("Validator webhook", func() {
 	})
 
 	Describe("The TenantValidator.HandleSelfEdit method", func() {
-		var newTenant, oldTenant *v1alpha2.Tenant
+		var newTenant, oldTenant *clv1alpha2.Tenant
 		JustBeforeEach(func() {
 			response = forgeResponse(tnValidator.HandleSelfEdit(ctx, newTenant, oldTenant))
 		})
 
 		When("only public keys are changed", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{PublicKeys: []string{"some-key"}}}
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{PublicKeys: []string{"other-key"}}}
+				oldTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{PublicKeys: []string{"some-key"}}}
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{PublicKeys: []string{"other-key"}}}
 			})
 			It("should allow the change", func() {
 				Expect(response.Allowed).To(BeTrue())
@@ -225,7 +225,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("lastLogin is changed within the LastLoginToleration", func() {
 			BeforeEach(func() {
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{
 					LastLogin: &metav1.Time{
 						Time: time.Now().Add(webhook.LastLoginToleration / 2),
 					},
@@ -238,7 +238,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("lastLogin too far from now (abs(lastLogin-now)) > LastLoginToleration)", func() {
 			BeforeEach(func() {
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{
 					LastLogin: &metav1.Time{
 						Time: time.Now().Add(webhook.LastLoginToleration + time.Millisecond),
 					},
@@ -252,10 +252,10 @@ var _ = Describe("Validator webhook", func() {
 		})
 
 		Describe("a workspace is added", func() {
-			WhenBody := func(nt *v1alpha2.Tenant, shouldSucceed bool) func() {
+			WhenBody := func(nt *clv1alpha2.Tenant, shouldSucceed bool) func() {
 				return func() {
 					BeforeEach(func() {
-						oldTenant = &v1alpha2.Tenant{}
+						oldTenant = &clv1alpha2.Tenant{}
 						newTenant = nt
 					})
 
@@ -279,9 +279,9 @@ var _ = Describe("Validator webhook", func() {
 			))
 
 			When("no autoenroll and candidate role", WhenBody(
-				forgeTenantWithWorkspace(v1alpha2.TenantWorkspaceEntry{
+				forgeTenantWithWorkspace(clv1alpha2.TenantWorkspaceEntry{
 					Name: workspaceNAName,
-					Role: v1alpha2.Candidate,
+					Role: clv1alpha2.Candidate,
 				}),
 				false,
 			))
@@ -292,9 +292,9 @@ var _ = Describe("Validator webhook", func() {
 			))
 
 			When("autoenroll withApproval and candidate role", WhenBody(
-				forgeTenantWithWorkspace(v1alpha2.TenantWorkspaceEntry{
+				forgeTenantWithWorkspace(clv1alpha2.TenantWorkspaceEntry{
 					Name: workspaceWAName,
-					Role: v1alpha2.Candidate,
+					Role: clv1alpha2.Candidate,
 				}),
 				true,
 			))
@@ -305,9 +305,9 @@ var _ = Describe("Validator webhook", func() {
 			))
 
 			When("autoenroll immediate and candidate role", WhenBody(
-				forgeTenantWithWorkspace(v1alpha2.TenantWorkspaceEntry{
+				forgeTenantWithWorkspace(clv1alpha2.TenantWorkspaceEntry{
 					Name: workspaceIMName,
-					Role: v1alpha2.Candidate,
+					Role: clv1alpha2.Candidate,
 				}),
 				false,
 			))
@@ -315,8 +315,8 @@ var _ = Describe("Validator webhook", func() {
 
 		When("other fields are changed", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{LastName: "test"}}
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{Email: "other"}}
+				oldTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{LastName: "test"}}
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{Email: "other"}}
 			})
 			It("should deny the change", func() {
 				Expect(response.Allowed).To(BeFalse())
@@ -327,7 +327,7 @@ var _ = Describe("Validator webhook", func() {
 	})
 
 	Describe("The TenantValidator.HandleWorkspaceEdit", func() {
-		var newTenant, oldTenant *v1alpha2.Tenant
+		var newTenant, oldTenant *clv1alpha2.Tenant
 		var operation admissionv1.Operation
 		JustBeforeEach(func() {
 			response = forgeResponse(tnValidator.HandleWorkspaceEdit(ctx, newTenant, oldTenant, manager, operation))
@@ -335,7 +335,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("manager adds a workspace he manages", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{}
+				oldTenant = &clv1alpha2.Tenant{}
 				newTenant = forgeTenantWithWorkspaceUser(testWorkspace)
 				operation = admissionv1.Update
 			})
@@ -346,7 +346,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("manager removes a workspace he manages", func() {
 			BeforeEach(func() {
-				newTenant = &v1alpha2.Tenant{}
+				newTenant = &clv1alpha2.Tenant{}
 				oldTenant = forgeTenantWithWorkspaceUser(testWorkspace)
 				operation = admissionv1.Update
 			})
@@ -357,7 +357,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("manager adds a workspace he doesn't manage", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{}
+				oldTenant = &clv1alpha2.Tenant{}
 				newTenant = forgeTenantWithWorkspaceUser("invalid-workspace")
 				operation = admissionv1.Update
 			})
@@ -370,7 +370,7 @@ var _ = Describe("Validator webhook", func() {
 
 		When("manager remvoes a workspace he doesn't manage", func() {
 			BeforeEach(func() {
-				newTenant = &v1alpha2.Tenant{}
+				newTenant = &clv1alpha2.Tenant{}
 				oldTenant = forgeTenantWithWorkspaceUser("invalid-workspace")
 				operation = admissionv1.Update
 			})
@@ -383,8 +383,8 @@ var _ = Describe("Validator webhook", func() {
 
 		When("other fields are changed", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{LastName: "test"}}
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{Email: "other"}}
+				oldTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{LastName: "test"}}
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{Email: "other"}}
 				operation = admissionv1.Update
 			})
 			It("should deny the change", func() {
@@ -396,8 +396,8 @@ var _ = Describe("Validator webhook", func() {
 
 		When("a new user is created", func() {
 			BeforeEach(func() {
-				oldTenant = &v1alpha2.Tenant{}
-				newTenant = &v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{Email: "other"}}
+				oldTenant = &clv1alpha2.Tenant{}
+				newTenant = &clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{Email: "other"}}
 				operation = admissionv1.Create
 			})
 			It("should allow the change", func() {
@@ -408,15 +408,15 @@ var _ = Describe("Validator webhook", func() {
 
 	Describe("The CalculateWorkspacesDiff function", func() {
 		type CalcWsDiffCase struct {
-			a, b            []v1alpha2.TenantWorkspaceEntry
+			a, b            []clv1alpha2.TenantWorkspaceEntry
 			expectedChanges []string
 		}
 		WhenBody := func(cwdc CalcWsDiffCase) func() {
 			return func() {
 				var actuals []string
 				result := webhook.CalculateWorkspacesDiff(
-					&v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{Workspaces: cwdc.a}},
-					&v1alpha2.Tenant{Spec: v1alpha2.TenantSpec{Workspaces: cwdc.b}},
+					&clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{Workspaces: cwdc.a}},
+					&clv1alpha2.Tenant{Spec: clv1alpha2.TenantSpec{Workspaces: cwdc.b}},
 				)
 				for k, v := range result {
 					if v {
@@ -428,39 +428,39 @@ var _ = Describe("Validator webhook", func() {
 				})
 			}
 		}
-		makeWs := func(name string, role v1alpha2.WorkspaceUserRole) v1alpha2.TenantWorkspaceEntry {
-			return v1alpha2.TenantWorkspaceEntry{Name: name, Role: role}
+		makeWs := func(name string, role clv1alpha2.WorkspaceUserRole) clv1alpha2.TenantWorkspaceEntry {
+			return clv1alpha2.TenantWorkspaceEntry{Name: name, Role: role}
 		}
 
 		When("The two tenants have no different workspaces", WhenBody(CalcWsDiffCase{
-			a:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager)},
-			b:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager)},
+			a:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager)},
+			b:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager)},
 			expectedChanges: nil,
 		}))
 
 		When("The first tenant has one more workspace", WhenBody(CalcWsDiffCase{
-			a:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager)},
-			b:               []v1alpha2.TenantWorkspaceEntry{},
+			a:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager)},
+			b:               []clv1alpha2.TenantWorkspaceEntry{},
 			expectedChanges: []string{"test-a"},
 		}))
 
 		When("The second tenant has one more workspace", WhenBody(CalcWsDiffCase{
-			a:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager)},
-			b:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager), makeWs("test-b", v1alpha2.User)},
+			a:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager)},
+			b:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager), makeWs("test-b", clv1alpha2.User)},
 			expectedChanges: []string{"test-b"},
 		}))
 
 		When("There is a difference in roles", WhenBody(CalcWsDiffCase{
-			a:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.User)},
-			b:               []v1alpha2.TenantWorkspaceEntry{makeWs("test-a", v1alpha2.Manager)},
+			a:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.User)},
+			b:               []clv1alpha2.TenantWorkspaceEntry{makeWs("test-a", clv1alpha2.Manager)},
 			expectedChanges: []string{"test-a"},
 		}))
 
 	})
 	When("Modifying the createPersonalWorkspace spec", func() {
-		var oldTenant, newTenant *v1alpha2.Tenant
+		var oldTenant, newTenant *clv1alpha2.Tenant
 		BeforeEach(func() {
-			oldTenant = &v1alpha2.Tenant{}
+			oldTenant = &clv1alpha2.Tenant{}
 			newTenant = oldTenant.DeepCopy()
 		})
 		When("The user is in bypass group", func() {
@@ -471,7 +471,7 @@ var _ = Describe("Validator webhook", func() {
 			})
 			When("The personal workspace is being enabled", func() {
 				BeforeEach(func() {
-					newTenant.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+					newTenant.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 						Instances: 2,
 						CPU:       resource.MustParse("4"),
 						Memory:    resource.MustParse("8Gi"),
@@ -487,7 +487,7 @@ var _ = Describe("Validator webhook", func() {
 				})
 				When("It was enabled before", func() {
 					BeforeEach(func() {
-						oldTenant.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+						oldTenant.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 							Instances: 2,
 							CPU:       resource.MustParse("4"),
 							Memory:    resource.MustParse("8Gi"),
@@ -512,7 +512,7 @@ var _ = Describe("Validator webhook", func() {
 				})
 				When("It was enabled before", func() {
 					BeforeEach(func() {
-						oldTenant.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+						oldTenant.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 							Instances: 2,
 							CPU:       resource.MustParse("4"),
 							Memory:    resource.MustParse("8Gi"),
@@ -522,13 +522,13 @@ var _ = Describe("Validator webhook", func() {
 					})
 					When("The personal workspace has active instances", func() {
 						BeforeEach(func() {
-							instance := &v1alpha2.Instance{
+							instance := &clv1alpha2.Instance{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      "test-instance",
 									Namespace: testTenantPersonalNamespace,
 								},
-								Spec: v1alpha2.InstanceSpec{
-									Template: v1alpha2.GenericRef{
+								Spec: clv1alpha2.InstanceSpec{
+									Template: clv1alpha2.GenericRef{
 										Name:      "test-template",
 										Namespace: testTenantPersonalNamespace,
 									},
@@ -569,7 +569,7 @@ var _ = Describe("Validator webhook", func() {
 								workspaceIM,
 							).WithInterceptorFuncs(interceptor.Funcs{
 								List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-									if _, ok := list.(*v1alpha2.InstanceList); ok {
+									if _, ok := list.(*clv1alpha2.InstanceList); ok {
 										return fmt.Errorf("error listing templates")
 									}
 									return client.List(ctx, list, opts...)
@@ -594,7 +594,7 @@ var _ = Describe("Validator webhook", func() {
 			When("The personal workspace is being enabled", func() {
 				BeforeEach(func() {
 					oldTenant.Spec.PersonalWorkspace = nil
-					newTenant.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+					newTenant.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 						Instances: 2,
 						CPU:       resource.MustParse("4"),
 						Memory:    resource.MustParse("8Gi"),
@@ -608,7 +608,7 @@ var _ = Describe("Validator webhook", func() {
 			})
 			When("The personal workspace is being disabled", func() {
 				BeforeEach(func() {
-					oldTenant.Spec.PersonalWorkspace = &common.WorkspaceResourceQuota{
+					oldTenant.Spec.PersonalWorkspace = &apicommon.WorkspaceResourceQuota{
 						Instances: 2,
 						CPU:       resource.MustParse("4"),
 						Memory:    resource.MustParse("8Gi"),

--- a/operators/pkg/controller/tenant/workspace.go
+++ b/operators/pkg/controller/tenant/workspace.go
@@ -23,8 +23,8 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -33,7 +33,7 @@ import (
 func (r *Reconciler) syncWorkspaces(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 ) error {
 	// create fresh lists
 	tn.Status.FailingWorkspaces = []string{}
@@ -54,7 +54,7 @@ func (r *Reconciler) syncWorkspaces(
 	}
 
 	// update labels
-	if err := r.enforcePreservingStatus(ctx, log, tn, func(t *v1alpha2.Tenant) *v1alpha2.Tenant {
+	if err := r.enforcePreservingStatus(ctx, log, tn, func(t *clv1alpha2.Tenant) *clv1alpha2.Tenant {
 		t.Labels = labels
 		return t
 	}); err != nil {
@@ -70,12 +70,12 @@ func (r *Reconciler) syncWorkspaces(
 func (r *Reconciler) syncSingleWorkspace(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha2.Tenant,
+	tn *clv1alpha2.Tenant,
 	labels map[string]string,
-	tenantWorkspace *v1alpha2.TenantWorkspaceEntry,
+	tenantWorkspace *clv1alpha2.TenantWorkspaceEntry,
 ) int {
 	nonBaseWorkspaces := 0
-	workspace := &v1alpha1.Workspace{}
+	workspace := &clv1alpha1.Workspace{}
 
 	err := r.Get(ctx, types.NamespacedName{
 		Name: tenantWorkspace.Name,
@@ -86,7 +86,7 @@ func (r *Reconciler) syncSingleWorkspace(
 		log.Error(err, "Error when checking if workspace exists in tenant", "workspace", tenantWorkspace.Name, "tenant", tn.Name)
 		tn.Status.FailingWorkspaces = append(tn.Status.FailingWorkspaces, tenantWorkspace.Name)
 		tnOpinternalErrors.WithLabelValues("tenant", "workspace-not-exist").Inc()
-	case tenantWorkspace.Role == v1alpha2.Candidate && workspace.Spec.AutoEnroll != v1alpha1.AutoenrollWithApproval:
+	case tenantWorkspace.Role == clv1alpha2.Candidate && workspace.Spec.AutoEnroll != clv1alpha1.AutoenrollWithApproval:
 		// Candidate role is allowed only if the workspace has autoEnroll = WithApproval
 		log.Error(err, "Workspace has not autoEnroll with approval, Candidate role is not allowed in tenant", "workspace", tenantWorkspace.Name, "tenant", tn.Name)
 		tn.Status.FailingWorkspaces = append(tn.Status.FailingWorkspaces, tenantWorkspace.Name)
@@ -104,7 +104,7 @@ func deleteWorkspacesRelatedLabels(
 	labels map[string]string,
 ) {
 	for lab := range labels {
-		if strings.HasPrefix(lab, v1alpha2.WorkspaceLabelPrefix) {
+		if strings.HasPrefix(lab, clv1alpha2.WorkspaceLabelPrefix) {
 			delete(labels, lab)
 		}
 	}
@@ -114,9 +114,9 @@ func deleteWorkspacesRelatedLabels(
 func (r *Reconciler) addWorkspaceLabel(
 	labels map[string]string,
 	workspaceName string,
-	role v1alpha2.WorkspaceUserRole,
+	role clv1alpha2.WorkspaceUserRole,
 ) {
-	labels[v1alpha2.WorkspaceLabelPrefix+workspaceName] = string(role)
+	labels[clv1alpha2.WorkspaceLabelPrefix+workspaceName] = string(role)
 }
 
 // this functions only adds the label to the structure, it does not update the tenant.
@@ -133,12 +133,12 @@ func (r *Reconciler) removeNoWorkspaceLabel(
 }
 
 func (r *Reconciler) getEnrolledWorkspaces(
-	tn *v1alpha2.Tenant,
-) []v1alpha2.TenantWorkspaceEntry {
-	validWorkspaces := make([]v1alpha2.TenantWorkspaceEntry, 0, len(tn.Spec.Workspaces))
+	tn *clv1alpha2.Tenant,
+) []clv1alpha2.TenantWorkspaceEntry {
+	validWorkspaces := make([]clv1alpha2.TenantWorkspaceEntry, 0, len(tn.Spec.Workspaces))
 	for _, ws := range tn.Spec.Workspaces {
 		// skip workspaces in Candidate status
-		if ws.Role == v1alpha2.Candidate {
+		if ws.Role == clv1alpha2.Candidate {
 			continue
 		}
 
@@ -156,12 +156,12 @@ func (r *Reconciler) getEnrolledWorkspaces(
 func (r *Reconciler) getWorkspacesList(
 	ctx context.Context,
 	log logr.Logger,
-	tnWss []v1alpha2.TenantWorkspaceEntry,
-) ([]v1alpha1.Workspace, error) {
-	workspaces := make([]v1alpha1.Workspace, 0, len(tnWss))
+	tnWss []clv1alpha2.TenantWorkspaceEntry,
+) ([]clv1alpha1.Workspace, error) {
+	workspaces := make([]clv1alpha1.Workspace, 0, len(tnWss))
 
 	for _, ws := range tnWss {
-		workspace := v1alpha1.Workspace{}
+		workspace := clv1alpha1.Workspace{}
 		err := r.Get(ctx, types.NamespacedName{
 			Name: ws.Name,
 		}, &workspace)

--- a/operators/pkg/controller/tenant/workspace_test.go
+++ b/operators/pkg/controller/tenant/workspace_test.go
@@ -20,25 +20,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("Workspace management", func() {
-	ws1 := &v1alpha1.Workspace{
+	ws1 := &clv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ws1",
 		},
-		Spec: v1alpha1.WorkspaceSpec{
-			AutoEnroll: v1alpha1.AutoenrollWithApproval,
+		Spec: clv1alpha1.WorkspaceSpec{
+			AutoEnroll: clv1alpha1.AutoenrollWithApproval,
 		},
 	}
-	ws2 := &v1alpha1.Workspace{
+	ws2 := &clv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ws2",
 		},
 	}
-	bws1 := &v1alpha1.Workspace{
+	bws1 := &clv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "base-ws1",
 		},
@@ -59,14 +59,14 @@ var _ = Describe("Workspace management", func() {
 	Context("When a workspace is present and valid", func() {
 		Context("and the role is manager", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 					Name: "ws1",
-					Role: v1alpha2.Manager,
+					Role: clv1alpha2.Manager,
 				}}
 			})
 
 			It("Should add the workspace label to the tenant", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/workspace-ws1", "manager"))
@@ -75,14 +75,14 @@ var _ = Describe("Workspace management", func() {
 
 		Context("and the role is user", func() {
 			BeforeEach(func() {
-				tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+				tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 					Name: "ws1",
-					Role: v1alpha2.User,
+					Role: clv1alpha2.User,
 				}}
 			})
 
 			It("Should add the workspace label to the tenant", func() {
-				tn := &v1alpha2.Tenant{}
+				tn := &clv1alpha2.Tenant{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 				Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/workspace-ws1", "user"))
@@ -92,14 +92,14 @@ var _ = Describe("Workspace management", func() {
 		Context("and the role is candidate", func() {
 			Context("and the workspace is auto-enrollable", func() {
 				BeforeEach(func() {
-					tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+					tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 						Name: "ws1",
-						Role: v1alpha2.Candidate,
+						Role: clv1alpha2.Candidate,
 					}}
 				})
 
 				It("Should add the workspace label to the tenant", func() {
-					tn := &v1alpha2.Tenant{}
+					tn := &clv1alpha2.Tenant{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 					Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/workspace-ws1", "candidate"))
@@ -108,21 +108,21 @@ var _ = Describe("Workspace management", func() {
 
 			Context("and the workspace is not auto-enrollable", func() {
 				BeforeEach(func() {
-					tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+					tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 						Name: "ws2",
-						Role: v1alpha2.Candidate,
+						Role: clv1alpha2.Candidate,
 					}}
 				})
 
 				It("Should not add the workspace label to the tenant", func() {
-					tn := &v1alpha2.Tenant{}
+					tn := &clv1alpha2.Tenant{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 					Expect(tn.Labels).NotTo(HaveKey("crownlabs.polito.it/workspace-ws2"))
 				})
 
 				It("Should add the workspace to the failing workspaces list", func() {
-					tn := &v1alpha2.Tenant{}
+					tn := &clv1alpha2.Tenant{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 					Expect(tn.Status.FailingWorkspaces).To(ContainElement("ws2"))
@@ -133,21 +133,21 @@ var _ = Describe("Workspace management", func() {
 
 	Context("When a workspace is present but not valid", func() {
 		BeforeEach(func() {
-			tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+			tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 				Name: "ws3", // ws3 does not exist
-				Role: v1alpha2.Manager,
+				Role: clv1alpha2.Manager,
 			}}
 		})
 
 		It("Should not add the workspace label to the tenant", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Labels).NotTo(HaveKey("crownlabs.polito.it/workspace-ws3"))
 		})
 
 		It("Should add the workspace to the failing workspaces list", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Status.FailingWorkspaces).To(ContainElement("ws3"))
@@ -157,11 +157,11 @@ var _ = Describe("Workspace management", func() {
 	Context("When a workspace is not present but the related label exists", func() {
 		BeforeEach(func() {
 			tnResource.Labels["crownlabs.polito.it/workspace-ws1"] = "manager"
-			tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{}
+			tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{}
 		})
 
 		It("Should remove the workspace label from the tenant", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Labels).NotTo(HaveKey("crownlabs.polito.it/workspace-ws1"))
@@ -170,7 +170,7 @@ var _ = Describe("Workspace management", func() {
 
 	Context("When no workspaces are present", func() {
 		It("Should add the no-workspaces label to the tenant", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/no-workspaces", "true"))
@@ -179,21 +179,21 @@ var _ = Describe("Workspace management", func() {
 
 	Context("When only default workspaces are present", func() {
 		BeforeEach(func() {
-			tnResource.Spec.Workspaces = []v1alpha2.TenantWorkspaceEntry{{
+			tnResource.Spec.Workspaces = []clv1alpha2.TenantWorkspaceEntry{{
 				Name: "base-ws1",
-				Role: v1alpha2.Manager,
+				Role: clv1alpha2.Manager,
 			}}
 		})
 
 		It("Should add the related label to the tenant", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/workspace-base-ws1", "manager"))
 		})
 
 		It("Should add the no-workspaces label to the tenant", func() {
-			tn := &v1alpha2.Tenant{}
+			tn := &clv1alpha2.Tenant{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tnName}, tn, BeTrue(), timeout, interval)
 
 			Expect(tn.Labels).To(HaveKeyWithValue("crownlabs.polito.it/no-workspaces", "true"))

--- a/operators/pkg/controller/workspace/authorization.go
+++ b/operators/pkg/controller/workspace/authorization.go
@@ -22,18 +22,18 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 func (r *Reconciler) createKeycloakRoles(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	log logr.Logger,
 ) error {
 	if !r.KeycloakActor.IsInitialized() {
-		ws.Status.Subscriptions["keycloak"] = v1alpha2.SubscrFailed
+		ws.Status.Subscriptions["keycloak"] = clv1alpha2.SubscrFailed
 		log.Info("Keycloak actor is not initialized, skipping role creation for workspace", "workspace", ws.Name)
 		return nil
 	}
@@ -42,7 +42,7 @@ func (r *Reconciler) createKeycloakRoles(
 	managerRoleName := forge.GetWorkspaceManagerRoleName(ws)
 	managerRoleDesc := forge.GetWorkspaceManagerRoleDescription(ws)
 	if err := r.createKeycloakRole(ctx, ws, managerRoleName, managerRoleDesc, log); err != nil {
-		ws.Status.Subscriptions["keycloak"] = v1alpha2.SubscrFailed
+		ws.Status.Subscriptions["keycloak"] = clv1alpha2.SubscrFailed
 		log.Error(err, "Error when creating Keycloak manager role", "role", managerRoleName, "workspace", ws.Name)
 		return err
 	}
@@ -51,19 +51,19 @@ func (r *Reconciler) createKeycloakRoles(
 	userRoleName := forge.GetWorkspaceUserRoleName(ws)
 	userRoleDesc := forge.GetWorkspaceUserRoleDescription(ws)
 	if err := r.createKeycloakRole(ctx, ws, userRoleName, userRoleDesc, log); err != nil {
-		ws.Status.Subscriptions["keycloak"] = v1alpha2.SubscrFailed
+		ws.Status.Subscriptions["keycloak"] = clv1alpha2.SubscrFailed
 		log.Error(err, "Error when creating Keycloak user role", "role", userRoleName, "workspace", ws.Name)
 		return err
 	}
 
-	ws.Status.Subscriptions["keycloak"] = v1alpha2.SubscrOk
+	ws.Status.Subscriptions["keycloak"] = clv1alpha2.SubscrOk
 
 	return nil
 }
 
 func (r *Reconciler) createKeycloakRole(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	roleName string,
 	roleDescription string,
 	log logr.Logger,
@@ -92,7 +92,7 @@ func (r *Reconciler) createKeycloakRole(
 
 func (r *Reconciler) deleteKeycloakRoles(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	log logr.Logger,
 ) error {
 	if !r.KeycloakActor.IsInitialized() {
@@ -119,7 +119,7 @@ func (r *Reconciler) deleteKeycloakRoles(
 
 func (r *Reconciler) deleteKeycloakRole(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	roleName string,
 	log logr.Logger,
 ) error {

--- a/operators/pkg/controller/workspace/authorization_test.go
+++ b/operators/pkg/controller/workspace/authorization_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
+	gocloak13 "github.com/Nerzal/gocloak/v13"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -26,8 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 )
 
@@ -54,16 +54,16 @@ var _ = Describe("Authorization", func() {
 			})
 
 			It("Should set the Keycloak subscription to ok", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
-				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(v1alpha2.SubscrOk))
+				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(clv1alpha2.SubscrOk))
 			})
 		})
 
 		Context("When Keycloak roles are already present", func() {
 			BeforeEach(func() {
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":manager").Return(&gocloak.Role{Name: gocloak.StringP("workspace-" + wsName + ":manager")}, nil).Times(1)
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak.Role{Name: gocloak.StringP("workspace-" + wsName + ":user")}, nil).Times(1)
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":manager").Return(&gocloak13.Role{Name: gocloak13.StringP("workspace-" + wsName + ":manager")}, nil).Times(1)
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak13.Role{Name: gocloak13.StringP("workspace-" + wsName + ":user")}, nil).Times(1)
 				keycloakActor.EXPECT().CreateRole(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			})
 
@@ -72,17 +72,17 @@ var _ = Describe("Authorization", func() {
 			})
 
 			It("Should set the Keycloak subscription to ok", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
-				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(v1alpha2.SubscrOk))
+				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(clv1alpha2.SubscrOk))
 			})
 		})
 
 		Context("When the Workspace is being deleted", func() {
 			BeforeEach(func() {
 				workspaceBeingDeleted()
-				wsResource.Status.Subscriptions = map[string]v1alpha2.SubscriptionStatus{
-					"keycloak": v1alpha2.SubscrOk,
+				wsResource.Status.Subscriptions = map[string]clv1alpha2.SubscriptionStatus{
+					"keycloak": clv1alpha2.SubscrOk,
 				}
 				keycloakActor.EXPECT().DeleteRole(gomock.Any(), "workspace-"+wsName+":manager").Return(nil).Times(1)
 				keycloakActor.EXPECT().DeleteRole(gomock.Any(), "workspace-"+wsName+":user").Return(nil).Times(1)
@@ -96,40 +96,40 @@ var _ = Describe("Authorization", func() {
 		Context("When an error occurs in the getRole call", func() {
 			BeforeEach(func() {
 				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":manager").Return(nil, fmt.Errorf("error getting role")).Times(1)
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak.Role{Name: gocloak.StringP("workspace-" + wsName + ":user")}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak13.Role{Name: gocloak13.StringP("workspace-" + wsName + ":user")}, nil).AnyTimes()
 			})
 
 			It("Should set the Keycloak subscription as failed", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
-				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(v1alpha2.SubscrFailed))
+				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(clv1alpha2.SubscrFailed))
 			})
 		})
 
 		Context("When an error occurs in the createRole call", func() {
 			BeforeEach(func() {
 				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":manager").Return(nil, nil).AnyTimes()
-				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak.Role{Name: gocloak.StringP("workspace-" + wsName + ":user")}, nil).AnyTimes()
+				keycloakActor.EXPECT().GetRole(gomock.Any(), "workspace-"+wsName+":user").Return(&gocloak13.Role{Name: gocloak13.StringP("workspace-" + wsName + ":user")}, nil).AnyTimes()
 				keycloakActor.EXPECT().CreateRole(gomock.Any(), "workspace-"+wsName+":manager", wsPrettyName+" Manager Role").Return("", fmt.Errorf("error creating role")).Times(1)
 			})
 
 			It("Should set the Keycloak subscription as failed", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
-				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(v1alpha2.SubscrFailed))
+				Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(clv1alpha2.SubscrFailed))
 			})
 		})
 
 		Context("When an error occurs in the deleteRole call", func() {
 			BeforeEach(func() {
-				wsResource.Finalizers = append(wsResource.Finalizers, v1alpha2.TnOperatorFinalizerName)
+				wsResource.Finalizers = append(wsResource.Finalizers, clv1alpha2.TnOperatorFinalizerName)
 				wsResource.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-				wsResource.Status.Namespace = v1alpha2.NameCreated{
+				wsResource.Status.Namespace = clv1alpha2.NameCreated{
 					Created: true,
 					Name:    "workspace-" + wsName,
 				}
-				wsResource.Status.Subscriptions = map[string]v1alpha2.SubscriptionStatus{
-					"keycloak": v1alpha2.SubscrOk,
+				wsResource.Status.Subscriptions = map[string]clv1alpha2.SubscriptionStatus{
+					"keycloak": clv1alpha2.SubscrOk,
 				}
 				keycloakActor.EXPECT().DeleteRole(gomock.Any(), "workspace-"+wsName+":user").Return(fmt.Errorf("error deleting role")).AnyTimes()
 				keycloakActor.EXPECT().DeleteRole(gomock.Any(), "workspace-"+wsName+":manager").Return(fmt.Errorf("error deleting role")).AnyTimes()
@@ -148,9 +148,9 @@ var _ = Describe("Authorization", func() {
 		})
 
 		It("Should set the Keycloak subscription to failed", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
-			Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(v1alpha2.SubscrFailed))
+			Expect(ws.Status.Subscriptions["keycloak"]).To(Equal(clv1alpha2.SubscrFailed))
 		})
 
 		It("Should not create Keycloak roles", func() {
@@ -167,9 +167,9 @@ var _ = Describe("Authorization", func() {
 
 		Context("When the Workspace is being deleted", func() {
 			BeforeEach(func() {
-				wsResource.Finalizers = append(wsResource.Finalizers, v1alpha2.TnOperatorFinalizerName)
+				wsResource.Finalizers = append(wsResource.Finalizers, clv1alpha2.TnOperatorFinalizerName)
 				wsResource.DeletionTimestamp = &metav1.Time{Time: time.Now()}
-				wsResource.Status.Namespace = v1alpha2.NameCreated{
+				wsResource.Status.Namespace = clv1alpha2.NameCreated{
 					Created: true,
 					Name:    "workspace-" + wsName,
 				}

--- a/operators/pkg/controller/workspace/authorization_test.go
+++ b/operators/pkg/controller/workspace/authorization_test.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	gocloak13 "github.com/Nerzal/gocloak/v13"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/operators/pkg/controller/workspace/autoenrollment.go
+++ b/operators/pkg/controller/workspace/autoenrollment.go
@@ -22,14 +22,14 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) enforceAutoEnrollment(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	log logr.Logger,
 ) error {
 	// check label and update if needed
@@ -40,9 +40,9 @@ func (r *Reconciler) enforceAutoEnrollment(
 		wantedLabel = "disabled"
 	}
 
-	if ws.Labels[v1alpha2.WorkspaceLabelAutoenroll] != wantedLabel {
-		if err := r.enforcePreservingStatus(ctx, log, ws, func(workspace *v1alpha1.Workspace) *v1alpha1.Workspace {
-			workspace.Labels[v1alpha2.WorkspaceLabelAutoenroll] = wantedLabel
+	if ws.Labels[clv1alpha2.WorkspaceLabelAutoenroll] != wantedLabel {
+		if err := r.enforcePreservingStatus(ctx, log, ws, func(workspace *clv1alpha1.Workspace) *clv1alpha1.Workspace {
+			workspace.Labels[clv1alpha2.WorkspaceLabelAutoenroll] = wantedLabel
 			return workspace
 		}); err != nil {
 			log.Error(err, "Error when updating workspace", "workspace", ws.Name)
@@ -52,7 +52,7 @@ func (r *Reconciler) enforceAutoEnrollment(
 
 	// if actual AutoEnroll is WithApproval, nothing left to do
 	// else, need to update Tenants in candidate status
-	if ws.Spec.AutoEnroll != v1alpha1.AutoenrollWithApproval {
+	if ws.Spec.AutoEnroll != clv1alpha1.AutoenrollWithApproval {
 		if err := r.autoEnrollUpdateTenants(ctx, ws, log); err != nil {
 			log.Error(err, "Error when updating tenants subscribed to workspace", "workspace", ws.Name)
 			return err
@@ -66,13 +66,13 @@ func (r *Reconciler) enforceAutoEnrollment(
 // this function shall be called only when AutoEnrollment is enabled and not WithApproval.
 func (r *Reconciler) autoEnrollUpdateTenants(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	log logr.Logger,
 ) error {
-	var tenantsToUpdate v1alpha2.TenantList
-	targetLabel := fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, ws.Name)
+	var tenantsToUpdate clv1alpha2.TenantList
+	targetLabel := fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, ws.Name)
 
-	err := r.List(ctx, &tenantsToUpdate, &client.MatchingLabels{targetLabel: string(v1alpha2.Candidate)})
+	err := r.List(ctx, &tenantsToUpdate, &client.MatchingLabels{targetLabel: string(clv1alpha2.Candidate)})
 	if err != nil {
 		log.Error(err, "Error when listing tenants subscribed to workspace", "workspace", ws.Name)
 		return err
@@ -91,19 +91,19 @@ func (r *Reconciler) autoEnrollUpdateTenants(
 
 func (r *Reconciler) autoEnrollUpdateSingleTenant(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
-	tenant *v1alpha2.Tenant,
+	ws *clv1alpha1.Workspace,
+	tenant *clv1alpha2.Tenant,
 	log logr.Logger,
 ) error {
 	patch := client.MergeFrom(tenant.DeepCopy())
 	removeWorkspaceFromTenant(&tenant.Spec.Workspaces, ws.Name)
 	// if AutoEnrollment is Immediate, add the workspace with User role
-	if ws.Spec.AutoEnroll == v1alpha1.AutoenrollImmediate {
+	if ws.Spec.AutoEnroll == clv1alpha1.AutoenrollImmediate {
 		tenant.Spec.Workspaces = append(
 			tenant.Spec.Workspaces,
-			v1alpha2.TenantWorkspaceEntry{
+			clv1alpha2.TenantWorkspaceEntry{
 				Name: ws.Name,
-				Role: v1alpha2.User,
+				Role: clv1alpha2.User,
 			},
 		)
 	}

--- a/operators/pkg/controller/workspace/autoenrollment_test.go
+++ b/operators/pkg/controller/workspace/autoenrollment_test.go
@@ -23,8 +23,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("AutoEnrollment", func() {
@@ -38,7 +38,7 @@ var _ = Describe("AutoEnrollment", func() {
 
 	Context("When no autoenrollment is configured", func() {
 		It("Should set the autoenroll label to 'disabled'", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -46,7 +46,7 @@ var _ = Describe("AutoEnrollment", func() {
 		})
 
 		It("Should update the Tenant spec to remove the workspace", func() {
-			tenant := &v1alpha2.Tenant{}
+			tenant := &clv1alpha2.Tenant{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tenantResources[0].Name}, tenant, BeTrue(), timeout, interval)
 
@@ -56,11 +56,11 @@ var _ = Describe("AutoEnrollment", func() {
 
 	Context("When autoenrollment is Immediate", func() {
 		BeforeEach(func() {
-			wsResource.Spec.AutoEnroll = v1alpha1.AutoenrollImmediate
+			wsResource.Spec.AutoEnroll = clv1alpha1.AutoenrollImmediate
 		})
 
 		It("Should set the autoenroll label to 'immediate'", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -68,24 +68,24 @@ var _ = Describe("AutoEnrollment", func() {
 		})
 
 		It("Should update the Tenant spec to set the workspace with User role", func() {
-			tenant := &v1alpha2.Tenant{}
+			tenant := &clv1alpha2.Tenant{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tenantResources[0].Name}, tenant, BeTrue(), timeout, interval)
 
-			Expect(tenant.Spec.Workspaces).To(ContainElement(v1alpha2.TenantWorkspaceEntry{
+			Expect(tenant.Spec.Workspaces).To(ContainElement(clv1alpha2.TenantWorkspaceEntry{
 				Name: wsName,
-				Role: v1alpha2.User,
+				Role: clv1alpha2.User,
 			}))
 		})
 	})
 
 	Context("When autoenrollment is WithApproval", func() {
 		BeforeEach(func() {
-			wsResource.Spec.AutoEnroll = v1alpha1.AutoenrollWithApproval
+			wsResource.Spec.AutoEnroll = clv1alpha1.AutoenrollWithApproval
 		})
 
 		It("Should set the autoenroll label to 'with-approval'", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -97,7 +97,7 @@ var _ = Describe("AutoEnrollment", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					if ws, ok := obj.(*v1alpha1.Workspace); ok && ws.Name == wsName && ws.Labels["crownlabs.polito.it/autoenroll"] == "disabled" {
+					if ws, ok := obj.(*clv1alpha1.Workspace); ok && ws.Name == wsName && ws.Labels["crownlabs.polito.it/autoenroll"] == "disabled" {
 						return fmt.Errorf("error updating workspace label")
 					}
 					return nil
@@ -116,14 +116,14 @@ var _ = Describe("AutoEnrollment", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
-					if _, ok := list.(*v1alpha2.TenantList); ok {
+					if _, ok := list.(*clv1alpha2.TenantList); ok {
 						return fmt.Errorf("error listing tenants")
 					}
 					return nil
 				},
 			})
 
-			wsResource.Spec.AutoEnroll = v1alpha1.AutoenrollImmediate // Ensure autoenrollment is set to Immediate for the test
+			wsResource.Spec.AutoEnroll = clv1alpha1.AutoenrollImmediate // Ensure autoenrollment is set to Immediate for the test
 
 			wsReconcileErrExpected = HaveOccurred()
 		})
@@ -137,14 +137,14 @@ var _ = Describe("AutoEnrollment", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					if tenant, ok := obj.(*v1alpha2.Tenant); ok && tenant.Name == tenantResources[0].Name {
+					if tenant, ok := obj.(*clv1alpha2.Tenant); ok && tenant.Name == tenantResources[0].Name {
 						return fmt.Errorf("error updating tenant spec")
 					}
 					return nil
 				},
 			})
 
-			wsResource.Spec.AutoEnroll = v1alpha1.AutoenrollImmediate // Ensure autoenrollment is set to Immediate for the test
+			wsResource.Spec.AutoEnroll = clv1alpha1.AutoenrollImmediate // Ensure autoenrollment is set to Immediate for the test
 
 			wsReconcileErrExpected = HaveOccurred()
 		})
@@ -154,7 +154,7 @@ var _ = Describe("AutoEnrollment", func() {
 		})
 
 		It("Should set the workspace status to not ready", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 

--- a/operators/pkg/controller/workspace/clusterrolebinding.go
+++ b/operators/pkg/controller/workspace/clusterrolebinding.go
@@ -21,9 +21,9 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -31,7 +31,7 @@ import (
 // enforceClusterRoleBindings ensures that all necessary ClusterRoleBindings exist for the workspace.
 func (r *Reconciler) enforceClusterRoleBindings(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Create or update the ClusterRoleBinding for managing instances
 	if err := r.enforceInstancesManagerBinding(ctx, ws); err != nil {
@@ -49,7 +49,7 @@ func (r *Reconciler) enforceClusterRoleBindings(
 // enforceInstancesManagerBinding ensures that the ClusterRoleBinding for managing instances exists.
 func (r *Reconciler) enforceInstancesManagerBinding(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Create only the skeleton of the ClusterRoleBinding with immutable information
 	name := forge.GetWorkspaceInstancesManagerBindingName(ws)
@@ -60,14 +60,14 @@ func (r *Reconciler) enforceInstancesManagerBinding(
 	}
 
 	// Update or create the resource, setting all mutable values in the callback
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
 		// Update labels
 		crb.Labels = forge.UpdateWorkspaceResourceCommonLabels(crb.Labels, r.TargetLabel)
 
 		// Configure subjects and roleRef
 		forge.ConfigureWorkspaceInstancesManagerBinding(ws, crb)
 
-		return controllerutil.SetControllerReference(ws, crb, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, crb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating instances ClusterRoleBinding for workspace %s: %w",
 			ws.Name, err)
@@ -79,7 +79,7 @@ func (r *Reconciler) enforceInstancesManagerBinding(
 // enforceTenantsManagerBinding ensures that the ClusterRoleBinding for managing tenants exists.
 func (r *Reconciler) enforceTenantsManagerBinding(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Create only the skeleton of the ClusterRoleBinding with immutable information
 	name := forge.GetWorkspaceTenantsManagerBindingName(ws)
@@ -90,14 +90,14 @@ func (r *Reconciler) enforceTenantsManagerBinding(
 	}
 
 	// Update or create the resource, setting all mutable values in the callback
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, crb, func() error {
 		// Update labels
 		crb.Labels = forge.UpdateWorkspaceResourceCommonLabels(crb.Labels, r.TargetLabel)
 
 		// Configure subjects and roleRef
 		forge.ConfigureWorkspaceTenantsManagerBinding(ws, crb)
 
-		return controllerutil.SetControllerReference(ws, crb, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, crb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating tenants ClusterRoleBinding for workspace %s: %w",
 			ws.Name, err)
@@ -109,7 +109,7 @@ func (r *Reconciler) enforceTenantsManagerBinding(
 // deleteClusterRoleBindings deletes all ClusterRoleBindings associated with the Workspace.
 func (r *Reconciler) enforceClusterRoleBindingsAbsence(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Delete the ClusterRoleBinding for managing instances
 	if err := r.enforceInstancesManagerBindingAbsence(ctx, ws); err != nil {
@@ -127,7 +127,7 @@ func (r *Reconciler) enforceClusterRoleBindingsAbsence(
 // deleteInstancesManagerBinding deletes the ClusterRoleBinding for managing instances.
 func (r *Reconciler) enforceInstancesManagerBindingAbsence(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Create only the skeleton of the ClusterRoleBinding needed for deletion
 	name := forge.GetWorkspaceInstancesManagerBindingName(ws)
@@ -147,7 +147,7 @@ func (r *Reconciler) enforceInstancesManagerBindingAbsence(
 // deleteTenantsManagerBinding deletes the ClusterRoleBinding for managing tenants.
 func (r *Reconciler) enforceTenantsManagerBindingAbsence(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Create only the skeleton of the ClusterRoleBinding needed for deletion
 	name := forge.GetWorkspaceTenantsManagerBindingName(ws)

--- a/operators/pkg/controller/workspace/clusterrolebinding_test.go
+++ b/operators/pkg/controller/workspace/clusterrolebinding_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 )
 
 var crbInstances = &rbacv1.ClusterRoleBinding{
@@ -118,7 +118,7 @@ var _ = Describe("ClusterRoleBinding", func() {
 			})
 
 			It("Should set the workspace status to not ready", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 				Expect(ws.Status.Ready).To(BeFalse())
 			})
@@ -168,7 +168,7 @@ var _ = Describe("ClusterRoleBinding", func() {
 				})
 
 				It("Should prevent the deletion of the workspace resource", func() {
-					ws := &v1alpha1.Workspace{}
+					ws := &clv1alpha1.Workspace{}
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 					Expect(ws.DeletionTimestamp).To(Not(BeNil()))
 				})

--- a/operators/pkg/controller/workspace/common.go
+++ b/operators/pkg/controller/workspace/common.go
@@ -19,15 +19,15 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) enforcePreservingStatus(
 	ctx context.Context,
 	log logr.Logger,
-	tn *v1alpha1.Workspace,
-	mutating func(*v1alpha1.Workspace) *v1alpha1.Workspace,
+	tn *clv1alpha1.Workspace,
+	mutating func(*clv1alpha1.Workspace) *clv1alpha1.Workspace,
 ) error {
 	// the update function will overwrite the status, so we need to save it
 	// and restore it after the update

--- a/operators/pkg/controller/workspace/namespace.go
+++ b/operators/pkg/controller/workspace/namespace.go
@@ -21,17 +21,17 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) enforceNamespace(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -39,18 +39,18 @@ func (r *Reconciler) enforceNamespace(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ns, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, ns, func() error {
 		// Configure the namespace
 		labels := forge.UpdateWorkspaceResourceCommonLabels(nil, r.TargetLabel)
 		forge.ConfigureWorkspaceNamespace(ns, labels)
 
-		return controllerutil.SetControllerReference(ws, ns, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, ns, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating namespace %s for workspace %s: %w",
 			ns.Name, ws.Name, err)
 	}
 
-	ws.Status.Namespace = v1alpha2.NameCreated{
+	ws.Status.Namespace = clv1alpha2.NameCreated{
 		Name:    ns.Name,
 		Created: true,
 	}
@@ -60,7 +60,7 @@ func (r *Reconciler) enforceNamespace(
 
 func (r *Reconciler) enforceNamespaceAbsence(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -73,7 +73,7 @@ func (r *Reconciler) enforceNamespaceAbsence(
 			ns.Name, ws.Name, err)
 	}
 
-	ws.Status.Namespace = v1alpha2.NameCreated{
+	ws.Status.Namespace = clv1alpha2.NameCreated{
 		Name:    ns.Name,
 		Created: false,
 	}

--- a/operators/pkg/controller/workspace/namespace.go
+++ b/operators/pkg/controller/workspace/namespace.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -33,7 +33,7 @@ func (r *Reconciler) enforceNamespace(
 	ctx context.Context,
 	ws *v1alpha1.Workspace,
 ) error {
-	ns := &v1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: forge.GetWorkspaceNamespaceName(ws),
 		},
@@ -62,7 +62,7 @@ func (r *Reconciler) enforceNamespaceAbsence(
 	ctx context.Context,
 	ws *v1alpha1.Workspace,
 ) error {
-	ns := &v1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: forge.GetWorkspaceNamespaceName(ws),
 		},

--- a/operators/pkg/controller/workspace/namespace_test.go
+++ b/operators/pkg/controller/workspace/namespace_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -29,7 +29,7 @@ import (
 	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
-var namespaceResource = &v1.Namespace{
+var namespaceResource = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "workspace-" + wsName,
 		Labels: map[string]string{
@@ -43,7 +43,7 @@ var namespaceResource = &v1.Namespace{
 var _ = Describe("Namespace", func() {
 	Context("When a workspace is created", func() {
 		It("Should create a namespace with the correct labels", func() {
-			ns := &v1.Namespace{}
+			ns := &corev1.Namespace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "workspace-" + wsName}, ns, BeTrue(), timeout, interval)
 
@@ -65,7 +65,7 @@ var _ = Describe("Namespace", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Create: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.CreateOption) error {
-						if ns, ok := obj.(*v1.Namespace); ok && ns.Name == "workspace-"+wsName {
+						if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "workspace-"+wsName {
 							return fmt.Errorf("failed to create namespace")
 						}
 						return nil
@@ -116,14 +116,14 @@ var _ = Describe("Namespace", func() {
 			})
 
 			It("Should delete the namespace", func() {
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "workspace-" + wsName}, &v1.Namespace{}, BeFalse(), timeout, interval)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "workspace-" + wsName}, &corev1.Namespace{}, BeFalse(), timeout, interval)
 			})
 
 			Context("When there is an error deleting the namespace", func() {
 				BeforeEach(func() {
 					builder.WithInterceptorFuncs(interceptor.Funcs{
 						Delete: func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
-							if ns, ok := obj.(*v1.Namespace); ok && ns.Name == "workspace-"+wsName {
+							if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "workspace-"+wsName {
 								return fmt.Errorf("error deleting namespace")
 							}
 							return nil

--- a/operators/pkg/controller/workspace/namespace_test.go
+++ b/operators/pkg/controller/workspace/namespace_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var namespaceResource = &corev1.Namespace{
@@ -53,7 +53,7 @@ var _ = Describe("Namespace", func() {
 		})
 
 		It("Should update the workspace status with the namespace name", func() {
-			ws := &v1alpha1.Workspace{}
+			ws := &clv1alpha1.Workspace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -80,7 +80,7 @@ var _ = Describe("Namespace", func() {
 			})
 
 			It("Should set the namespace status in the workspace to not created", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -88,7 +88,7 @@ var _ = Describe("Namespace", func() {
 			})
 
 			It("Should set the workspace status to not ready", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -104,7 +104,7 @@ var _ = Describe("Namespace", func() {
 
 		Context("When the namespace exists", func() {
 			BeforeEach(func() {
-				wsResource.Status.Namespace = v1alpha2.NameCreated{
+				wsResource.Status.Namespace = clv1alpha2.NameCreated{
 					Created: true,
 					Name:    "workspace-" + wsName,
 				}
@@ -138,13 +138,13 @@ var _ = Describe("Namespace", func() {
 				})
 
 				It("Should prevent the workspace from being deleted", func() {
-					ws := &v1alpha1.Workspace{}
+					ws := &clv1alpha1.Workspace{}
 
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 				})
 
 				It("Should not remove the namespace from the workspace status", func() {
-					ws := &v1alpha1.Workspace{}
+					ws := &clv1alpha1.Workspace{}
 
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -153,7 +153,7 @@ var _ = Describe("Namespace", func() {
 				})
 
 				It("Should set the workspace status to not ready", func() {
-					ws := &v1alpha1.Workspace{}
+					ws := &clv1alpha1.Workspace{}
 
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 

--- a/operators/pkg/controller/workspace/reconciler.go
+++ b/operators/pkg/controller/workspace/reconciler.go
@@ -27,11 +27,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -39,9 +39,9 @@ import (
 type Reconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
-	TargetLabel   common.KVLabel
-	KeycloakActor common.KeycloakActorIface
-	Reschedule    common.Rescheduler
+	TargetLabel   ctrlcommon.KVLabel
+	KeycloakActor ctrlcommon.KeycloakActorIface
+	Reschedule    ctrlcommon.Rescheduler
 }
 
 // Reconcile reconciles the state of a Workspace resource.
@@ -51,7 +51,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	log.Info("Reconciling workspace")
 
-	var ws v1alpha1.Workspace
+	var ws clv1alpha1.Workspace
 	if err := r.Get(ctx, req.NamespacedName, &ws); client.IgnoreNotFound(err) != nil {
 		log.Error(err, "Error when getting workspace before starting reconcile", "workspace", req.Name)
 		return ctrl.Result{}, err
@@ -67,7 +67,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	avoidStatusUpdate := false
-	defer func(original, updated *v1alpha1.Workspace) {
+	defer func(original, updated *clv1alpha1.Workspace) {
 		if avoidStatusUpdate {
 			return
 		}
@@ -98,9 +98,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// add the finalizer if not already present
-	if !controllerutil.ContainsFinalizer(&ws, v1alpha2.TnOperatorFinalizerName) {
-		if err := r.enforcePreservingStatus(ctx, log, &ws, func(workspace *v1alpha1.Workspace) *v1alpha1.Workspace {
-			controllerutil.AddFinalizer(workspace, v1alpha2.TnOperatorFinalizerName)
+	if !ctrlutil.ContainsFinalizer(&ws, clv1alpha2.TnOperatorFinalizerName) {
+		if err := r.enforcePreservingStatus(ctx, log, &ws, func(workspace *clv1alpha1.Workspace) *clv1alpha1.Workspace {
+			ctrlutil.AddFinalizer(workspace, clv1alpha2.TnOperatorFinalizerName)
 			return workspace
 		}); err != nil {
 			log.Error(err, "Error adding finalizer to workspace")
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	log.Info("AutoEnrollment enforced for workspace")
 
 	if ws.Status.Subscriptions == nil {
-		ws.Status.Subscriptions = make(map[string]v1alpha2.SubscriptionStatus)
+		ws.Status.Subscriptions = make(map[string]clv1alpha2.SubscriptionStatus)
 	}
 
 	// setup roles in Keycloak
@@ -150,7 +150,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Workspace{}, builder.WithPredicates(pred)).
+		For(&clv1alpha1.Workspace{}, builder.WithPredicates(pred)).
 		Owns(&corev1.Namespace{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.RoleBinding{}).
@@ -161,7 +161,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 func (r *Reconciler) enforceWorkspaceAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// remove the Workspace from Tenants
 	if err := r.handleTenantWorkspaceDeletion(ctx, ws, log); err != nil {
@@ -182,9 +182,9 @@ func (r *Reconciler) enforceWorkspaceAbsence(
 	log.Info("Subresources deleted for workspace")
 
 	// delete finalizer
-	if controllerutil.ContainsFinalizer(ws, v1alpha2.TnOperatorFinalizerName) {
-		if err := r.enforcePreservingStatus(ctx, log, ws, func(workspace *v1alpha1.Workspace) *v1alpha1.Workspace {
-			controllerutil.RemoveFinalizer(workspace, v1alpha2.TnOperatorFinalizerName)
+	if ctrlutil.ContainsFinalizer(ws, clv1alpha2.TnOperatorFinalizerName) {
+		if err := r.enforcePreservingStatus(ctx, log, ws, func(workspace *clv1alpha1.Workspace) *clv1alpha1.Workspace {
+			ctrlutil.RemoveFinalizer(workspace, clv1alpha2.TnOperatorFinalizerName)
 			return workspace
 		}); err != nil {
 			return fmt.Errorf("error removing finalizer from workspace %s: %w", ws.Name, err)
@@ -198,7 +198,7 @@ func (r *Reconciler) enforceWorkspaceAbsence(
 func (r *Reconciler) enforceSubresources(
 	ctx context.Context,
 	log logr.Logger,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Enforce the Namespace for the Workspace
 	if err := r.enforceNamespace(ctx, ws); err != nil {
@@ -224,7 +224,7 @@ func (r *Reconciler) enforceSubresources(
 func (r *Reconciler) enforceSubresourcesAbsence(
 	ctx context.Context,
 	log logr.Logger,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	// Delete the RoleBindings for the Workspace
 	if err := r.enforceRoleBindingsAbsence(ctx, ws); err != nil {

--- a/operators/pkg/controller/workspace/reconciler.go
+++ b/operators/pkg/controller/workspace/reconciler.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -151,7 +151,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Workspace{}, builder.WithPredicates(pred)).
-		Owns(&v1.Namespace{}).
+		Owns(&corev1.Namespace{}).
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&rbacv1.RoleBinding{}).
 		WithLogConstructor(utils.LogConstructor(mgr.GetLogger(), "Workspace")).

--- a/operators/pkg/controller/workspace/reconciler_test.go
+++ b/operators/pkg/controller/workspace/reconciler_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -69,7 +69,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 		})
 
 		It("Should not create any resources", func() {
-			ns := &v1.Namespace{}
+			ns := &corev1.Namespace{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "workspace-" + wsName}, ns, BeFalse(), timeout, interval)
 		})
@@ -86,7 +86,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 			})
 
 			It("Should not delete the resources", func() {
-				ns := &v1.Namespace{}
+				ns := &corev1.Namespace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "workspace-" + wsName}, ns, BeTrue(), timeout, interval)
 

--- a/operators/pkg/controller/workspace/reconciler_test.go
+++ b/operators/pkg/controller/workspace/reconciler_test.go
@@ -24,7 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 )
 
 var _ = Describe("WorkspaceReconciler", func() {
@@ -49,7 +49,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 
 	Context("When the resource is not found in the cluster", func() {
 		BeforeEach(func() {
-			wsResource = &v1alpha1.Workspace{}
+			wsResource = &clv1alpha1.Workspace{}
 		})
 
 		It("Should not return an error", func() {
@@ -96,7 +96,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 	})
 
 	It("Should add the finalizer to the workspace resource", func() {
-		ws := &v1alpha1.Workspace{}
+		ws := &clv1alpha1.Workspace{}
 
 		DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -107,7 +107,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 		BeforeEach(func() {
 			builder.WithInterceptorFuncs(interceptor.Funcs{
 				Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-					if ws, ok := obj.(*v1alpha1.Workspace); ok && ws.Name == wsName {
+					if ws, ok := obj.(*clv1alpha1.Workspace); ok && ws.Name == wsName {
 						return fmt.Errorf("failed to add finalizer")
 					}
 					return nil
@@ -131,7 +131,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						if ws, ok := obj.(*v1alpha1.Workspace); ok && ws.Name == wsName {
+						if ws, ok := obj.(*clv1alpha1.Workspace); ok && ws.Name == wsName {
 							return fmt.Errorf("failed to remove finalizer")
 						}
 						return nil
@@ -146,7 +146,7 @@ var _ = Describe("WorkspaceReconciler", func() {
 			})
 
 			It("Should prevent the deletion of the workspace resource", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 			})

--- a/operators/pkg/controller/workspace/rolebinding.go
+++ b/operators/pkg/controller/workspace/rolebinding.go
@@ -22,16 +22,16 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) enforceRoleBindings(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	if !ws.Status.Namespace.Created {
 		return fmt.Errorf("cannot manage RoleBindings for Workspace %s: namespace not created", ws.Name)
@@ -58,7 +58,7 @@ func (r *Reconciler) enforceRoleBindings(
 
 func (r *Reconciler) enforceRoleBindingsAbsence(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 ) error {
 	if !ws.Status.Namespace.Created {
 		return nil // No RoleBindings to delete if the namespace is not created
@@ -111,7 +111,7 @@ func (r *Reconciler) deleteSingleRb(
 // enforceUserViewTemplatesRoleBinding creates or updates the RoleBinding for User View Templates.
 func (r *Reconciler) enforceUserViewTemplatesRoleBinding(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	namespace string,
 ) error {
 	rb := &rbacv1.RoleBinding{
@@ -121,14 +121,14 @@ func (r *Reconciler) enforceUserViewTemplatesRoleBinding(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
 		// Update labels
 		rb.Labels = forge.UpdateWorkspaceResourceCommonLabels(rb.Labels, r.TargetLabel)
 
 		// Configure the RoleBinding
 		forge.ConfigureWorkspaceUserViewTemplatesBinding(ws, rb, rb.Labels)
 
-		return controllerutil.SetControllerReference(ws, rb, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, rb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating User View Templates RoleBinding: %w", err)
 	}
@@ -139,7 +139,7 @@ func (r *Reconciler) enforceUserViewTemplatesRoleBinding(
 // enforceManagerManageTemplatesRoleBinding creates or updates the RoleBinding for Manager Manage Templates.
 func (r *Reconciler) enforceManagerManageTemplatesRoleBinding(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	namespace string,
 ) error {
 	rb := &rbacv1.RoleBinding{
@@ -149,14 +149,14 @@ func (r *Reconciler) enforceManagerManageTemplatesRoleBinding(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
 		// Update labels
 		rb.Labels = forge.UpdateWorkspaceResourceCommonLabels(rb.Labels, r.TargetLabel)
 
 		// Configure the RoleBinding
 		forge.ConfigureWorkspaceManagerManageTemplatesBinding(ws, rb, rb.Labels)
 
-		return controllerutil.SetControllerReference(ws, rb, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, rb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating Manager Manage Templates RoleBinding: %w", err)
 	}
@@ -167,7 +167,7 @@ func (r *Reconciler) enforceManagerManageTemplatesRoleBinding(
 // enforceManagerManageSharedVolumesRoleBinding creates or updates the RoleBinding for Manager Manage SharedVolumes.
 func (r *Reconciler) enforceManagerManageSharedVolumesRoleBinding(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	namespace string,
 ) error {
 	rb := &rbacv1.RoleBinding{
@@ -177,14 +177,14 @@ func (r *Reconciler) enforceManagerManageSharedVolumesRoleBinding(
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
+	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
 		// Update labels
 		rb.Labels = forge.UpdateWorkspaceResourceCommonLabels(rb.Labels, r.TargetLabel)
 
 		// Configure the RoleBinding
 		forge.ConfigureWorkspaceManagerManageSharedVolumesBinding(ws, rb, rb.Labels)
 
-		return controllerutil.SetControllerReference(ws, rb, r.Scheme)
+		return ctrlutil.SetControllerReference(ws, rb, r.Scheme)
 	}); err != nil {
 		return fmt.Errorf("error while creating/updating Manager Manage SharedVolumes RoleBinding: %w", err)
 	}

--- a/operators/pkg/controller/workspace/rolebinding_test.go
+++ b/operators/pkg/controller/workspace/rolebinding_test.go
@@ -25,8 +25,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var roleBindingResources = []*rbacv1.RoleBinding{
@@ -173,7 +173,7 @@ var _ = Describe("RoleBinding", func() {
 			})
 
 			It("Should set the workspace status as not ready", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -189,7 +189,7 @@ var _ = Describe("RoleBinding", func() {
 
 		Context("When the rolebindings exist", func() {
 			BeforeEach(func() {
-				wsResource.Status.Namespace = v1alpha2.NameCreated{
+				wsResource.Status.Namespace = clv1alpha2.NameCreated{
 					Created: true,
 					Name:    "workspace-" + wsName,
 				}
@@ -235,7 +235,7 @@ var _ = Describe("RoleBinding", func() {
 				})
 
 				It("Should prevent the workspace from being deleted", func() {
-					ws := &v1alpha1.Workspace{}
+					ws := &clv1alpha1.Workspace{}
 
 					DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -252,7 +252,7 @@ var _ = Describe("RoleBinding", func() {
 
 		Context("When the rolebindings do not exist", func() {
 			BeforeEach(func() {
-				wsResource.Status.Namespace = v1alpha2.NameCreated{
+				wsResource.Status.Namespace = clv1alpha2.NameCreated{
 					Created: true,
 					Name:    "workspace-" + wsName,
 				}

--- a/operators/pkg/controller/workspace/suite_test.go
+++ b/operators/pkg/controller/workspace/suite_test.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegaTypes "github.com/onsi/gomega/types"
-	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/operators/pkg/controller/workspace/suite_test.go
+++ b/operators/pkg/controller/workspace/suite_test.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/mock"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/workspace"
 )
@@ -53,7 +53,7 @@ var (
 	keycloakActor       *mock.MockKeycloakActorIface
 	workspaceReconciler workspace.Reconciler
 
-	wsResource             *v1alpha1.Workspace
+	wsResource             *clv1alpha1.Workspace
 	wsReconcileErrExpected gomegaTypes.GomegaMatcher
 
 	objects []client.Object
@@ -65,8 +65,8 @@ func TestWorkspace(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	Expect(v1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(v1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(clv1alpha2.AddToScheme(scheme.Scheme)).To(Succeed())
 })
 
 var _ = BeforeEach(func() {
@@ -78,14 +78,14 @@ var _ = BeforeEach(func() {
 
 	keycloakActor.EXPECT().IsInitialized().Return(false).AnyTimes()
 
-	wsResource = &v1alpha1.Workspace{
+	wsResource = &clv1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: wsName,
 			Labels: map[string]string{
 				"crownlabs.polito.it/operator-selector": "test",
 			},
 		},
-		Spec: v1alpha1.WorkspaceSpec{
+		Spec: clv1alpha1.WorkspaceSpec{
 			PrettyName: wsPrettyName,
 		},
 	}
@@ -106,7 +106,7 @@ var _ = JustBeforeEach(func() {
 		Client:        cl,
 		Scheme:        scheme.Scheme,
 		KeycloakActor: keycloakActor,
-		TargetLabel:   common.NewLabel("crownlabs.polito.it/operator-selector", "test"),
+		TargetLabel:   ctrlcommon.NewLabel("crownlabs.polito.it/operator-selector", "test"),
 	}
 
 	_, err := workspaceReconciler.Reconcile(ctx, ctrl.Request{
@@ -143,6 +143,6 @@ func removeObjFromObjectsList(obj client.Object) {
 }
 
 func workspaceBeingDeleted() {
-	wsResource.Finalizers = append(wsResource.Finalizers, v1alpha2.TnOperatorFinalizerName)
+	wsResource.Finalizers = append(wsResource.Finalizers, clv1alpha2.TnOperatorFinalizerName)
 	wsResource.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 }

--- a/operators/pkg/controller/workspace/tenant.go
+++ b/operators/pkg/controller/workspace/tenant.go
@@ -21,18 +21,18 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 func (r *Reconciler) handleTenantWorkspaceDeletion(
 	ctx context.Context,
-	ws *v1alpha1.Workspace,
+	ws *clv1alpha1.Workspace,
 	log logr.Logger,
 ) error {
-	var tenantsToUpdate v1alpha2.TenantList
+	var tenantsToUpdate clv1alpha2.TenantList
 	targetLabel := forge.GetWorkspaceTargetLabel(ws.Name)
 
 	if err := r.List(ctx, &tenantsToUpdate, &client.HasLabels{targetLabel}); err != nil {
@@ -42,7 +42,7 @@ func (r *Reconciler) handleTenantWorkspaceDeletion(
 
 	for i := range tenantsToUpdate.Items {
 		tn := &tenantsToUpdate.Items[i]
-		if err := utils.PatchObject(ctx, r.Client, tn, func(t *v1alpha2.Tenant) *v1alpha2.Tenant {
+		if err := utils.PatchObject(ctx, r.Client, tn, func(t *clv1alpha2.Tenant) *clv1alpha2.Tenant {
 			removeWorkspaceFromTenant(&t.Spec.Workspaces, ws.Name)
 			return t
 		}); err != nil {
@@ -55,7 +55,7 @@ func (r *Reconciler) handleTenantWorkspaceDeletion(
 }
 
 func removeWorkspaceFromTenant(
-	workspaces *[]v1alpha2.TenantWorkspaceEntry,
+	workspaces *[]clv1alpha2.TenantWorkspaceEntry,
 	wsToRemove string,
 ) {
 	idxToRemove := -1

--- a/operators/pkg/controller/workspace/tenant_test.go
+++ b/operators/pkg/controller/workspace/tenant_test.go
@@ -24,11 +24,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
-var tenantResources = []*v1alpha2.Tenant{
+var tenantResources = []*clv1alpha2.Tenant{
 	{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-candidate",
@@ -37,13 +37,13 @@ var tenantResources = []*v1alpha2.Tenant{
 				fmt.Sprintf("crownlabs.polito.it/workspace-%s", wsName): "candidate",
 			},
 		},
-		Spec: v1alpha2.TenantSpec{
+		Spec: clv1alpha2.TenantSpec{
 			FirstName: "Candidate",
 			LastName:  "Tenant",
 			Email:     "candidate-tenant@test.email",
-			Workspaces: []v1alpha2.TenantWorkspaceEntry{{
+			Workspaces: []clv1alpha2.TenantWorkspaceEntry{{
 				Name: wsName,
-				Role: v1alpha2.Candidate,
+				Role: clv1alpha2.Candidate,
 			}},
 		},
 	},
@@ -55,13 +55,13 @@ var tenantResources = []*v1alpha2.Tenant{
 				fmt.Sprintf("crownlabs.polito.it/workspace-%s", wsName): "user",
 			},
 		},
-		Spec: v1alpha2.TenantSpec{
+		Spec: clv1alpha2.TenantSpec{
 			FirstName: "User",
 			LastName:  "Tenant",
 			Email:     "user-tenant@test.email",
-			Workspaces: []v1alpha2.TenantWorkspaceEntry{{
+			Workspaces: []clv1alpha2.TenantWorkspaceEntry{{
 				Name: wsName,
-				Role: v1alpha2.User,
+				Role: clv1alpha2.User,
 			}},
 		},
 	},
@@ -73,13 +73,13 @@ var tenantResources = []*v1alpha2.Tenant{
 				fmt.Sprintf("crownlabs.polito.it/workspace-%s", wsName): "manager",
 			},
 		},
-		Spec: v1alpha2.TenantSpec{
+		Spec: clv1alpha2.TenantSpec{
 			FirstName: "Manager",
 			LastName:  "Tenant",
 			Email:     "manager-tenant@test.email",
-			Workspaces: []v1alpha2.TenantWorkspaceEntry{{
+			Workspaces: []clv1alpha2.TenantWorkspaceEntry{{
 				Name: wsName,
-				Role: v1alpha2.Manager,
+				Role: clv1alpha2.Manager,
 			}},
 		},
 	},
@@ -101,7 +101,7 @@ var _ = Describe("Tenant", func() {
 		})
 
 		It("Should remove the workspace from the Tenant spec", func() {
-			tenant := &v1alpha2.Tenant{}
+			tenant := &clv1alpha2.Tenant{}
 
 			DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: tenantResources[0].Name}, tenant, BeTrue(), timeout, interval)
 
@@ -112,7 +112,7 @@ var _ = Describe("Tenant", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					List: func(_ context.Context, _ client.WithWatch, list client.ObjectList, _ ...client.ListOption) error {
-						if _, ok := list.(*v1alpha2.TenantList); ok {
+						if _, ok := list.(*clv1alpha2.TenantList); ok {
 							return fmt.Errorf("failed to list tenants")
 						}
 						return nil
@@ -127,7 +127,7 @@ var _ = Describe("Tenant", func() {
 			})
 
 			It("should prevent the workspace from being deleted", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 
@@ -139,7 +139,7 @@ var _ = Describe("Tenant", func() {
 			BeforeEach(func() {
 				builder.WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(_ context.Context, _ client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
-						if tenant, ok := obj.(*v1alpha2.Tenant); ok && tenant.Name == tenantResources[0].Name {
+						if tenant, ok := obj.(*clv1alpha2.Tenant); ok && tenant.Name == tenantResources[0].Name {
 							return fmt.Errorf("failed to update tenant")
 						}
 						return nil
@@ -154,7 +154,7 @@ var _ = Describe("Tenant", func() {
 			})
 
 			It("should prevent the workspace from being deleted", func() {
-				ws := &v1alpha1.Workspace{}
+				ws := &clv1alpha1.Workspace{}
 
 				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: wsName}, ws, BeTrue(), timeout, interval)
 

--- a/operators/pkg/examagent/instance.go
+++ b/operators/pkg/examagent/instance.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -92,7 +92,7 @@ func (ih *InstanceHandler) HandleGet(w http.ResponseWriter, r *http.Request, log
 	log = log.WithValues("instance", inst.Name)
 
 	if err := ih.Client.Get(r.Context(), forge.NamespacedNameFromObject(inst), inst); err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			log.Error(err, "instance not found")
 			WriteError(w, r, log, http.StatusNotFound, "The requested Instance does not exist.")
 			return

--- a/operators/pkg/forge/keycloak.go
+++ b/operators/pkg/forge/keycloak.go
@@ -17,34 +17,34 @@ package forge
 import (
 	"fmt"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // WorkspaceRoleName generates the role name for a workspace.
 func WorkspaceRoleName(
 	wsName string,
-	role v1alpha2.WorkspaceUserRole,
+	role clv1alpha2.WorkspaceUserRole,
 ) string {
 	return fmt.Sprintf("workspace-%s:%s", wsName, role)
 }
 
 // GetWorkspaceManagerRoleName returns the Keycloak role name for workspace managers.
-func GetWorkspaceManagerRoleName(ws *v1alpha1.Workspace) string {
-	return WorkspaceRoleName(ws.Name, v1alpha2.Manager)
+func GetWorkspaceManagerRoleName(ws *clv1alpha1.Workspace) string {
+	return WorkspaceRoleName(ws.Name, clv1alpha2.Manager)
 }
 
 // GetWorkspaceManagerRoleDescription returns the Keycloak role description for workspace managers.
-func GetWorkspaceManagerRoleDescription(ws *v1alpha1.Workspace) string {
+func GetWorkspaceManagerRoleDescription(ws *clv1alpha1.Workspace) string {
 	return fmt.Sprintf("%s Manager Role", ws.Spec.PrettyName)
 }
 
 // GetWorkspaceUserRoleName returns the Keycloak role name for workspace users.
-func GetWorkspaceUserRoleName(ws *v1alpha1.Workspace) string {
-	return WorkspaceRoleName(ws.Name, v1alpha2.User)
+func GetWorkspaceUserRoleName(ws *clv1alpha1.Workspace) string {
+	return WorkspaceRoleName(ws.Name, clv1alpha2.User)
 }
 
 // GetWorkspaceUserRoleDescription returns the Keycloak role description for workspace users.
-func GetWorkspaceUserRoleDescription(ws *v1alpha1.Workspace) string {
+func GetWorkspaceUserRoleDescription(ws *clv1alpha1.Workspace) string {
 	return fmt.Sprintf("%s User Role", ws.Spec.PrettyName)
 }

--- a/operators/pkg/forge/keycloak_test.go
+++ b/operators/pkg/forge/keycloak_test.go
@@ -19,22 +19,22 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 var _ = Describe("Keycloak forging", func() {
 	var (
-		workspace *v1alpha1.Workspace
+		workspace *clv1alpha1.Workspace
 	)
 
 	BeforeEach(func() {
-		workspace = &v1alpha1.Workspace{
+		workspace = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-workspace",
 			},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "Test Workspace",
 			},
 		}
@@ -43,7 +43,7 @@ var _ = Describe("Keycloak forging", func() {
 	Context("WorkspaceRoleName", func() {
 		It("should return the correct role name for a workspace if the role is Manager", func() {
 			ws := "test-workspace"
-			role := v1alpha2.Manager
+			role := clv1alpha2.Manager
 			expectedRoleName := "workspace-test-workspace:manager"
 
 			roleName := forge.WorkspaceRoleName(ws, role)
@@ -52,7 +52,7 @@ var _ = Describe("Keycloak forging", func() {
 
 		It("should return the correct role name for a workspace if the role is User", func() {
 			ws := "test-workspace"
-			role := v1alpha2.User
+			role := clv1alpha2.User
 			expectedRoleName := "workspace-test-workspace:user"
 
 			roleName := forge.WorkspaceRoleName(ws, role)
@@ -114,13 +114,13 @@ var _ = Describe("Keycloak forging", func() {
 		It("Should use the correct format for manager role", func() {
 			managerRole := forge.GetWorkspaceManagerRoleName(workspace)
 			Expect(managerRole).To(ContainSubstring(workspace.Name))
-			Expect(managerRole).To(ContainSubstring(string(v1alpha2.Manager)))
+			Expect(managerRole).To(ContainSubstring(string(clv1alpha2.Manager)))
 		})
 
 		It("Should use the correct format for user role", func() {
 			userRole := forge.GetWorkspaceUserRoleName(workspace)
 			Expect(userRole).To(ContainSubstring(workspace.Name))
-			Expect(userRole).To(ContainSubstring(string(v1alpha2.User)))
+			Expect(userRole).To(ContainSubstring(string(clv1alpha2.User)))
 		})
 	})
 })

--- a/operators/pkg/forge/labels.go
+++ b/operators/pkg/forge/labels.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 const (
@@ -249,7 +249,7 @@ func SharedVolumeObjectLabels(labels map[string]string) map[string]string {
 }
 
 // TenantLabels receives in input a set of labels and returns the updated set depending on the specified tenant.
-func TenantLabels(labels map[string]string, tenant *clv1alpha2.Tenant, targetLabel common.KVLabel) map[string]string {
+func TenantLabels(labels map[string]string, tenant *clv1alpha2.Tenant, targetLabel ctrlcommon.KVLabel) map[string]string {
 	labels = deepCopyLabels(labels)
 
 	labels = UpdateTenantResourceCommonLabels(labels, targetLabel)
@@ -304,7 +304,7 @@ func InstanceNameFromLabels(labels map[string]string) (string, bool) {
 }
 
 // UpdateWorkspaceResourceCommonLabels updates the common labels for resources managed by the workspace controller.
-func UpdateWorkspaceResourceCommonLabels(labels map[string]string, targetLabel common.KVLabel) map[string]string {
+func UpdateWorkspaceResourceCommonLabels(labels map[string]string, targetLabel ctrlcommon.KVLabel) map[string]string {
 	if labels == nil {
 		labels = make(map[string]string, 1)
 	}

--- a/operators/pkg/forge/labels_test.go
+++ b/operators/pkg/forge/labels_test.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -712,7 +712,7 @@ var _ = Describe("Labels forging", func() {
 				"existing-label": "existing-value",
 			}
 
-			targetLabel := common.NewLabel("test-key", "test-value")
+			targetLabel := ctrlcommon.NewLabel("test-key", "test-value")
 
 			resultLabels := forge.UpdateWorkspaceResourceCommonLabels(inputLabels, targetLabel)
 
@@ -725,7 +725,7 @@ var _ = Describe("Labels forging", func() {
 		It("Should initialize labels map when nil", func() {
 			var inputLabels map[string]string
 
-			targetLabel := common.NewLabel("test-key", "test-value")
+			targetLabel := ctrlcommon.NewLabel("test-key", "test-value")
 
 			resultLabels := forge.UpdateWorkspaceResourceCommonLabels(inputLabels, targetLabel)
 

--- a/operators/pkg/forge/loadbalancers.go
+++ b/operators/pkg/forge/loadbalancers.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -62,22 +62,22 @@ func ConfigureLoadBalancerAnnotationKeys(raw string) (s, ip string, err error) {
 }
 
 // LoadBalancerServiceSpec forges the spec for a LoadBalancer service for public exposure.
-func LoadBalancerServiceSpec(instance *clv1alpha2.Instance, ports []clv1alpha2.PublicServicePort) v1.ServiceSpec {
-	svcPorts := make([]v1.ServicePort, len(ports))
+func LoadBalancerServiceSpec(instance *clv1alpha2.Instance, ports []clv1alpha2.PublicServicePort) corev1.ServiceSpec {
+	svcPorts := make([]corev1.ServicePort, len(ports))
 	for i, p := range ports {
 		protocol := p.Protocol
 		if protocol == "" {
-			protocol = v1.ProtocolTCP
+			protocol = corev1.ProtocolTCP
 		}
-		svcPorts[i] = v1.ServicePort{
+		svcPorts[i] = corev1.ServicePort{
 			Name:       p.Name,
 			Port:       p.Port,
 			TargetPort: intstr.FromInt32(p.TargetPort),
 			Protocol:   protocol,
 		}
 	}
-	return v1.ServiceSpec{
-		Type:     v1.ServiceTypeLoadBalancer,
+	return corev1.ServiceSpec{
+		Type:     corev1.ServiceTypeLoadBalancer,
 		Selector: InstanceSelectorLabels(instance),
 		Ports:    svcPorts,
 	}

--- a/operators/pkg/forge/loadbalancers_test.go
+++ b/operators/pkg/forge/loadbalancers_test.go
@@ -17,7 +17,7 @@ package forge_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -56,7 +56,7 @@ var _ = Describe("LoadBalancers forging", func() {
 
 	Describe("The forge.LoadBalancerServiceSpec function", func() {
 		var (
-			spec  v1.ServiceSpec
+			spec  corev1.ServiceSpec
 			ports []clv1alpha2.PublicServicePort
 		)
 
@@ -76,7 +76,7 @@ var _ = Describe("LoadBalancers forging", func() {
 
 		When("Forging the LoadBalancer service spec", func() {
 			It("Should set the correct service type", func() {
-				Expect(spec.Type).To(Equal(v1.ServiceTypeLoadBalancer))
+				Expect(spec.Type).To(Equal(corev1.ServiceTypeLoadBalancer))
 			})
 
 			It("Should configure the correct selector", func() {
@@ -90,11 +90,11 @@ var _ = Describe("LoadBalancers forging", func() {
 
 			It("Should configure the correct port details", func() {
 				actual := spec.Ports[0]
-				expectedPort := v1.ServicePort{
+				expectedPort := corev1.ServicePort{
 					Name:       portName,
 					Port:       port,
 					TargetPort: intstr.FromInt32(targetPort),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				}
 				if actual.Protocol == "" {
 					expectedPort.Protocol = ""
@@ -103,21 +103,21 @@ var _ = Describe("LoadBalancers forging", func() {
 			})
 
 			It("Should configure explicit TCP protocol", func() {
-				ports[0].Protocol = v1.ProtocolTCP
+				ports[0].Protocol = corev1.ProtocolTCP
 				spec = forge.LoadBalancerServiceSpec(&instance, ports)
-				Expect(spec.Ports[0].Protocol).To(Equal(v1.ProtocolTCP))
+				Expect(spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			})
 
 			It("Should configure explicit UDP protocol", func() {
-				ports[0].Protocol = v1.ProtocolUDP
+				ports[0].Protocol = corev1.ProtocolUDP
 				spec = forge.LoadBalancerServiceSpec(&instance, ports)
-				Expect(spec.Ports[0].Protocol).To(Equal(v1.ProtocolUDP))
+				Expect(spec.Ports[0].Protocol).To(Equal(corev1.ProtocolUDP))
 			})
 
 			It("Should default to TCP when protocol is empty", func() {
 				ports[0].Protocol = ""
 				spec = forge.LoadBalancerServiceSpec(&instance, ports)
-				Expect(spec.Ports[0].Protocol).To(Equal(v1.ProtocolTCP))
+				Expect(spec.Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
 			})
 		})
 
@@ -141,11 +141,11 @@ var _ = Describe("LoadBalancers forging", func() {
 				Expect(spec.Ports).To(HaveLen(2))
 
 				actual0 := spec.Ports[0]
-				expectedPort0 := v1.ServicePort{
+				expectedPort0 := corev1.ServicePort{
 					Name:       "http",
 					Port:       8080,
 					TargetPort: intstr.FromInt32(80),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				}
 				if actual0.Protocol == "" {
 					expectedPort0.Protocol = ""
@@ -153,11 +153,11 @@ var _ = Describe("LoadBalancers forging", func() {
 				Expect(actual0).To(Equal(expectedPort0))
 
 				actual1 := spec.Ports[1]
-				expectedPort1 := v1.ServicePort{
+				expectedPort1 := corev1.ServicePort{
 					Name:       "https",
 					Port:       8443,
 					TargetPort: intstr.FromInt32(443),
-					Protocol:   v1.ProtocolTCP,
+					Protocol:   corev1.ProtocolTCP,
 				}
 				if actual1.Protocol == "" {
 					expectedPort1.Protocol = ""

--- a/operators/pkg/forge/namespace.go
+++ b/operators/pkg/forge/namespace.go
@@ -21,12 +21,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // GetWorkspaceNamespaceName returns the name of the namespace for a workspace.
-func GetWorkspaceNamespaceName(ws *v1alpha1.Workspace) string {
+func GetWorkspaceNamespaceName(ws *clv1alpha1.Workspace) string {
 	return fmt.Sprintf("workspace-%s", ws.Name)
 }
 
@@ -45,12 +45,12 @@ func ConfigureWorkspaceNamespace(ns *corev1.Namespace, labels map[string]string)
 }
 
 // GetTenantNamespaceName returns the name of the namespace for a tenant.
-func GetTenantNamespaceName(tn *v1alpha2.Tenant) string {
+func GetTenantNamespaceName(tn *clv1alpha2.Tenant) string {
 	return fmt.Sprintf("tenant-%s", strings.ReplaceAll(tn.Name, ".", "-"))
 }
 
 // ConfigureTenantNamespace configures a namespace for a tenant.
-func ConfigureTenantNamespace(ns *corev1.Namespace, tn *v1alpha2.Tenant, labels map[string]string) {
+func ConfigureTenantNamespace(ns *corev1.Namespace, tn *clv1alpha2.Tenant, labels map[string]string) {
 	// Set the labels for the namespace
 	if ns.Labels == nil {
 		ns.Labels = make(map[string]string)

--- a/operators/pkg/forge/namespace_test.go
+++ b/operators/pkg/forge/namespace_test.go
@@ -20,23 +20,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 var _ = Describe("Namespace forging", func() {
 	var (
-		workspace *v1alpha1.Workspace
+		workspace *clv1alpha1.Workspace
 		labels    map[string]string
 	)
 
 	BeforeEach(func() {
-		workspace = &v1alpha1.Workspace{
+		workspace = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-workspace",
 			},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "Test Workspace",
 			},
 		}
@@ -105,7 +105,7 @@ var _ = Describe("Namespace forging", func() {
 
 	var _ = Describe("GetTenantNamespaceName", func() {
 		It("Should format namespace name correctly for simple tenant name", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},
@@ -116,7 +116,7 @@ var _ = Describe("Namespace forging", func() {
 		})
 
 		It("Should replace dots with dashes in tenant name", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "s123456.student",
 				},
@@ -129,7 +129,7 @@ var _ = Describe("Namespace forging", func() {
 
 	var _ = Describe("ConfigureTenantNamespace", func() {
 		It("Should initialize labels if nil and set required labels", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},
@@ -150,7 +150,7 @@ var _ = Describe("Namespace forging", func() {
 		})
 
 		It("Should preserve existing labels and add new ones", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},
@@ -181,7 +181,7 @@ var _ = Describe("Namespace forging", func() {
 
 	var _ = Describe("GetTenantNamespaceName", func() {
 		It("Should format namespace name correctly for simple tenant name", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},
@@ -192,7 +192,7 @@ var _ = Describe("Namespace forging", func() {
 		})
 
 		It("Should replace dots with dashes in tenant name", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "s123456.student",
 				},
@@ -205,7 +205,7 @@ var _ = Describe("Namespace forging", func() {
 
 	var _ = Describe("ConfigureTenantNamespace", func() {
 		It("Should initialize labels if nil and set required labels", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},
@@ -226,7 +226,7 @@ var _ = Describe("Namespace forging", func() {
 		})
 
 		It("Should preserve existing labels and add new ones", func() {
-			tenant := &v1alpha2.Tenant{
+			tenant := &clv1alpha2.Tenant{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "student",
 				},

--- a/operators/pkg/forge/rbac.go
+++ b/operators/pkg/forge/rbac.go
@@ -21,7 +21,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
@@ -40,18 +40,18 @@ const (
 )
 
 // GetWorkspaceInstancesManagerBindingName returns the name of the ClusterRoleBinding for managing instances in a workspace.
-func GetWorkspaceInstancesManagerBindingName(ws *v1alpha1.Workspace) string {
+func GetWorkspaceInstancesManagerBindingName(ws *clv1alpha1.Workspace) string {
 	return fmt.Sprintf("%s-%s", WorkspaceInstancesManagerRoleName, ws.Name)
 }
 
 // GetWorkspaceTenantsManagerBindingName returns the name of the ClusterRoleBinding for managing tenants in a workspace.
-func GetWorkspaceTenantsManagerBindingName(ws *v1alpha1.Workspace) string {
+func GetWorkspaceTenantsManagerBindingName(ws *clv1alpha1.Workspace) string {
 	return fmt.Sprintf("%s-%s", WorkspaceTenantsManagerRoleName, ws.Name)
 }
 
 // ConfigureWorkspaceInstancesManagerBinding configures the RoleRef and Subjects for a ClusterRoleBinding
 // that grants permissions to manage instances in a workspace.
-func ConfigureWorkspaceInstancesManagerBinding(ws *v1alpha1.Workspace, crb *rbacv1.ClusterRoleBinding) {
+func ConfigureWorkspaceInstancesManagerBinding(ws *clv1alpha1.Workspace, crb *rbacv1.ClusterRoleBinding) {
 	// Configure the RoleRef for instances management
 	crb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",
@@ -71,7 +71,7 @@ func ConfigureWorkspaceInstancesManagerBinding(ws *v1alpha1.Workspace, crb *rbac
 
 // ConfigureWorkspaceTenantsManagerBinding configures the RoleRef and Subjects for a ClusterRoleBinding
 // that grants permissions to manage tenants in a workspace.
-func ConfigureWorkspaceTenantsManagerBinding(ws *v1alpha1.Workspace, crb *rbacv1.ClusterRoleBinding) {
+func ConfigureWorkspaceTenantsManagerBinding(ws *clv1alpha1.Workspace, crb *rbacv1.ClusterRoleBinding) {
 	// Configure the RoleRef for tenants management
 	crb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",

--- a/operators/pkg/forge/rbac_test.go
+++ b/operators/pkg/forge/rbac_test.go
@@ -20,22 +20,22 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 var _ = Describe("RBAC forging", func() {
 	var (
-		workspace *v1alpha1.Workspace
+		workspace *clv1alpha1.Workspace
 	)
 
 	BeforeEach(func() {
-		workspace = &v1alpha1.Workspace{
+		workspace = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-workspace",
 			},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "Test Workspace",
 			},
 		}

--- a/operators/pkg/forge/resourcequota.go
+++ b/operators/pkg/forge/resourcequota.go
@@ -18,7 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
 	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 )
 
@@ -48,8 +48,8 @@ var (
 )
 
 // TenantResourceList forges the WorkspaceResourceQuota as the sum of all quota for each workspace plus the personal workspace quota.
-func TenantResourceList(workspaces []clv1alpha1.Workspace, personalWorkspaceQuota *common.WorkspaceResourceQuota) common.WorkspaceResourceQuota {
-	var quota common.WorkspaceResourceQuota
+func TenantResourceList(workspaces []clv1alpha1.Workspace, personalWorkspaceQuota *apicommon.WorkspaceResourceQuota) apicommon.WorkspaceResourceQuota {
+	var quota apicommon.WorkspaceResourceQuota
 
 	// sum all quota for each existing workspace
 	for i := range workspaces {
@@ -80,7 +80,7 @@ func TenantResourceList(workspaces []clv1alpha1.Workspace, personalWorkspaceQuot
 }
 
 // TenantResourceQuotaSpec converts a WorkspaceResourceQuota to a ResourceQuota's resource list.
-func TenantResourceQuotaSpec(quota *common.WorkspaceResourceQuota) corev1.ResourceList {
+func TenantResourceQuotaSpec(quota *apicommon.WorkspaceResourceQuota) corev1.ResourceList {
 	return corev1.ResourceList{
 		corev1.ResourceLimitsCPU:      quota.CPU,
 		corev1.ResourceLimitsMemory:   quota.Memory,

--- a/operators/pkg/forge/resourcequota_test.go
+++ b/operators/pkg/forge/resourcequota_test.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/common"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
 	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
@@ -37,7 +37,7 @@ var _ = Describe("Resource quota spec forging", func() {
 			BeforeEach(func() {
 				tenant = clv1alpha2.Tenant{
 					Spec: clv1alpha2.TenantSpec{
-						PersonalWorkspace: &common.WorkspaceResourceQuota{
+						PersonalWorkspace: &apicommon.WorkspaceResourceQuota{
 							CPU:       *resource.NewQuantity(25, resource.DecimalSI),
 							Memory:    *resource.NewScaledQuantity(50, resource.Giga),
 							Instances: 6,
@@ -56,7 +56,7 @@ var _ = Describe("Resource quota spec forging", func() {
 		Describe("Forging the tenant resource quota with sample workspaces", func() {
 			var (
 				workspaces  []clv1alpha1.Workspace
-				resultQuota common.WorkspaceResourceQuota
+				resultQuota apicommon.WorkspaceResourceQuota
 			)
 
 			BeforeEach(func() {
@@ -64,13 +64,13 @@ var _ = Describe("Resource quota spec forging", func() {
 				workspaces = make([]clv1alpha1.Workspace, 0)
 				var sampleWorkspace1, sampleWorkspace2 clv1alpha1.Workspace
 				// sample resource quota spec for each workspace.
-				quota1 := common.WorkspaceResourceQuota{
+				quota1 := apicommon.WorkspaceResourceQuota{
 					CPU:       *resource.NewQuantity(10, resource.DecimalSI),
 					Memory:    *resource.NewScaledQuantity(15, resource.Giga),
 					Instances: 2,
 				}
 
-				quota2 := common.WorkspaceResourceQuota{
+				quota2 := apicommon.WorkspaceResourceQuota{
 					CPU:       *resource.NewQuantity(20, resource.DecimalSI),
 					Memory:    *resource.NewScaledQuantity(25, resource.Giga),
 					Instances: 3,
@@ -112,7 +112,7 @@ var _ = Describe("Resource quota spec forging", func() {
 		BeforeEach(func() {
 			tenant = clv1alpha2.Tenant{
 				Spec: clv1alpha2.TenantSpec{
-					PersonalWorkspace: &common.WorkspaceResourceQuota{
+					PersonalWorkspace: &apicommon.WorkspaceResourceQuota{
 						CPU:       *resource.NewQuantity(15, resource.DecimalSI),
 						Memory:    *resource.NewScaledQuantity(20, resource.Giga),
 						Instances: 3,

--- a/operators/pkg/forge/rolebinding.go
+++ b/operators/pkg/forge/rolebinding.go
@@ -20,8 +20,8 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 )
 
 // ConfigureWorkspaceUserViewTemplatesBinding configures a RoleBinding for a workspace user to view templates.
-func ConfigureWorkspaceUserViewTemplatesBinding(ws *v1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
+func ConfigureWorkspaceUserViewTemplatesBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
@@ -54,14 +54,14 @@ func ConfigureWorkspaceUserViewTemplatesBinding(ws *v1alpha1.Workspace, rb *rbac
 	rb.Subjects = []rbacv1.Subject{
 		{
 			Kind:     rbacv1.GroupKind,
-			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, v1alpha2.User)),
+			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, clv1alpha2.User)),
 			APIGroup: rbacv1.GroupName,
 		},
 	}
 }
 
 // ConfigureWorkspaceManagerManageTemplatesBinding configures a RoleBinding for a workspace manager to manage templates.
-func ConfigureWorkspaceManagerManageTemplatesBinding(ws *v1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
+func ConfigureWorkspaceManagerManageTemplatesBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
@@ -81,14 +81,14 @@ func ConfigureWorkspaceManagerManageTemplatesBinding(ws *v1alpha1.Workspace, rb 
 	rb.Subjects = []rbacv1.Subject{
 		{
 			Kind:     rbacv1.GroupKind,
-			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, v1alpha2.Manager)),
+			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, clv1alpha2.Manager)),
 			APIGroup: rbacv1.GroupName,
 		},
 	}
 }
 
 // ConfigureWorkspaceManagerManageSharedVolumesBinding configures a RoleBinding for a workspace manager to manage shared volumes.
-func ConfigureWorkspaceManagerManageSharedVolumesBinding(ws *v1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
+func ConfigureWorkspaceManagerManageSharedVolumesBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
@@ -106,14 +106,14 @@ func ConfigureWorkspaceManagerManageSharedVolumesBinding(ws *v1alpha1.Workspace,
 	rb.Subjects = []rbacv1.Subject{
 		{
 			Kind:     rbacv1.GroupKind,
-			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, v1alpha2.Manager)),
+			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, clv1alpha2.Manager)),
 			APIGroup: rbacv1.GroupName,
 		},
 	}
 }
 
 // ConfigurePersonalWorkspaceManageTemplatesBinding configures a RoleBinding for a tenant to manage templates.
-func ConfigurePersonalWorkspaceManageTemplatesBinding(tn *v1alpha2.Tenant, rb *rbacv1.RoleBinding, labels map[string]string) {
+func ConfigurePersonalWorkspaceManageTemplatesBinding(tn *clv1alpha2.Tenant, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set the labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)

--- a/operators/pkg/forge/rolebinding_test.go
+++ b/operators/pkg/forge/rolebinding_test.go
@@ -20,33 +20,33 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
 var _ = Describe("RoleBinding forging", func() {
 	var (
-		tenant    *v1alpha2.Tenant
-		workspace *v1alpha1.Workspace
+		tenant    *clv1alpha2.Tenant
+		workspace *clv1alpha1.Workspace
 		labels    map[string]string
 	)
 
 	BeforeEach(func() {
-		tenant = &v1alpha2.Tenant{
+		tenant = &clv1alpha2.Tenant{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-tenant",
 			},
-			Spec: v1alpha2.TenantSpec{
+			Spec: clv1alpha2.TenantSpec{
 				FirstName: "Test",
 				LastName:  "Tenant",
 			},
 		}
-		workspace = &v1alpha1.Workspace{
+		workspace = &clv1alpha1.Workspace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-workspace",
 			},
-			Spec: v1alpha1.WorkspaceSpec{
+			Spec: clv1alpha1.WorkspaceSpec{
 				PrettyName: "Test Workspace",
 			},
 		}

--- a/operators/pkg/forge/storage.go
+++ b/operators/pkg/forge/storage.go
@@ -29,7 +29,7 @@ import (
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 const (
@@ -227,7 +227,7 @@ func MirrorPVCSpec(origin *corev1.PersistentVolumeClaim, mirrorStorageClassName 
 }
 
 // UpdateMyDriveMirrorPVCLabels updates the labels for a Mirror PVC of a MyDrive.
-func UpdateMyDriveMirrorPVCLabels(labels map[string]string, targetLabel common.KVLabel) map[string]string {
+func UpdateMyDriveMirrorPVCLabels(labels map[string]string, targetLabel ctrlcommon.KVLabel) map[string]string {
 	labels = UpdateTenantResourceCommonLabels(labels, targetLabel)
 	labels[LabelVolumeTypeKey] = VolumeTypeValueMirror
 

--- a/operators/pkg/forge/storage_test.go
+++ b/operators/pkg/forge/storage_test.go
@@ -32,7 +32,7 @@ import (
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -501,7 +501,7 @@ var _ = Describe("External Volume Mounts and Provisioning Job forging", func() {
 	})
 
 	Describe("UpdateMyDriveMirrorPVCLabels", func() {
-		targetLabel := common.NewLabel(targetLabelKey, "test")
+		targetLabel := ctrlcommon.NewLabel(targetLabelKey, "test")
 
 		It("Should initialize labels if nil and set the right label", func() {
 			var labels map[string]string

--- a/operators/pkg/forge/tenant.go
+++ b/operators/pkg/forge/tenant.go
@@ -24,18 +24,18 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	commonapi "github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 // GetWorkspaceTargetLabel returns the label key for identifying tenants with a specific workspace.
 func GetWorkspaceTargetLabel(workspaceName string) string {
-	return fmt.Sprintf("%s%s", v1alpha2.WorkspaceLabelPrefix, workspaceName)
+	return fmt.Sprintf("%s%s", clv1alpha2.WorkspaceLabelPrefix, workspaceName)
 }
 
 // UpdateTenantResourceCommonLabels updates the common labels for resources managed by the tenant controller.
-func UpdateTenantResourceCommonLabels(labels map[string]string, targetLabel common.KVLabel) map[string]string {
+func UpdateTenantResourceCommonLabels(labels map[string]string, targetLabel ctrlcommon.KVLabel) map[string]string {
 	if labels == nil {
 		labels = make(map[string]string, 1)
 	}
@@ -78,7 +78,7 @@ func CleanTenantName(name string) string {
 }
 
 // ConfigureTenantResourceQuota configures a ResourceQuota for a tenant namespace.
-func ConfigureTenantResourceQuota(rq *corev1.ResourceQuota, quota *commonapi.WorkspaceResourceQuota, labels map[string]string) {
+func ConfigureTenantResourceQuota(rq *corev1.ResourceQuota, quota *apicommon.WorkspaceResourceQuota, labels map[string]string) {
 	// Set the labels
 	if rq.Labels == nil {
 		rq.Labels = make(map[string]string)

--- a/operators/pkg/forge/tenant_test.go
+++ b/operators/pkg/forge/tenant_test.go
@@ -23,9 +23,9 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	commonapi "github.com/netgroup-polito/CrownLabs/operators/api/common"
-	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	apicommon "github.com/netgroup-polito/CrownLabs/operators/api/common"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 )
 
@@ -48,7 +48,7 @@ var _ = Describe("Tenant forging", func() {
 
 		It("Should prepend the workspace label prefix correctly", func() {
 			// Verify we're using the correct prefix from the v1alpha2 package
-			Expect(v1alpha2.WorkspaceLabelPrefix).To(Equal("crownlabs.polito.it/workspace-"))
+			Expect(clv1alpha2.WorkspaceLabelPrefix).To(Equal("crownlabs.polito.it/workspace-"))
 
 			workspaceName := "demo"
 			expectedLabel := "crownlabs.polito.it/workspace-demo"
@@ -104,7 +104,7 @@ var _ = Describe("Tenant forging", func() {
 	var _ = Describe("ConfigureTenantResourceQuota", func() {
 		It("Should initialize labels if nil and set quota spec", func() {
 			rq := &corev1.ResourceQuota{}
-			quota := &commonapi.WorkspaceResourceQuota{}
+			quota := &apicommon.WorkspaceResourceQuota{}
 			labels := map[string]string{
 				"custom-label": "custom-value",
 			}
@@ -125,7 +125,7 @@ var _ = Describe("Tenant forging", func() {
 				},
 			}
 
-			quota := &commonapi.WorkspaceResourceQuota{}
+			quota := &apicommon.WorkspaceResourceQuota{}
 			labels := map[string]string{
 				"custom-label": "custom-value",
 			}
@@ -218,7 +218,7 @@ var _ = Describe("Tenant forging", func() {
 				"existing-label": "existing-value",
 			}
 
-			targetLabel := common.NewLabel("test-key", "test-value")
+			targetLabel := ctrlcommon.NewLabel("test-key", "test-value")
 
 			resultLabels := forge.UpdateTenantResourceCommonLabels(inputLabels, targetLabel)
 
@@ -231,7 +231,7 @@ var _ = Describe("Tenant forging", func() {
 		It("Should initialize labels map when nil", func() {
 			var inputLabels map[string]string
 
-			targetLabel := common.NewLabel("test-key", "test-value")
+			targetLabel := ctrlcommon.NewLabel("test-key", "test-value")
 
 			resultLabels := forge.UpdateTenantResourceCommonLabels(inputLabels, targetLabel)
 

--- a/operators/pkg/imagelist/savers.go
+++ b/operators/pkg/imagelist/savers.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +70,7 @@ func (s *DefaultImageListSaver) CreateOrUpdateImageList(registryName string, ima
 	key := types.NamespacedName{Name: s.name}
 	err := s.client.Get(s.ctx, key, imageList)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			// Create new ImageList
 			newList := &clv1alpha1.ImageList{
 				ObjectMeta: metav1.ObjectMeta{

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"fmt"
 
-	batch "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	batchv1 "k8s.io/api/batch/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
@@ -63,7 +63,7 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		defer r.ReconcileDeferHook()
 	}
 
-	isnap := &crownlabsv1alpha2.InstanceSnapshot{}
+	isnap := &clv1alpha2.InstanceSnapshot{}
 
 	if err := r.Get(ctx, req.NamespacedName, isnap); client.IgnoreNotFound(err) != nil {
 		klog.Errorf("Error when getting InstanceSnapshot %s before starting reconcile -> %s", isnap.Name, err)
@@ -88,11 +88,11 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Check the current status of the InstanceSnapshot by checking
 	// the state of its assigned job.
 	jobName := forge.NamespacedNameFromObject(isnap)
-	found := &batch.Job{}
+	found := &batchv1.Job{}
 	err := r.Get(ctx, jobName, found)
 
 	switch {
-	case err != nil && errors.IsNotFound(err):
+	case err != nil && kerrors.IsNotFound(err):
 		if retry, err1 := r.CreateSnapshottingJob(ctx, isnap); err1 != nil {
 			klog.Error(err1)
 			// Check if we need to try again with the creation of the job
@@ -117,7 +117,7 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 			klog.Error(err1)
 			return ctrl.Result{}, err1
-		case jstatus == batch.JobComplete:
+		case jstatus == batchv1.JobComplete:
 
 			successMessage := fmt.Sprintf("Image %s created and uploaded", isnap.Spec.ImageName)
 			// If we are able to retrieve the execution time, report it
@@ -127,7 +127,7 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			}
 			klog.Info(successMessage)
 			r.EventsRecorder.Event(isnap, "Normal", "Created", successMessage)
-		case jstatus == batch.JobFailed:
+		case jstatus == batchv1.JobFailed:
 
 			klog.Infof("Image %s could not be created", isnap.Spec.ImageName)
 			r.EventsRecorder.Event(isnap, "Warning", "CreationFailed", "The creation job failed")
@@ -141,8 +141,8 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 func (r *InstanceSnapshotReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		// The generation changed predicate allow to avoid updates on the status changes of the InstanceSnapshot
-		For(&crownlabsv1alpha2.InstanceSnapshot{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Owns(&batch.Job{}).
+		For(&clv1alpha2.InstanceSnapshot{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Owns(&batchv1.Job{}).
 		WithLogConstructor(utils.LogConstructor(mgr.GetLogger(), "InstanceSnapshot")).
 		Complete(r)
 }

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_suite_test.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	instancesnapshot_controller "github.com/netgroup-polito/CrownLabs/operators/pkg/instancesnapshot-controller"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
 )
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = crownlabsv1alpha2.AddToScheme(scheme.Scheme)
+	err = clv1alpha2.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_test.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_test.go
@@ -22,8 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	batch "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +47,7 @@ var _ = Describe("InstancesnapshotController", func() {
 	)
 
 	var (
-		workingNs = v1.Namespace{
+		workingNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: WorkingNamespace,
@@ -55,8 +55,8 @@ var _ = Describe("InstancesnapshotController", func() {
 					"test-suite": "true",
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
 		templateEnvironment = crownlabsv1alpha2.TemplateSpec{
 			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
@@ -141,7 +141,7 @@ var _ = Describe("InstancesnapshotController", func() {
 		}
 
 		By("By checking that the namespace has been created")
-		createdNs := &v1.Namespace{}
+		createdNs := &corev1.Namespace{}
 
 		nsLookupKey := types.NamespacedName{Name: WorkingNamespace}
 		doesEventuallyExists(ctx, nsLookupKey, createdNs, BeTrue(), timeout, interval)
@@ -173,11 +173,11 @@ var _ = Describe("InstancesnapshotController", func() {
 
 			By("Changing the job status to completed and set Job start and end time")
 			jobLookupKey := types.NamespacedName{Name: newInstanceSnapshot.Name, Namespace: WorkingNamespace}
-			snapjob := &batch.Job{}
+			snapjob := &batchv1.Job{}
 			Expect(k8sClient.Get(ctx, jobLookupKey, snapjob)).Should(Succeed())
-			snapjob.Status.Conditions = []batch.JobCondition{
-				{Type: batch.JobComplete, Status: v1.ConditionTrue},
-				{Type: batch.JobSuccessCriteriaMet, Status: v1.ConditionTrue},
+			snapjob.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+				{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue},
 			}
 			snapjob.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 			snapjob.Status.StartTime = &metav1.Time{Time: time.Now().Add(-4 * time.Minute)}
@@ -195,11 +195,11 @@ var _ = Describe("InstancesnapshotController", func() {
 
 			By("Changing the job status to completed without setting Job start and end time")
 			jobLookupKey := types.NamespacedName{Name: newInstanceSnapshot.Name, Namespace: WorkingNamespace}
-			snapjob := &batch.Job{}
+			snapjob := &batchv1.Job{}
 			Expect(k8sClient.Get(ctx, jobLookupKey, snapjob)).Should(Succeed())
-			snapjob.Status.Conditions = []batch.JobCondition{
-				{Type: batch.JobComplete, Status: v1.ConditionTrue},
-				{Type: batch.JobSuccessCriteriaMet, Status: v1.ConditionTrue},
+			snapjob.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+				{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue},
 			}
 			snapjob.Status.StartTime = &metav1.Time{Time: time.Now()}
 			snapjob.Status.CompletionTime = &metav1.Time{Time: time.Now()}
@@ -288,11 +288,11 @@ var _ = Describe("InstancesnapshotController", func() {
 
 			By("Changing the job status to failed")
 			jobLookupKey := types.NamespacedName{Name: newInstanceSnapshot.Name, Namespace: WorkingNamespace}
-			snapjob := &batch.Job{}
+			snapjob := &batchv1.Job{}
 			Expect(k8sClient.Get(ctx, jobLookupKey, snapjob)).Should(Succeed())
-			snapjob.Status.Conditions = []batch.JobCondition{
-				{Type: batch.JobFailed, Status: v1.ConditionTrue},
-				{Type: batch.JobFailureTarget, Status: v1.ConditionTrue},
+			snapjob.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue},
+				{Type: batchv1.JobFailureTarget, Status: corev1.ConditionTrue},
 			}
 			snapjob.Status.StartTime = &metav1.Time{Time: time.Now()}
 			Expect(k8sClient.Status().Update(ctx, snapjob)).Should(Succeed())
@@ -327,7 +327,7 @@ func checkIsnapSuccessfulCreation(ctx context.Context, isnap *crownlabsv1alpha2.
 
 	By("Checking if the job for the creation of the snapshot has been created")
 	jobLookupKey := types.NamespacedName{Name: isnap.Name, Namespace: workingNamespace}
-	createdJob := &batch.Job{}
+	createdJob := &batchv1.Job{}
 
 	doesEventuallyExists(ctx, jobLookupKey, createdJob, BeTrue(), timeout, interval)
 

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_test.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller_test.go
@@ -24,13 +24,13 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 var _ = Describe("InstancesnapshotController", func() {
@@ -58,20 +58,20 @@ var _ = Describe("InstancesnapshotController", func() {
 			Spec:   corev1.NamespaceSpec{},
 			Status: corev1.NamespaceStatus{},
 		}
-		templateEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templateEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      true,
 					Image:           "crownlabs/vm",
 				},
@@ -79,42 +79,42 @@ var _ = Describe("InstancesnapshotController", func() {
 			DeleteAfter:       "",
 			InactivityTimeout: "",
 		}
-		template = crownlabsv1alpha2.Template{
+		template = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      TemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templateEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		instance = crownlabsv1alpha2.Instance{
+		instance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      InstanceName,
 				Namespace: WorkingNamespace,
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: false,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      TemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name: TenantName,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		instanceSnapshot = crownlabsv1alpha2.InstanceSnapshot{
+		instanceSnapshot = clv1alpha2.InstanceSnapshot{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      InstanceSnapshotName,
 				Namespace: WorkingNamespace,
 			},
-			Spec: crownlabsv1alpha2.InstanceSnapshotSpec{
-				Instance: crownlabsv1alpha2.GenericRef{
+			Spec: clv1alpha2.InstanceSnapshotSpec{
+				Instance: clv1alpha2.GenericRef{
 					Name:      InstanceName,
 					Namespace: WorkingNamespace,
 				},
@@ -130,7 +130,7 @@ var _ = Describe("InstancesnapshotController", func() {
 		newInstance := instance.DeepCopy()
 		By("Creating the namespace where to create instance and template")
 		err := k8sClient.Create(ctx, newNs)
-		if err != nil && errors.IsAlreadyExists(err) {
+		if err != nil && kerrors.IsAlreadyExists(err) {
 			By("Cleaning up the environment")
 			By("Deleting template")
 			Expect(k8sClient.Delete(ctx, &template)).Should(Succeed())
@@ -151,7 +151,7 @@ var _ = Describe("InstancesnapshotController", func() {
 
 		By("By checking that the template has been created")
 		templateLookupKey := types.NamespacedName{Name: TemplateName, Namespace: WorkingNamespace}
-		createdTemplate := &crownlabsv1alpha2.Template{}
+		createdTemplate := &clv1alpha2.Template{}
 
 		doesEventuallyExists(ctx, templateLookupKey, createdTemplate, BeTrue(), timeout, interval)
 
@@ -160,7 +160,7 @@ var _ = Describe("InstancesnapshotController", func() {
 
 		By("Checking that the instance has been created")
 		instanceLookupKey := types.NamespacedName{Name: InstanceName, Namespace: WorkingNamespace}
-		createdInstance := &crownlabsv1alpha2.Instance{}
+		createdInstance := &clv1alpha2.Instance{}
 
 		doesEventuallyExists(ctx, instanceLookupKey, createdInstance, BeTrue(), timeout, interval)
 	})
@@ -184,7 +184,7 @@ var _ = Describe("InstancesnapshotController", func() {
 			Expect(k8sClient.Status().Update(ctx, snapjob)).Should(Succeed())
 
 			By("Checking if the InstanceSnapshot status is Completed")
-			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, crownlabsv1alpha2.Completed, timeout, interval)
+			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, clv1alpha2.Completed, timeout, interval)
 		})
 
 		It("Should start snapshot creation given an environment name", func() {
@@ -206,14 +206,14 @@ var _ = Describe("InstancesnapshotController", func() {
 			Expect(k8sClient.Status().Update(ctx, snapjob)).Should(Succeed())
 
 			By("Checking if the InstanceSnapshot status is Completed")
-			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, crownlabsv1alpha2.Completed, timeout, interval)
+			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, clv1alpha2.Completed, timeout, interval)
 		})
 	})
 
 	Context("Testing incorrect environment configurations", func() {
 		It("Should fail: the VM is running", func() {
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: InstanceName, Namespace: WorkingNamespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
@@ -228,7 +228,7 @@ var _ = Describe("InstancesnapshotController", func() {
 
 		It("Should fail: vm is not persistent", func() {
 			By("Getting current Template")
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			templateLookupKey := types.NamespacedName{Name: TemplateName, Namespace: WorkingNamespace}
 			Expect(k8sClient.Get(ctx, templateLookupKey, currentTemplate)).Should(Succeed())
 
@@ -243,12 +243,12 @@ var _ = Describe("InstancesnapshotController", func() {
 
 		It("Should fail: environment is a standalone", func() {
 			By("Getting current Template")
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			templateLookupKey := types.NamespacedName{Name: TemplateName, Namespace: WorkingNamespace}
 			Expect(k8sClient.Get(ctx, templateLookupKey, currentTemplate)).Should(Succeed())
 
 			By("Setting environment as Standalone")
-			currentTemplate.Spec.EnvironmentList[0].EnvironmentType = crownlabsv1alpha2.ClassStandalone
+			currentTemplate.Spec.EnvironmentList[0].EnvironmentType = clv1alpha2.ClassStandalone
 			Expect(k8sClient.Update(ctx, currentTemplate)).Should(Succeed())
 
 			newInstanceSnapshot := instanceSnapshot.DeepCopy()
@@ -258,7 +258,7 @@ var _ = Describe("InstancesnapshotController", func() {
 
 		It("Should fail: template does not exist", func() {
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: InstanceName, Namespace: WorkingNamespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
@@ -298,15 +298,15 @@ var _ = Describe("InstancesnapshotController", func() {
 			Expect(k8sClient.Status().Update(ctx, snapjob)).Should(Succeed())
 
 			By("Checking if the InstanceSnapshot status is Failed")
-			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, crownlabsv1alpha2.Failed, timeout, interval)
+			checkIsnapStatus(ctx, newInstanceSnapshot.Name, WorkingNamespace, clv1alpha2.Failed, timeout, interval)
 		})
 	})
 })
 
-func checkIsnapStatus(ctx context.Context, isnapName, workingNamespace string, desiredStatus crownlabsv1alpha2.SnapshotStatus, timeout, interval time.Duration) {
+func checkIsnapStatus(ctx context.Context, isnapName, workingNamespace string, desiredStatus clv1alpha2.SnapshotStatus, timeout, interval time.Duration) {
 	isnapLookupKey := types.NamespacedName{Name: isnapName, Namespace: workingNamespace}
-	retrievedIsnap := &crownlabsv1alpha2.InstanceSnapshot{}
-	Eventually(func() crownlabsv1alpha2.SnapshotStatus {
+	retrievedIsnap := &clv1alpha2.InstanceSnapshot{}
+	Eventually(func() clv1alpha2.SnapshotStatus {
 		err := k8sClient.Get(ctx, isnapLookupKey, retrievedIsnap)
 		if err != nil {
 			return ""
@@ -315,13 +315,13 @@ func checkIsnapStatus(ctx context.Context, isnapName, workingNamespace string, d
 	}, timeout, interval).Should(Equal(desiredStatus))
 }
 
-func checkIsnapSuccessfulCreation(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot, workingNamespace string, timeout, interval time.Duration) {
+func checkIsnapSuccessfulCreation(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot, workingNamespace string, timeout, interval time.Duration) {
 	By("Creating the InstanceSnapshot resource")
 	Expect(k8sClient.Create(ctx, isnap)).Should(Succeed())
 
 	By("Checking that the instance snapshot has been created")
 	instanceSnapshotLookupKey := types.NamespacedName{Name: isnap.Name, Namespace: workingNamespace}
-	createdInstanceSnapshot := &crownlabsv1alpha2.InstanceSnapshot{}
+	createdInstanceSnapshot := &clv1alpha2.InstanceSnapshot{}
 
 	doesEventuallyExists(ctx, instanceSnapshotLookupKey, createdInstanceSnapshot, BeTrue(), timeout, interval)
 
@@ -337,16 +337,16 @@ func checkIsnapSuccessfulCreation(ctx context.Context, isnap *crownlabsv1alpha2.
 	})))
 }
 
-func checkIsnapCreationFailure(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot, workingNamespace string, timeout, interval time.Duration) {
+func checkIsnapCreationFailure(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot, workingNamespace string, timeout, interval time.Duration) {
 	By("Creating the InstanceSnapshot resource")
 	Expect(k8sClient.Create(ctx, isnap)).Should(Succeed())
 
 	By("Checking that the instance has been created")
 	instanceSnapshotLookupKey := types.NamespacedName{Name: isnap.Name, Namespace: workingNamespace}
-	createdInstanceSnapshot := &crownlabsv1alpha2.InstanceSnapshot{}
+	createdInstanceSnapshot := &clv1alpha2.InstanceSnapshot{}
 
 	doesEventuallyExists(ctx, instanceSnapshotLookupKey, createdInstanceSnapshot, BeTrue(), timeout, interval)
 
 	By("Checking that the InstanceSnapshot failed")
-	checkIsnapStatus(ctx, isnap.Name, workingNamespace, crownlabsv1alpha2.Failed, timeout, interval)
+	checkIsnapStatus(ctx, isnap.Name, workingNamespace, clv1alpha2.Failed, timeout, interval)
 }

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
@@ -20,24 +20,24 @@ import (
 	"strings"
 	"time"
 
-	batch "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 // ValidateRequest validates the InstanceSnapshot request, returns an error and if there's the need to try again.
-func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot) (bool, error) {
+func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot) (bool, error) {
 	// First it is needed to check if the instance actually exists.
 	instanceName := forge.NamespacedNameFromGenericRef(isnap.Spec.Instance)
-	instance := &crownlabsv1alpha2.Instance{}
+	instance := &clv1alpha2.Instance{}
 
-	if err := r.Get(ctx, instanceName, instance); err != nil && errors.IsNotFound(err) {
+	if err := r.Get(ctx, instanceName, instance); err != nil && kerrors.IsNotFound(err) {
 		// The declared instance does not exist so don't try again.
 		return false, fmt.Errorf("instance %s not found in namespace %s. It is not possible to complete the InstanceSnapshot %s",
 			instanceName.Name, instanceName.Namespace, isnap.Name)
@@ -51,9 +51,9 @@ func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap 
 	// - the environment is a persistent vm and not a container.
 
 	templateName := forge.NamespacedNameFromGenericRef(instance.Spec.Template)
-	template := &crownlabsv1alpha2.Template{}
+	template := &clv1alpha2.Template{}
 
-	if err := r.Get(ctx, templateName, template); err != nil && errors.IsNotFound(err) {
+	if err := r.Get(ctx, templateName, template); err != nil && kerrors.IsNotFound(err) {
 		// The declared template does not exist set the phase as failed and don't try again.
 		return false, fmt.Errorf("template %s not found in namespace %s. It is not possible to complete the InstanceSnapshot %s",
 			templateName.Name, templateName.Namespace, isnap.Name)
@@ -62,7 +62,7 @@ func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap 
 	}
 
 	// Retrieve the environment from the template.
-	var env *crownlabsv1alpha2.Environment
+	var env *clv1alpha2.Environment
 
 	if isnap.Spec.Environment.Name != "" {
 		for i := range template.Spec.EnvironmentList {
@@ -83,7 +83,7 @@ func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap 
 	}
 
 	// Check if the environment is a persistent VM.
-	if (env.EnvironmentType != crownlabsv1alpha2.ClassVM && env.EnvironmentType != crownlabsv1alpha2.ClassCloudVM) || !env.Persistent {
+	if (env.EnvironmentType != clv1alpha2.ClassVM && env.EnvironmentType != clv1alpha2.ClassCloudVM) || !env.Persistent {
 		return false, fmt.Errorf("environment %s is not a persistent VM. It is not possible to complete the InstanceSnapshot %s",
 			env.Name, isnap.Name)
 	}
@@ -97,10 +97,10 @@ func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap 
 }
 
 // GetJobStatus sets a Job and returns its status.
-func (r *InstanceSnapshotReconciler) GetJobStatus(job *batch.Job) (bool, batch.JobConditionType) {
+func (r *InstanceSnapshotReconciler) GetJobStatus(job *batchv1.Job) (bool, batchv1.JobConditionType) {
 	for _, c := range job.Status.Conditions {
 		// If the status corresponding to Success or failed is true, it means that the job completed.
-		if c.Status == corev1.ConditionTrue && (c.Type == batch.JobFailed || c.Type == batch.JobComplete) {
+		if c.Status == corev1.ConditionTrue && (c.Type == batchv1.JobFailed || c.Type == batchv1.JobComplete) {
 			return true, c.Type
 		}
 	}
@@ -110,13 +110,13 @@ func (r *InstanceSnapshotReconciler) GetJobStatus(job *batch.Job) (bool, batch.J
 }
 
 // CreateSnapshottingJobDefinition generates the job to be created.
-func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot) (batch.Job, error) {
+func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot) (batchv1.Job, error) {
 	// Get the tenant name in order to set it as directory of the image
 	instanceName := forge.NamespacedNameFromGenericRef(isnap.Spec.Instance)
-	instance := &crownlabsv1alpha2.Instance{}
+	instance := &clv1alpha2.Instance{}
 
 	if err := r.Get(ctx, instanceName, instance); err != nil {
-		return batch.Job{}, fmt.Errorf("error in retrieving the instance for InstanceSnapshot %s -> %w", isnap.Name, err)
+		return batchv1.Job{}, fmt.Errorf("error in retrieving the instance for InstanceSnapshot %s -> %w", isnap.Name, err)
 	}
 
 	var backoff int32 = 2
@@ -223,12 +223,12 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context
 		},
 	}
 
-	snapjob := batch.Job{
+	snapjob := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isnap.Name,
 			Namespace: isnap.Namespace,
 		},
-		Spec: batch.JobSpec{
+		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoff,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_logic.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_logic.go
@@ -18,17 +18,17 @@ import (
 	"context"
 	"fmt"
 
-	batch "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 )
 
 // CreateSnapshottingJob creates the job in charge of creating the snapshot.
-func (r *InstanceSnapshotReconciler) CreateSnapshottingJob(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot) (bool, error) {
+func (r *InstanceSnapshotReconciler) CreateSnapshottingJob(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot) (bool, error) {
 	r.EventsRecorder.Event(isnap, "Normal", "Validating", "Start validation of the request")
 
-	isnap.Status.Phase = crownlabsv1alpha2.Pending
+	isnap.Status.Phase = clv1alpha2.Pending
 	if err := r.Status().Update(ctx, isnap); err != nil {
 		return true, fmt.Errorf("error when updating status of InstanceSnapshot %s -> %w", isnap.Name, err)
 	}
@@ -41,7 +41,7 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJob(ctx context.Context, 
 		}
 
 		// Set the status as failed
-		isnap.Status.Phase = crownlabsv1alpha2.Failed
+		isnap.Status.Phase = clv1alpha2.Failed
 		if uerr := r.Status().Update(ctx, isnap); uerr != nil {
 			return true, fmt.Errorf("error when updating status of InstanceSnapshot %s -> %w", isnap.Name, uerr)
 		}
@@ -65,7 +65,7 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJob(ctx context.Context, 
 		return true, fmt.Errorf("error when creating the job for %s -> %w", isnap.Name, err)
 	}
 
-	isnap.Status.Phase = crownlabsv1alpha2.Processing
+	isnap.Status.Phase = clv1alpha2.Processing
 	if err := r.Status().Update(ctx, isnap); err != nil {
 		return true, fmt.Errorf("error when updating status of InstanceSnapshot %s -> %w", isnap.Name, err)
 	}
@@ -74,18 +74,18 @@ func (r *InstanceSnapshotReconciler) CreateSnapshottingJob(ctx context.Context, 
 }
 
 // HandleExistingJob checks the status of the existing job and updates the status of the InstanceSnapshot accordingly.
-func (r *InstanceSnapshotReconciler) HandleExistingJob(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot, snapjob *batch.Job) (batch.JobConditionType, error) {
+func (r *InstanceSnapshotReconciler) HandleExistingJob(ctx context.Context, isnap *clv1alpha2.InstanceSnapshot, snapjob *batchv1.Job) (batchv1.JobConditionType, error) {
 	completed, jstatus := r.GetJobStatus(snapjob)
 	if completed {
-		if jstatus == batch.JobComplete {
+		if jstatus == batchv1.JobComplete {
 			// The job is completed and the image has been uploaded to the registry
-			isnap.Status.Phase = crownlabsv1alpha2.Completed
+			isnap.Status.Phase = clv1alpha2.Completed
 			if err := r.Status().Update(ctx, isnap); err != nil {
 				return "", fmt.Errorf("error when updating status of InstanceSnapshot %s -> %w", isnap.Name, err)
 			}
 		} else {
 			// The creation of the snapshot failed since the job failed
-			isnap.Status.Phase = crownlabsv1alpha2.Failed
+			isnap.Status.Phase = clv1alpha2.Failed
 			if err := r.Status().Update(ctx, isnap); err != nil {
 				return "", fmt.Errorf("error when updating status of InstanceSnapshot %s -> %w", isnap.Name, err)
 			}

--- a/operators/pkg/instautoctrl/common.go
+++ b/operators/pkg/instautoctrl/common.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	pkgcontext "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
+	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/mail"
@@ -115,11 +115,11 @@ func sendNotification(ctx context.Context, mc *mail.Client, mailTemplatePath str
 		return fmt.Errorf("mail client is not configured")
 	}
 
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
-	tenant := pkgcontext.TenantFrom(ctx)
+	tenant := clctx.TenantFrom(ctx)
 	if tenant == nil {
 		return fmt.Errorf("tenant not found in context")
 	}
@@ -145,7 +145,7 @@ func sendNotification(ctx context.Context, mc *mail.Client, mailTemplatePath str
 // GetTenantFromInstance retrieves the Tenant object associated with the Instance.
 func GetTenantFromInstance(ctx context.Context, c client.Client) (*clv1alpha2.Tenant, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("get-user-from-instance")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return nil, fmt.Errorf("instance not found in context")
 	}

--- a/operators/pkg/instautoctrl/expiration.go
+++ b/operators/pkg/instautoctrl/expiration.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	pkgcontext "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
+	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/mail"
@@ -111,9 +111,9 @@ func (r *InstanceExpirationReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Get lifespan from template's deleteAfter field
 	deleteAfter := template.Spec.DeleteAfter
 
-	ctx, _ = pkgcontext.TemplateInto(ctx, template)
-	ctx, _ = pkgcontext.InstanceInto(ctx, instance)
-	ctx, _ = pkgcontext.TenantInto(ctx, tenant)
+	ctx, _ = clctx.TemplateInto(ctx, template)
+	ctx, _ = clctx.InstanceInto(ctx, instance)
+	ctx, _ = clctx.TenantInto(ctx, tenant)
 
 	// If the template's deleteAfter field is set to neverTimeoutValue , never delete
 	if deleteAfter == NeverTimeoutValue {
@@ -129,7 +129,7 @@ func (r *InstanceExpirationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	tracer.Step("expiration checked")
 	if remainingTime <= 0 {
-		tenant := pkgcontext.TenantFrom(ctx)
+		tenant := clctx.TenantFrom(ctx)
 		if tenant == nil {
 			return ctrl.Result{}, fmt.Errorf("tenant not found in context")
 		}
@@ -188,7 +188,7 @@ func (r *InstanceExpirationReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 // ShouldTerminateInstance checks if the instance should be terminated.
 func (r *InstanceExpirationReconciler) ShouldTerminateInstance(ctx context.Context) (bool, time.Duration, error) {
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return false, r.NotificationInterval, fmt.Errorf("instance not found in context")
 	}
@@ -221,7 +221,7 @@ func (r *InstanceExpirationReconciler) ShouldTerminateInstance(ctx context.Conte
 // CheckInstanceExpiration returns the remaining time before expiration as a time.Duration.
 func (r *InstanceExpirationReconciler) CheckInstanceExpiration(ctx context.Context, deleteAfter string) (time.Duration, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("get-remaining-time")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return 0, fmt.Errorf("instance not found in context")
 	}
@@ -245,7 +245,7 @@ func (r *InstanceExpirationReconciler) CheckInstanceExpiration(ctx context.Conte
 // DeleteInstance attempts to delete the instance.
 func (r *InstanceExpirationReconciler) DeleteInstance(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
@@ -265,12 +265,12 @@ func (r *InstanceExpirationReconciler) DeleteInstance(ctx context.Context) error
 // NotifyInstanceDeletion handles sending notification emails when an instance is deleted.
 func (r *InstanceExpirationReconciler) NotifyInstanceDeletion(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("notify-instance-deletion")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
 
-	tenant := pkgcontext.TenantFrom(ctx)
+	tenant := clctx.TenantFrom(ctx)
 	if tenant == nil {
 		return fmt.Errorf("tenant not found in context")
 	}
@@ -290,7 +290,7 @@ func (r *InstanceExpirationReconciler) NotifyInstanceDeletion(ctx context.Contex
 
 // ShouldSendWarningNotification checks if a warning notification should be sent for an expiring instance.
 func (r *InstanceExpirationReconciler) ShouldSendWarningNotification(ctx context.Context) (bool, error) {
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return false, fmt.Errorf("instance not found in context")
 	}

--- a/operators/pkg/instautoctrl/inactivity.go
+++ b/operators/pkg/instautoctrl/inactivity.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	pkgcontext "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
+	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/mail"
@@ -112,9 +112,9 @@ func (r *InstanceInactiveTerminationReconciler) Reconcile(ctx context.Context, r
 	tracer.Step("instance, template and tenant retrieved")
 
 	// Add the instance, template and tenant to the context
-	ctx, _ = pkgcontext.InstanceInto(ctx, instance)
-	ctx, _ = pkgcontext.TemplateInto(ctx, template)
-	ctx, _ = pkgcontext.TenantInto(ctx, tenant)
+	ctx, _ = clctx.InstanceInto(ctx, instance)
+	ctx, _ = clctx.TemplateInto(ctx, template)
+	ctx, _ = clctx.TenantInto(ctx, tenant)
 
 	inactivityTimeout := template.Spec.InactivityTimeout
 	// If set to neverTimeoutValue, return without rescheduling
@@ -219,7 +219,7 @@ func (r *InstanceInactiveTerminationReconciler) Reconcile(ctx context.Context, r
 // UpdateInstanceLastLogin updates the last login time of the instance in the annotations.
 func (r *InstanceInactiveTerminationReconciler) UpdateInstanceLastLogin(ctx context.Context, inactivityTimeoutDuration time.Duration) error {
 	log := ctrl.LoggerFrom(ctx).WithName("update-instance-last-login")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
@@ -288,7 +288,7 @@ func (r *InstanceInactiveTerminationReconciler) UpdateInstanceLastLogin(ctx cont
 // GetRemainingInactivityTime checks if the Instance has to be terminated.
 func (r *InstanceInactiveTerminationReconciler) GetRemainingInactivityTime(ctx context.Context, inactivityTimeoutDuration time.Duration) (time.Duration, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("check-instance-termination")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return 0, fmt.Errorf("instance not found in context")
 	}
@@ -314,7 +314,7 @@ func (r *InstanceInactiveTerminationReconciler) GetRemainingInactivityTime(ctx c
 func (r *InstanceInactiveTerminationReconciler) GetInactivityNotificationWindow(ctx context.Context, instance *clv1alpha2.Instance) (time.Duration, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("GetInactivityNotificationWindow")
 
-	template := pkgcontext.TemplateFrom(ctx)
+	template := clctx.TemplateFrom(ctx)
 
 	// Calculate the remaining number of alerts that should be sent
 	NumAlerts := r.InstanceMaxNumberOfAlerts
@@ -363,11 +363,11 @@ func IsTemplatePersistent(template *clv1alpha2.Template) bool {
 func (r *InstanceInactiveTerminationReconciler) TerminateInstance(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("termination")
 
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
-	template := pkgcontext.TemplateFrom(ctx)
+	template := clctx.TemplateFrom(ctx)
 	if template == nil {
 		return fmt.Errorf("template not found in context")
 	}
@@ -411,7 +411,7 @@ func (r *InstanceInactiveTerminationReconciler) IncrementAnnotation(ctx context.
 func (r *InstanceInactiveTerminationReconciler) SetupInstanceAnnotations(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("setup-instance-annotations")
 
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
@@ -496,7 +496,7 @@ func (r *InstanceInactiveTerminationReconciler) getAlertCounts(ctx context.Conte
 	}
 
 	maxAlerts = r.InstanceMaxNumberOfAlerts
-	template := pkgcontext.TemplateFrom(ctx)
+	template := clctx.TemplateFrom(ctx)
 	if template != nil {
 		// if the CustomNumberOfAlertsAnnotation is set, override the default max alerts
 		if customMaxAlertsStr, ok := template.Annotations[forge.CustomNumberOfAlertsAnnotation]; ok {
@@ -575,7 +575,7 @@ func (r *InstanceInactiveTerminationReconciler) ShouldSendWarningNotification(ct
 // SendInactivityWarning sends an inactivity warning email to the user and updates the instance annotations.
 func (r *InstanceInactiveTerminationReconciler) SendInactivityWarning(ctx context.Context, instance *clv1alpha2.Instance) error {
 	log := ctrl.LoggerFrom(ctx)
-	tenant := pkgcontext.TenantFrom(ctx)
+	tenant := clctx.TenantFrom(ctx)
 	if tenant == nil {
 		return fmt.Errorf("tenant not found in context")
 	}
@@ -617,12 +617,12 @@ func (r *InstanceInactiveTerminationReconciler) SendInactivityWarning(ctx contex
 // SendTerminationNotification handles sending notification emails when an instance is deleted.
 func (r *InstanceInactiveTerminationReconciler) SendTerminationNotification(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("send-termination-notification")
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}
 
-	tenant := pkgcontext.TenantFrom(ctx)
+	tenant := clctx.TenantFrom(ctx)
 	if tenant == nil {
 		return fmt.Errorf("tenant not found in context")
 	}
@@ -643,7 +643,7 @@ func (r *InstanceInactiveTerminationReconciler) SendTerminationNotification(ctx 
 func (r *InstanceInactiveTerminationReconciler) ResetAnnotations(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("reset-annotation")
 
-	instance := pkgcontext.InstanceFrom(ctx)
+	instance := clctx.InstanceFrom(ctx)
 	if instance == nil {
 		return fmt.Errorf("instance not found in context")
 	}

--- a/operators/pkg/instautoctrl/prometheus_utils.go
+++ b/operators/pkg/instautoctrl/prometheus_utils.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/api"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -38,7 +38,7 @@ type Prometheus struct {
 	queryBastionSSHData      string
 	queryWebSSHData          string
 	queryStep                time.Duration
-	client                   v1.API
+	client                   prometheusv1.API
 }
 
 // NewPrometheusObj creates a new Prometheus client with the given configuration.
@@ -54,7 +54,7 @@ func NewPrometheusObj(
 		return nil, err
 	}
 
-	v1api := v1.NewAPI(client)
+	v1api := prometheusv1.NewAPI(client)
 
 	return &Prometheus{
 		address:                  address,
@@ -140,7 +140,7 @@ func (p *Prometheus) GetLastActivityTime(query string, interval time.Duration) (
 	end := time.Now()
 	start := end.Add(-interval)
 
-	r := v1.Range{
+	r := prometheusv1.Range{
 		Start: start,
 		End:   end,
 		Step:  p.queryStep,

--- a/operators/pkg/instautoctrl/submission.go
+++ b/operators/pkg/instautoctrl/submission.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	batch "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,7 +52,7 @@ type InstanceSubmissionReconciler struct {
 func (r *InstanceSubmissionReconciler) SetupWithManager(mgr ctrl.Manager, concurrency int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&clv1alpha2.Instance{}).
-		Owns(&batch.Job{}).
+		Owns(&batchv1.Job{}).
 		Named("instance-submission").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: concurrency,
@@ -157,10 +157,10 @@ func (r *InstanceSubmissionReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 // EnforceInstanceSubmissionJob ensures that the submission job for the given instance is present.
-func (r *InstanceSubmissionReconciler) EnforceInstanceSubmissionJob(ctx context.Context, instance *clv1alpha2.Instance, environment *clv1alpha2.Environment) (jobStatus *batch.JobStatus, err error) {
+func (r *InstanceSubmissionReconciler) EnforceInstanceSubmissionJob(ctx context.Context, instance *clv1alpha2.Instance, environment *clv1alpha2.Environment) (jobStatus *batchv1.JobStatus, err error) {
 	// Get the submission job.
 	submitterName := "submitter"
-	job := batch.Job{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name+"-"+submitterName)}
+	job := batchv1.Job{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name+"-"+submitterName)}
 
 	jobSpec := forge.SubmissionJobSpec(instance, environment, &r.ContainerEnvOpts)
 

--- a/operators/pkg/instautoctrl/test_e2e/instautoctrl_expiration_test.go
+++ b/operators/pkg/instautoctrl/test_e2e/instautoctrl_expiration_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,7 +49,7 @@ var _ = Describe("Instautoctrl-expiration", func() {
 	)
 
 	var (
-		workingNs = v1.Namespace{
+		workingNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: WorkingNamespace,
@@ -57,8 +57,8 @@ var _ = Describe("Instautoctrl-expiration", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
 		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
 			WorkspaceRef: crownlabsv1alpha2.GenericRef{},

--- a/operators/pkg/instautoctrl/test_e2e/instautoctrl_expiration_test.go
+++ b/operators/pkg/instautoctrl/test_e2e/instautoctrl_expiration_test.go
@@ -22,13 +22,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 )
 
@@ -60,20 +60,20 @@ var _ = Describe("Instautoctrl-expiration", func() {
 			Spec:   corev1.NamespaceSpec{},
 			Status: corev1.NamespaceStatus{},
 		}
-		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      true,
 					Image:           "crownlabs/vm",
 				},
@@ -81,20 +81,20 @@ var _ = Describe("Instautoctrl-expiration", func() {
 			DeleteAfter:       CustomDeleteAfter,
 			InactivityTimeout: CustomInactivityTimeout,
 		}
-		templateNonPersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templateNonPersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -102,83 +102,83 @@ var _ = Describe("Instautoctrl-expiration", func() {
 			DeleteAfter:       CustomDeleteAfter2,
 			InactivityTimeout: CustomInactivityTimeout2,
 		}
-		persistentTemplate = crownlabsv1alpha2.Template{
+		persistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		nonPersistentTemplate = crownlabsv1alpha2.Template{
+		nonPersistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nonPersistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templateNonPersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
 
-		persistentInstance = crownlabsv1alpha2.Instance{
+		persistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName,
 				Namespace: WorkingNamespace,
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: false,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: WorkingNamespace,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
-		nonPersistentInstance = crownlabsv1alpha2.Instance{
+		nonPersistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NonPersistentInstanceName,
 				Namespace: WorkingNamespace,
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: false,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      nonPersistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name: TenantName,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		nonPersistentInstance2 = crownlabsv1alpha2.Instance{
+		nonPersistentInstance2 = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NonPersistentInstanceName2,
 				Namespace: WorkingNamespace,
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: false,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      nonPersistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name: TenantName,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		tenant = crownlabsv1alpha2.Tenant{
+		tenant = clv1alpha2.Tenant{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TenantName,
@@ -186,11 +186,11 @@ var _ = Describe("Instautoctrl-expiration", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec: crownlabsv1alpha2.TenantSpec{
+			Spec: clv1alpha2.TenantSpec{
 				FirstName: "John",
 				LastName:  "Doe",
 				Email:     "john@gmail.com",
-				Workspaces: []crownlabsv1alpha2.TenantWorkspaceEntry{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{
 					{Name: workingNs.Name,
 						Role: "user"},
 				},
@@ -229,7 +229,7 @@ var _ = Describe("Instautoctrl-expiration", func() {
 		newTenant := tenant.DeepCopy()
 		By("Creating the namespace where to create instance and template")
 		err := k8sClientExpiration.Create(ctx, newNs)
-		if err != nil && errors.IsAlreadyExists(err) {
+		if err != nil && kerrors.IsAlreadyExists(err) {
 			By("Cleaning up the environment")
 			By("Deleting templates")
 			Expect(k8sClientExpiration.Delete(ctx, &persistentTemplate)).Should(Succeed())
@@ -257,13 +257,13 @@ var _ = Describe("Instautoctrl-expiration", func() {
 	Context("Testing never deletion", func() {
 		It("Should succeed: the persistent VM is not deleted because it has a never deletion time", func() {
 			By("Checking that the persistent template has a never deletion time")
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			templateLookupKey := types.NamespacedName{Name: persistentTemplateName, Namespace: WorkingNamespace}
 			Expect(k8sClientExpiration.Get(ctx, templateLookupKey, currentTemplate)).Should(Succeed())
 			Expect(currentTemplate.Spec.DeleteAfter).To(Equal(instautoctrl.NeverTimeoutValue))
 		})
 		It("Should succeed: the persistent VM has a valid deletion time and should be deleted", func() {
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			templateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
 			Expect(k8sClientExpiration.Get(ctx, templateLookupKey, currentTemplate)).Should(Succeed())
 			Expect(currentTemplate.Spec.DeleteAfter).ToNot(Equal(CustomDeleteAfter))

--- a/operators/pkg/instautoctrl/test_e2e/instautoctrl_inactivity_test.go
+++ b/operators/pkg/instautoctrl/test_e2e/instautoctrl_inactivity_test.go
@@ -22,13 +22,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 )
 
@@ -78,39 +78,39 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 			Spec:   corev1.NamespaceSpec{},
 			Status: corev1.NamespaceStatus{},
 		}
-		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      true,
 					Image:           "crownlabs/vm",
 				},
 			},
 		}
-		templateNonPersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templateNonPersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -118,20 +118,20 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 			DeleteAfter:       CustomDeleteAfterNonPersistent,
 			InactivityTimeout: CustomInactivityTimeoutNonPersistent,
 		}
-		templatePersistentEnvironmentWithCustomInactivityTimeout = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironmentWithCustomInactivityTimeout = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -139,34 +139,34 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 			DeleteAfter:       CustomDeleteAfterPersistent2,
 			InactivityTimeout: CustomInactivityTimeoutPersistent2,
 		}
-		persistentTemplate2 = crownlabsv1alpha2.Template{
+		persistentTemplate2 = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName2,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironmentWithCustomInactivityTimeout,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		persistentTemplate = crownlabsv1alpha2.Template{
+		persistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		nonPersistentTemplate = crownlabsv1alpha2.Template{
+		nonPersistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nonPersistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templateNonPersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		persistentInstance2 = crownlabsv1alpha2.Instance{
+		persistentInstance2 = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName2,
@@ -179,21 +179,21 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName2,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		persistentInstance = crownlabsv1alpha2.Instance{
+		persistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName,
@@ -206,20 +206,20 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
-		nonPersistentInstance = crownlabsv1alpha2.Instance{
+		nonPersistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NonPersistentInstanceName,
@@ -232,21 +232,21 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      nonPersistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		tenant = crownlabsv1alpha2.Tenant{
+		tenant = clv1alpha2.Tenant{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      TenantName,
@@ -255,11 +255,11 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec: crownlabsv1alpha2.TenantSpec{
+			Spec: clv1alpha2.TenantSpec{
 				FirstName: "John",
 				LastName:  "Doe",
 				Email:     "john@gmail.com",
-				Workspaces: []crownlabsv1alpha2.TenantWorkspaceEntry{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{
 					{Name: workingNs.Name,
 						Role: "user"},
 				},
@@ -304,7 +304,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 		By("Creating the namespace where to create instance and template")
 		err1 := k8sClient.Create(ctx, tenNs)
 		err2 := k8sClient.Create(ctx, newNs)
-		if (err1 != nil || err2 != nil) && (errors.IsAlreadyExists(err1) || errors.IsAlreadyExists(err2)) {
+		if (err1 != nil || err2 != nil) && (kerrors.IsAlreadyExists(err1) || kerrors.IsAlreadyExists(err2)) {
 			By("Cleaning up the environment")
 			By("Deleting templates")
 			Expect(k8sClient.Delete(ctx, &persistentTemplate)).Should(Succeed())
@@ -329,9 +329,9 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 		persistentTemplateLookupKey := types.NamespacedName{Name: persistentTemplateName, Namespace: WorkingNamespace}
 		nonPersistentTemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
 		persistentTemplate2LookupKey := types.NamespacedName{Name: persistentTemplateName2, Namespace: WorkingNamespace}
-		createdPersitentTemplate := &crownlabsv1alpha2.Template{}
-		createdNonPersitentTemplate := &crownlabsv1alpha2.Template{}
-		createdPersistentTemplate2 := &crownlabsv1alpha2.Template{}
+		createdPersitentTemplate := &clv1alpha2.Template{}
+		createdNonPersitentTemplate := &clv1alpha2.Template{}
+		createdPersistentTemplate2 := &clv1alpha2.Template{}
 
 		doesEventuallyExists(ctx, persistentTemplateLookupKey, createdPersitentTemplate, BeTrue(), timeout, interval, k8sClient)
 		doesEventuallyExists(ctx, nonPersistentTemplateLookupKey, createdNonPersitentTemplate, BeTrue(), timeout, interval, k8sClient)
@@ -375,12 +375,12 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 				AnyTimes()
 
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: PersistentInstanceName, Namespace: tenant.Namespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
 			By("Getting current templates")
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 
 			templateLookupKey := types.NamespacedName{Name: currentInstance.Spec.Template.Name, Namespace: WorkingNamespace}
 			Expect(k8sClient.Get(ctx, templateLookupKey, currentTemplate)).Should(Succeed())
@@ -425,7 +425,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 				AnyTimes()
 
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenant.Namespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
@@ -466,7 +466,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 				AnyTimes()
 
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenant.Namespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
@@ -532,7 +532,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 				AnyTimes()
 
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: PersistentInstanceName, Namespace: tenant.Namespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 
@@ -572,7 +572,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 				AnyTimes()
 
 			By("Getting current instance")
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			instanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenant.Namespace}
 			Expect(k8sClient.Get(ctx, instanceLookupKey, currentInstance)).Should(Succeed())
 

--- a/operators/pkg/instautoctrl/test_e2e/instautoctrl_inactivity_test.go
+++ b/operators/pkg/instautoctrl/test_e2e/instautoctrl_inactivity_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +55,7 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 	)
 
 	var (
-		workingNs = v1.Namespace{
+		workingNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: WorkingNamespace,
@@ -63,10 +63,10 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
-		tenantNs = v1.Namespace{
+		tenantNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TenantName,
@@ -75,8 +75,8 @@ var _ = Describe("Instautoctrl-inactivity", func() {
 					"crownlabs.polito.it/tenant":            TenantName,
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
 		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
 			WorkspaceRef: crownlabsv1alpha2.GenericRef{},

--- a/operators/pkg/instautoctrl/test_e2e/instautoctrl_suite_test.go
+++ b/operators/pkg/instautoctrl/test_e2e/instautoctrl_suite_test.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl/mocks"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	Expect(crownlabsv1alpha2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(clv1alpha2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(virtv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(cdiv1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 

--- a/operators/pkg/instautoctrl/test_unit/instautoctrl_expiration_unit_test.go
+++ b/operators/pkg/instautoctrl/test_unit/instautoctrl_expiration_unit_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 	)
 
 	var (
-		workingNs = v1.Namespace{
+		workingNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: WorkingNamespace,
@@ -62,10 +62,10 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
-		tenantNs = v1.Namespace{
+		tenantNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TenantName,
@@ -74,8 +74,8 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 					"crownlabs.polito.it/tenant":            TenantName,
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
 		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
 			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
@@ -241,8 +241,8 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		}
 
 		By("By checking that the namespace has been created")
-		createdNs := &v1.Namespace{}
-		tenantNs := &v1.Namespace{}
+		createdNs := &corev1.Namespace{}
+		tenantNs := &corev1.Namespace{}
 
 		nsLookupKey := types.NamespacedName{Name: WorkingNamespace}
 		Expect(k8sClient.Get(ctx, nsLookupKey, createdNs)).To(Succeed())

--- a/operators/pkg/instautoctrl/test_unit/instautoctrl_expiration_unit_test.go
+++ b/operators/pkg/instautoctrl/test_unit/instautoctrl_expiration_unit_test.go
@@ -22,14 +22,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	pkgcontext "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 )
@@ -77,39 +77,39 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 			Spec:   corev1.NamespaceSpec{},
 			Status: corev1.NamespaceStatus{},
 		}
-		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      true,
 					Image:           "crownlabs/vm",
 				},
 			},
 		}
-		templateNonPersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templateNonPersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -118,26 +118,26 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 			InactivityTimeout: CustomInactivityTimeout2,
 		}
 
-		persistentTemplate = crownlabsv1alpha2.Template{
+		persistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		nonPersistentTemplate = crownlabsv1alpha2.Template{
+		nonPersistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nonPersistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templateNonPersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
 
-		persistentInstance = crownlabsv1alpha2.Instance{
+		persistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName,
@@ -150,20 +150,20 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
-		nonPersistentInstance = crownlabsv1alpha2.Instance{
+		nonPersistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NonPersistentInstanceName,
@@ -176,21 +176,21 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      nonPersistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		tenant = crownlabsv1alpha2.Tenant{
+		tenant = clv1alpha2.Tenant{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      TenantName,
@@ -199,11 +199,11 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec: crownlabsv1alpha2.TenantSpec{
+			Spec: clv1alpha2.TenantSpec{
 				FirstName: "John",
 				LastName:  "Doe",
 				Email:     "john@gmail.com",
-				Workspaces: []crownlabsv1alpha2.TenantWorkspaceEntry{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{
 					{Name: workingNs.Name,
 						Role: "user"},
 				},
@@ -234,7 +234,7 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		By("Creating the namespace where to create instance and template")
 		err1 := k8sClient.Create(ctx, newTenantNs)
 		err2 := k8sClient.Create(ctx, newWorkingNs)
-		if (err1 != nil || err2 != nil) && (errors.IsAlreadyExists(err1) || errors.IsAlreadyExists(err2)) {
+		if (err1 != nil || err2 != nil) && (kerrors.IsAlreadyExists(err1) || kerrors.IsAlreadyExists(err2)) {
 			cleanupEnvironment()
 		} else if err1 != nil || err2 != nil {
 			Fail(fmt.Sprintf("Unable to create namespace -> %s %s", err1, err2))
@@ -259,8 +259,8 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		By("By checking that the template has been created")
 		persistentTemplateLookupKey := types.NamespacedName{Name: persistentTemplateName, Namespace: WorkingNamespace}
 		nonPersistentTemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-		createdPersitentTemplate := &crownlabsv1alpha2.Template{}
-		createdNonPersitentTemplate := &crownlabsv1alpha2.Template{}
+		createdPersitentTemplate := &clv1alpha2.Template{}
+		createdNonPersitentTemplate := &clv1alpha2.Template{}
 
 		Expect(k8sClient.Get(ctx, persistentTemplateLookupKey, createdPersitentTemplate)).To(Succeed())
 		Expect(k8sClient.Get(ctx, nonPersistentTemplateLookupKey, createdNonPersitentTemplate)).To(Succeed())
@@ -272,8 +272,8 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		By("Checking that the instances has been created")
 		persistanteInstanceLookupKey := types.NamespacedName{Name: PersistentInstanceName, Namespace: tenant.Name}
 		nonPersistentInstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenant.Name}
-		createdPersistentInstance := &crownlabsv1alpha2.Instance{}
-		createdNonPersistentInstance := &crownlabsv1alpha2.Instance{}
+		createdPersistentInstance := &clv1alpha2.Instance{}
+		createdNonPersistentInstance := &clv1alpha2.Instance{}
 
 		Expect(k8sClient.Get(ctx, persistanteInstanceLookupKey, createdPersistentInstance)).To(Succeed())
 		Expect(k8sClient.Get(ctx, nonPersistentInstanceLookupKey, createdNonPersistentInstance)).To(Succeed())
@@ -286,18 +286,18 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		}
 		By("Checking that the instance is running")
 		InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-		currentInstance := &crownlabsv1alpha2.Instance{}
+		currentInstance := &clv1alpha2.Instance{}
 		Expect(k8sClient.Get(ctx, InstanceLookupKey, currentInstance)).To(Succeed())
 		TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-		currentTemplate := &crownlabsv1alpha2.Template{}
+		currentTemplate := &clv1alpha2.Template{}
 		Expect(k8sClient.Get(ctx, TemplateLookupKey, currentTemplate)).To(Succeed())
 		tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-		currentTenant := &crownlabsv1alpha2.Tenant{}
+		currentTenant := &clv1alpha2.Tenant{}
 		Expect(k8sClient.Get(ctx, tenantLookupKey, currentTenant)).To(Succeed())
 		ctx := context.Background()
-		ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-		ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-		ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+		ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+		ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+		ctx, _ = clctx.TenantInto(ctx, currentTenant)
 		remainingTime, err := r.CheckInstanceExpiration(ctx, currentTemplate.Spec.InactivityTimeout)
 		Expect(err).ToNot(HaveOccurred())
 		deleteAfterDuration, err := time.ParseDuration(CustomDeleteAfter2)
@@ -311,18 +311,18 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		}
 		By("Checking that the instance is running")
 		InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-		currentInstance := &crownlabsv1alpha2.Instance{}
+		currentInstance := &clv1alpha2.Instance{}
 		Expect(k8sClient.Get(ctx, InstanceLookupKey, currentInstance)).To(Succeed())
 		TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-		currentTemplate := &crownlabsv1alpha2.Template{}
+		currentTemplate := &clv1alpha2.Template{}
 		Expect(k8sClient.Get(ctx, TemplateLookupKey, currentTemplate)).To(Succeed())
 		tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-		currentTenant := &crownlabsv1alpha2.Tenant{}
+		currentTenant := &clv1alpha2.Tenant{}
 		Expect(k8sClient.Get(ctx, tenantLookupKey, currentTenant)).To(Succeed())
 		ctx := context.Background()
-		ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-		ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-		ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+		ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+		ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+		ctx, _ = clctx.TenantInto(ctx, currentTenant)
 		By("Calling deleteInstance function")
 		err := r.DeleteInstance(ctx)
 		Expect(err).ToNot(HaveOccurred())
@@ -335,18 +335,18 @@ var _ = Describe("Instautoctrl-expiration-unit", func() {
 		}
 		By("Checking that the instance is running")
 		InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-		currentInstance := &crownlabsv1alpha2.Instance{}
+		currentInstance := &clv1alpha2.Instance{}
 		Expect(k8sClient.Get(ctx, InstanceLookupKey, currentInstance)).To(Succeed())
 		TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-		currentTemplate := &crownlabsv1alpha2.Template{}
+		currentTemplate := &clv1alpha2.Template{}
 		Expect(k8sClient.Get(ctx, TemplateLookupKey, currentTemplate)).To(Succeed())
 		tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-		currentTenant := &crownlabsv1alpha2.Tenant{}
+		currentTenant := &clv1alpha2.Tenant{}
 		Expect(k8sClient.Get(ctx, tenantLookupKey, currentTenant)).To(Succeed())
 		ctx := context.Background()
-		ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-		ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-		ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+		ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+		ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+		ctx, _ = clctx.TenantInto(ctx, currentTenant)
 
 		By("Calling ShouldSendWarningNotification function")
 		shouldSend, err := r.ShouldSendWarningNotification(ctx)

--- a/operators/pkg/instautoctrl/test_unit/instautoctrl_inactivity_unit_test.go
+++ b/operators/pkg/instautoctrl/test_unit/instautoctrl_inactivity_unit_test.go
@@ -23,14 +23,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
-	pkgcontext "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl"
 )
@@ -84,39 +84,39 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 			Spec:   corev1.NamespaceSpec{},
 			Status: corev1.NamespaceStatus{},
 		}
-		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      true,
 					Image:           "crownlabs/vm",
 				},
 			},
 		}
-		templateNonPersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templateNonPersistentEnvironment = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -124,20 +124,20 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 			DeleteAfter:       CustomDeleteAfterNonPersistent,
 			InactivityTimeout: CustomInactivityTimeoutNonPersistent,
 		}
-		templatePersistentEnvironmentWithCustomInactivityTimeout = crownlabsv1alpha2.TemplateSpec{
-			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
+		templatePersistentEnvironmentWithCustomInactivityTimeout = clv1alpha2.TemplateSpec{
+			WorkspaceRef: clv1alpha2.GenericRef{},
 			PrettyName:   "My Template",
 			Description:  "Description of my template",
-			EnvironmentList: []crownlabsv1alpha2.Environment{
+			EnvironmentList: []clv1alpha2.Environment{
 				{
 					Name:       "env-1",
 					GuiEnabled: true,
-					Resources: crownlabsv1alpha2.EnvironmentResources{
+					Resources: clv1alpha2.EnvironmentResources{
 						CPU:                   1,
 						ReservedCPUPercentage: 1,
 						Memory:                resource.MustParse("1024M"),
 					},
-					EnvironmentType: crownlabsv1alpha2.ClassVM,
+					EnvironmentType: clv1alpha2.ClassVM,
 					Persistent:      false,
 					Image:           "crownlabs/vm",
 				},
@@ -145,34 +145,34 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 			DeleteAfter:       CustomDeleteAfterPersistent2,
 			InactivityTimeout: CustomInactivityTimeoutPersistent2,
 		}
-		persistentTemplate2 = crownlabsv1alpha2.Template{
+		persistentTemplate2 = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName2,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironmentWithCustomInactivityTimeout,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		persistentTemplate = crownlabsv1alpha2.Template{
+		persistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      persistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templatePersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		nonPersistentTemplate = crownlabsv1alpha2.Template{
+		nonPersistentTemplate = clv1alpha2.Template{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nonPersistentTemplateName,
 				Namespace: WorkingNamespace,
 			},
 			Spec:   templateNonPersistentEnvironment,
-			Status: crownlabsv1alpha2.TemplateStatus{},
+			Status: clv1alpha2.TemplateStatus{},
 		}
-		persistentInstance2 = crownlabsv1alpha2.Instance{
+		persistentInstance2 = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName2,
@@ -185,21 +185,21 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/instance-type":     "persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName2,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		persistentInstance = crownlabsv1alpha2.Instance{
+		persistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      PersistentInstanceName,
@@ -212,20 +212,20 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/instance-type":     "persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      persistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
-		nonPersistentInstance = crownlabsv1alpha2.Instance{
+		nonPersistentInstance = clv1alpha2.Instance{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NonPersistentInstanceName,
@@ -238,21 +238,21 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/instance-type":     "non-persistent",
 				},
 			},
-			Spec: crownlabsv1alpha2.InstanceSpec{
+			Spec: clv1alpha2.InstanceSpec{
 				Running: true,
-				Template: crownlabsv1alpha2.GenericRef{
+				Template: clv1alpha2.GenericRef{
 					Name:      nonPersistentTemplateName,
 					Namespace: WorkingNamespace,
 				},
-				Tenant: crownlabsv1alpha2.GenericRef{
+				Tenant: clv1alpha2.GenericRef{
 					Name:      TenantName,
 					Namespace: tenantNs.Name,
 				},
 			},
-			Status: crownlabsv1alpha2.InstanceStatus{},
+			Status: clv1alpha2.InstanceStatus{},
 		}
 
-		tenant = crownlabsv1alpha2.Tenant{
+		tenant = clv1alpha2.Tenant{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      TenantName,
@@ -261,11 +261,11 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec: crownlabsv1alpha2.TenantSpec{
+			Spec: clv1alpha2.TenantSpec{
 				FirstName: "John",
 				LastName:  "Doe",
 				Email:     "john@gmail.com",
-				Workspaces: []crownlabsv1alpha2.TenantWorkspaceEntry{
+				Workspaces: []clv1alpha2.TenantWorkspaceEntry{
 					{Name: workingNs.Name,
 						Role: "user"},
 				},
@@ -327,7 +327,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		By("Creating the namespace where to create instance and template")
 		err1 := k8sClient.Create(ctx, tenNs)
 		err2 := k8sClient.Create(ctx, newNs)
-		if (err1 != nil || err2 != nil) && (errors.IsAlreadyExists(err1) || errors.IsAlreadyExists(err2)) {
+		if (err1 != nil || err2 != nil) && (kerrors.IsAlreadyExists(err1) || kerrors.IsAlreadyExists(err2)) {
 			cleanupEnvironment()
 		} else if err1 != nil || err2 != nil {
 			Fail(fmt.Sprintf("Unable to create namespace -> %s %s", err1, err2))
@@ -352,9 +352,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		persistentTemplateLookupKey := types.NamespacedName{Name: persistentTemplateName, Namespace: WorkingNamespace}
 		nonPersistentTemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
 		persistentTemplate2LookupKey := types.NamespacedName{Name: persistentTemplateName2, Namespace: WorkingNamespace}
-		createdPersitentTemplate := &crownlabsv1alpha2.Template{}
-		createdNonPersitentTemplate := &crownlabsv1alpha2.Template{}
-		createdPersistentTemplate2 := &crownlabsv1alpha2.Template{}
+		createdPersitentTemplate := &clv1alpha2.Template{}
+		createdNonPersitentTemplate := &clv1alpha2.Template{}
+		createdPersistentTemplate2 := &clv1alpha2.Template{}
 
 		doesEventuallyExists(ctx, persistentTemplateLookupKey, createdPersitentTemplate, BeTrue(), timeout, interval, k8sClient)
 		doesEventuallyExists(ctx, nonPersistentTemplateLookupKey, createdNonPersitentTemplate, BeTrue(), timeout, interval, k8sClient)
@@ -365,7 +365,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 		By("Checking that the tenant has been created")
 		tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: WorkingNamespace}
-		createdTenant := &crownlabsv1alpha2.Tenant{}
+		createdTenant := &clv1alpha2.Tenant{}
 		doesEventuallyExists(ctx, tenantLookupKey, createdTenant, BeTrue(), timeout, interval, k8sClient)
 
 		By("Creating the instances")
@@ -377,9 +377,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		persistanteInstanceLookupKey := types.NamespacedName{Name: PersistentInstanceName, Namespace: tenantNs.Name}
 		nonPersistentInstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenNs.Name}
 		persistentInstance2LookupKey := types.NamespacedName{Name: PersistentInstanceName, Namespace: tenantNs.Name}
-		createdPersistentInstance := &crownlabsv1alpha2.Instance{}
-		createdNonPersistentInstance := &crownlabsv1alpha2.Instance{}
-		createdPersistentInstance2 := &crownlabsv1alpha2.Instance{}
+		createdPersistentInstance := &clv1alpha2.Instance{}
+		createdNonPersistentInstance := &clv1alpha2.Instance{}
+		createdPersistentInstance2 := &clv1alpha2.Instance{}
 
 		doesEventuallyExists(ctx, persistanteInstanceLookupKey, createdPersistentInstance, BeTrue(), timeout, interval, k8sClient)
 		doesEventuallyExists(ctx, nonPersistentInstanceLookupKey, createdNonPersistentInstance, BeTrue(), timeout, interval, k8sClient)
@@ -397,18 +397,18 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance is running")
 			InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			doesEventuallyExists(ctx, InstanceLookupKey, currentInstance, BeTrue(), timeout, interval, k8sClient)
 			TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			doesEventuallyExists(ctx, TemplateLookupKey, currentTemplate, BeTrue(), timeout, interval, k8sClient)
 			tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-			currentTenant := &crownlabsv1alpha2.Tenant{}
+			currentTenant := &clv1alpha2.Tenant{}
 			doesEventuallyExists(ctx, tenantLookupKey, currentTenant, BeTrue(), timeout, interval, k8sClient)
 			ctx := context.Background()
-			ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-			ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-			ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+			ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+			ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+			ctx, _ = clctx.TenantInto(ctx, currentTenant)
 			By("Calling TerminateInstance function")
 			err := r.TerminateInstance(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -416,7 +416,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 			By("Checking that the instance has been deleted")
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, InstanceLookupKey, currentInstance)
-				return errors.IsNotFound(err)
+				return kerrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue(), "Instance should be deleted")
 		})
 	})
@@ -432,18 +432,18 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance is running")
 			InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-			currentInstance := &crownlabsv1alpha2.Instance{}
+			currentInstance := &clv1alpha2.Instance{}
 			doesEventuallyExists(ctx, InstanceLookupKey, currentInstance, BeTrue(), timeout, interval, k8sClient)
 			TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-			currentTemplate := &crownlabsv1alpha2.Template{}
+			currentTemplate := &clv1alpha2.Template{}
 			doesEventuallyExists(ctx, TemplateLookupKey, currentTemplate, BeTrue(), timeout, interval, k8sClient)
 			tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-			currentTenant := &crownlabsv1alpha2.Tenant{}
+			currentTenant := &clv1alpha2.Tenant{}
 			doesEventuallyExists(ctx, tenantLookupKey, currentTenant, BeTrue(), timeout, interval, k8sClient)
 			ctx := context.Background()
-			ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-			ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-			ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+			ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+			ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+			ctx, _ = clctx.TenantInto(ctx, currentTenant)
 
 			oldLastLogin := currentInstance.GetAnnotations()[forge.LastActivityAnnotation]
 			err := r.SetupInstanceAnnotations(ctx)
@@ -454,7 +454,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance has been updated")
 			Eventually(func() bool {
-				updatedInstance := &crownlabsv1alpha2.Instance{}
+				updatedInstance := &clv1alpha2.Instance{}
 				err := k8sClient.Get(ctx, InstanceLookupKey, updatedInstance)
 				if err != nil {
 					return false
@@ -473,9 +473,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		var (
 			r                         *instautoctrl.InstanceInactiveTerminationReconciler
 			ctx                       context.Context
-			currentInstance           *crownlabsv1alpha2.Instance
-			currentTemplate           *crownlabsv1alpha2.Template
-			currentTenant             *crownlabsv1alpha2.Tenant
+			currentInstance           *clv1alpha2.Instance
+			currentTemplate           *clv1alpha2.Template
+			currentTenant             *clv1alpha2.Tenant
 			inactivityTimeoutDuration time.Duration
 		)
 
@@ -490,20 +490,20 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance is running")
 			InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-			currentInstance = &crownlabsv1alpha2.Instance{}
+			currentInstance = &clv1alpha2.Instance{}
 			doesEventuallyExists(ctx, InstanceLookupKey, currentInstance, BeTrue(), timeout, interval, k8sClient)
 
 			TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-			currentTemplate = &crownlabsv1alpha2.Template{}
+			currentTemplate = &clv1alpha2.Template{}
 			doesEventuallyExists(ctx, TemplateLookupKey, currentTemplate, BeTrue(), timeout, interval, k8sClient)
 
 			tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-			currentTenant = &crownlabsv1alpha2.Tenant{}
+			currentTenant = &clv1alpha2.Tenant{}
 			doesEventuallyExists(ctx, tenantLookupKey, currentTenant, BeTrue(), timeout, interval, k8sClient)
 
-			ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-			ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-			ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+			ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+			ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+			ctx, _ = clctx.TenantInto(ctx, currentTenant)
 
 			inactivityTimeoutDuration = time.Hour * 24 * 14
 			err := r.SetupInstanceAnnotations(ctx)
@@ -575,9 +575,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		var (
 			r               *instautoctrl.InstanceInactiveTerminationReconciler
 			ctx             context.Context
-			currentInstance *crownlabsv1alpha2.Instance
-			currentTemplate *crownlabsv1alpha2.Template
-			currentTenant   *crownlabsv1alpha2.Tenant
+			currentInstance *clv1alpha2.Instance
+			currentTemplate *clv1alpha2.Template
+			currentTenant   *clv1alpha2.Tenant
 		)
 
 		JustBeforeEach(func() {
@@ -592,20 +592,20 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance is running")
 			InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-			currentInstance = &crownlabsv1alpha2.Instance{}
+			currentInstance = &clv1alpha2.Instance{}
 			doesEventuallyExists(ctx, InstanceLookupKey, currentInstance, BeTrue(), timeout, interval, k8sClient)
 
 			TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-			currentTemplate = &crownlabsv1alpha2.Template{}
+			currentTemplate = &clv1alpha2.Template{}
 			doesEventuallyExists(ctx, TemplateLookupKey, currentTemplate, BeTrue(), timeout, interval, k8sClient)
 
 			tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-			currentTenant = &crownlabsv1alpha2.Tenant{}
+			currentTenant = &clv1alpha2.Tenant{}
 			doesEventuallyExists(ctx, tenantLookupKey, currentTenant, BeTrue(), timeout, interval, k8sClient)
 
-			ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-			ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-			ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+			ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+			ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+			ctx, _ = clctx.TenantInto(ctx, currentTenant)
 		})
 
 		It("should add all missing annotations and patch", func() {
@@ -621,9 +621,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 	Describe("Testing shouldSendWarningNotification function", func() {
 		var (
 			reconciler *instautoctrl.InstanceInactiveTerminationReconciler
-			instance   *crownlabsv1alpha2.Instance
+			instance   *clv1alpha2.Instance
 			ctx        context.Context
-			template   *crownlabsv1alpha2.Template
+			template   *clv1alpha2.Template
 		)
 
 		BeforeEach(func() {
@@ -632,16 +632,16 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 				NotificationInterval:          time.Hour,
 				InstanceMaxNumberOfAlerts:     3,
 			}
-			instance = &crownlabsv1alpha2.Instance{
+			instance = &clv1alpha2.Instance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-instance",
 					Annotations: map[string]string{},
 				},
-				Spec: crownlabsv1alpha2.InstanceSpec{
+				Spec: clv1alpha2.InstanceSpec{
 					Running: true,
 				},
 			}
-			template = &crownlabsv1alpha2.Template{
+			template = &clv1alpha2.Template{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						forge.CustomNumberOfAlertsAnnotation: "4",
@@ -649,7 +649,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 				},
 			}
 			ctx = context.Background()
-			ctx, _ = pkgcontext.TemplateInto(ctx, template)
+			ctx, _ = clctx.TemplateInto(ctx, template)
 		})
 
 		It("returns false if inactivity notifications are disabled", func() {
@@ -710,9 +710,9 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		var (
 			r               *instautoctrl.InstanceInactiveTerminationReconciler
 			ctx             context.Context
-			currentInstance *crownlabsv1alpha2.Instance
-			currentTemplate *crownlabsv1alpha2.Template
-			currentTenant   *crownlabsv1alpha2.Tenant
+			currentInstance *clv1alpha2.Instance
+			currentTemplate *clv1alpha2.Template
+			currentTenant   *clv1alpha2.Tenant
 		)
 		JustBeforeEach(func() {
 			ctx = context.Background()
@@ -725,20 +725,20 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 
 			By("Checking that the instance is running")
 			InstanceLookupKey := types.NamespacedName{Name: NonPersistentInstanceName, Namespace: tenantNs.Name}
-			currentInstance = &crownlabsv1alpha2.Instance{}
+			currentInstance = &clv1alpha2.Instance{}
 			doesEventuallyExists(ctx, InstanceLookupKey, currentInstance, BeTrue(), timeout, interval, k8sClient)
 
 			TemplateLookupKey := types.NamespacedName{Name: nonPersistentTemplateName, Namespace: WorkingNamespace}
-			currentTemplate = &crownlabsv1alpha2.Template{}
+			currentTemplate = &clv1alpha2.Template{}
 			doesEventuallyExists(ctx, TemplateLookupKey, currentTemplate, BeTrue(), timeout, interval, k8sClient)
 
 			tenantLookupKey := types.NamespacedName{Name: TenantName, Namespace: tenantNs.Name}
-			currentTenant = &crownlabsv1alpha2.Tenant{}
+			currentTenant = &clv1alpha2.Tenant{}
 			doesEventuallyExists(ctx, tenantLookupKey, currentTenant, BeTrue(), timeout, interval, k8sClient)
 
-			ctx, _ = pkgcontext.InstanceInto(ctx, currentInstance)
-			ctx, _ = pkgcontext.TemplateInto(ctx, currentTemplate)
-			ctx, _ = pkgcontext.TenantInto(ctx, currentTenant)
+			ctx, _ = clctx.InstanceInto(ctx, currentInstance)
+			ctx, _ = clctx.TemplateInto(ctx, currentTemplate)
+			ctx, _ = clctx.TenantInto(ctx, currentTenant)
 			err := r.SetupInstanceAnnotations(ctx)
 			Expect(err).ToNot(HaveOccurred(), "SetupInstanceAnnotations should not return an error")
 		})

--- a/operators/pkg/instautoctrl/test_unit/instautoctrl_inactivity_unit_test.go
+++ b/operators/pkg/instautoctrl/test_unit/instautoctrl_inactivity_unit_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +61,7 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 	}
 
 	var (
-		workingNs = v1.Namespace{
+		workingNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: WorkingNamespace,
@@ -69,10 +69,10 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/operator-selector": "test-suite",
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
-		tenantNs = v1.Namespace{
+		tenantNs = corev1.Namespace{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TenantName,
@@ -81,8 +81,8 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 					"crownlabs.polito.it/tenant":            TenantName,
 				},
 			},
-			Spec:   v1.NamespaceSpec{},
-			Status: v1.NamespaceStatus{},
+			Spec:   corev1.NamespaceSpec{},
+			Status: corev1.NamespaceStatus{},
 		}
 		templatePersistentEnvironment = crownlabsv1alpha2.TemplateSpec{
 			WorkspaceRef: crownlabsv1alpha2.GenericRef{},
@@ -334,8 +334,8 @@ var _ = Describe("Instautoctrl inactivity unit test", func() {
 		}
 
 		By("By checking that the namespace has been created")
-		workNs := &v1.Namespace{}
-		tenantNs := &v1.Namespace{}
+		workNs := &corev1.Namespace{}
+		tenantNs := &corev1.Namespace{}
 
 		nsLookupKey := types.NamespacedName{Name: WorkingNamespace}
 		doesEventuallyExists(ctx, nsLookupKey, workNs, BeTrue(), timeout, interval, k8sClient)

--- a/operators/pkg/instautoctrl/test_unit/instautoctrl_unit_suite_test.go
+++ b/operators/pkg/instautoctrl/test_unit/instautoctrl_unit_suite_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/instautoctrl/mocks"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils/tests"
 )
@@ -71,7 +71,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	Expect(crownlabsv1alpha2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
+	Expect(clv1alpha2.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(virtv1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 	Expect(cdiv1beta1.AddToScheme(scheme.Scheme)).NotTo(HaveOccurred())
 

--- a/operators/pkg/instctrl/containers.go
+++ b/operators/pkg/instctrl/containers.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -57,7 +57,7 @@ func (r *InstanceReconciler) enforcePVC(ctx context.Context) error {
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 
-	pvc := v1.PersistentVolumeClaim{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
+	pvc := corev1.PersistentVolumeClaim{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
 
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &pvc, func() error {
 		// PVC's spec is immutable, it has to be set at creation

--- a/operators/pkg/instctrl/exposition.go
+++ b/operators/pkg/instctrl/exposition.go
@@ -17,7 +17,7 @@ package instctrl
 import (
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -53,7 +53,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionPresence(ctx context.Conte
 	}
 
 	// Enforce the service presence
-	service := v1.Service{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
+	service := corev1.Service{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
 	res, err := ctrl.CreateOrUpdate(ctx, r.Client, &service, func() error {
 		// Service specifications are forged only at creation time, to prevent issues in case of updates.
 		// Indeed, enforcing the specs may cause service disruption if they diverge from the backend
@@ -134,7 +134,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionAbsence(ctx context.Contex
 	instance.Status.Environments[envIndex].IP = ""
 
 	// Enforce service absence
-	service := v1.Service{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
+	service := corev1.Service{ObjectMeta: forge.ObjectMetaWithSuffix(instance, environment.Name)}
 	if err := utils.EnforceObjectAbsence(ctx, r.Client, &service, "service"); err != nil {
 		return err
 	}

--- a/operators/pkg/instctrl/ip_manager.go
+++ b/operators/pkg/instctrl/ip_manager.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"sort"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -165,7 +165,7 @@ func UpdateUsedPortsByIP(ctx context.Context, c client.Client, excludeSvcName, e
 	usedPortsByIP := make(map[string]map[int32]bool)
 	log := ctrl.LoggerFrom(ctx)
 
-	svcList := &v1.ServiceList{}
+	svcList := &corev1.ServiceList{}
 
 	// Use a label selector to list only the relevant services.
 	labels := forge.LoadBalancerServiceLabels(opts)
@@ -180,7 +180,7 @@ func UpdateUsedPortsByIP(ctx context.Context, c client.Client, excludeSvcName, e
 	for i := range svcList.Items {
 		svc := &svcList.Items[i]
 		// Check for ServiceType is LoadBalancer, although the label should be enough for the purpose.
-		if svc.Spec.Type != v1.ServiceTypeLoadBalancer {
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			continue
 		}
 

--- a/operators/pkg/instctrl/ip_manager_test.go
+++ b/operators/pkg/instctrl/ip_manager_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -104,7 +104,7 @@ var _ = Describe("IPManager", func() {
 	})
 
 	It("UpdateUsedPortsByIP scans and returns used ports by IP", func() {
-		svc1 := &v1.Service{
+		svc1 := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-service-1",
 				Namespace: "test-ns",
@@ -113,15 +113,15 @@ var _ = Describe("IPManager", func() {
 					"metallb.universe.tf/loadBalancerIPs": "172.18.0.240",
 				},
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeLoadBalancer,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
 					{Name: "http", Port: 8080, TargetPort: intstr.FromInt(80)},
 					{Name: "https", Port: 8443, TargetPort: intstr.FromInt(443)},
 				},
 			},
 		}
-		svc2 := &v1.Service{
+		svc2 := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-service-2",
 				Namespace: "test-ns",
@@ -130,9 +130,9 @@ var _ = Describe("IPManager", func() {
 					"metallb.universe.tf/loadBalancerIPs": "172.18.0.241",
 				},
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeLoadBalancer,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
 					{Name: "api", Port: 9090, TargetPort: intstr.FromInt(90)},
 				},
 			},
@@ -157,7 +157,7 @@ var _ = Describe("IPManager", func() {
 	It("UpdateUsedPortsByIP excludes specified service", func() {
 		uniquePort := int32(9999)
 		uniqueIP := "172.18.0.243"
-		svc := &v1.Service{
+		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "exclude-service",
 				Namespace: "test-ns",
@@ -166,9 +166,9 @@ var _ = Describe("IPManager", func() {
 					"metallb.universe.tf/loadBalancerIPs": uniqueIP,
 				},
 			},
-			Spec: v1.ServiceSpec{
-				Type: v1.ServiceTypeLoadBalancer,
-				Ports: []v1.ServicePort{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
 					{Name: "unique-port", Port: uniquePort, TargetPort: intstr.FromInt(80)},
 				},
 			},

--- a/operators/pkg/instctrl/networkpolicy.go
+++ b/operators/pkg/instctrl/networkpolicy.go
@@ -21,7 +21,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
@@ -47,7 +47,7 @@ func (r *InstanceReconciler) enforcePublicExposureNetworkPolicyPresence(ctx cont
 	}
 
 	// The instance is running and public exposure is ready, so create or update the policy.
-	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, &netPol, func() error {
+	res, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &netPol, func() error {
 		forge.PublicExposureNetworkPolicy(instance, &netPol)
 		return ctrl.SetControllerReference(instance, &netPol, r.Scheme)
 	})

--- a/operators/pkg/instctrl/publicexposure.go
+++ b/operators/pkg/instctrl/publicexposure.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -42,7 +42,7 @@ func (r *InstanceReconciler) EnforcePublicExposure(ctx context.Context) error {
 		if hasOnlyOneEnvironment {
 			return r.enforcePublicExposurePresence(ctx)
 		}
-		r.EventsRecorder.Eventf(instance, v1.EventTypeWarning, EvPublicExposureMultiEnv, EvPublicExposureMultiEnvMsg)
+		r.EventsRecorder.Eventf(instance, corev1.EventTypeWarning, EvPublicExposureMultiEnv, EvPublicExposureMultiEnvMsg)
 	}
 	return r.enforcePublicExposureAbsence(ctx)
 }
@@ -68,7 +68,7 @@ func (r *InstanceReconciler) enforcePublicExposurePresence(ctx context.Context) 
 		return err
 	}
 
-	service := &v1.Service{
+	service := &corev1.Service{
 		ObjectMeta: forge.ObjectMetaWithSuffix(instance, forge.LabelPublicExposureValue),
 	}
 
@@ -194,7 +194,7 @@ func (r *InstanceReconciler) enforcePublicExposurePresence(ctx context.Context) 
 // enforcePublicExposureAbsence ensures the absence of the LoadBalancer service.
 func (r *InstanceReconciler) enforcePublicExposureAbsence(ctx context.Context) error {
 	instance := clctx.InstanceFrom(ctx)
-	service := &v1.Service{
+	service := &corev1.Service{
 		ObjectMeta: forge.ObjectMetaWithSuffix(instance, forge.LabelPublicExposureValue),
 	}
 
@@ -243,7 +243,7 @@ func needsServiceUpdate(specPorts, statusPorts, svcPorts []clv1alpha2.PublicServ
 	type portKey struct {
 		Name     string
 		Target   int32
-		Protocol v1.Protocol
+		Protocol corev1.Protocol
 	}
 
 	// Build set of keys from spec

--- a/operators/pkg/instctrl/publicexposure.go
+++ b/operators/pkg/instctrl/publicexposure.go
@@ -20,7 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
@@ -72,9 +72,9 @@ func (r *InstanceReconciler) enforcePublicExposurePresence(ctx context.Context) 
 		ObjectMeta: forge.ObjectMetaWithSuffix(instance, forge.LabelPublicExposureValue),
 	}
 
-	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
+	op, err := ctrlutil.CreateOrUpdate(ctx, r.Client, service, func() error {
 		// Set owner reference
-		if err := controllerutil.SetControllerReference(instance, service, r.Scheme); err != nil {
+		if err := ctrlutil.SetControllerReference(instance, service, r.Scheme); err != nil {
 			return err
 		}
 

--- a/operators/pkg/instctrl/storage.go
+++ b/operators/pkg/instctrl/storage.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
@@ -47,14 +47,14 @@ func (r *InstanceReconciler) EnforceShVolMirrorPVCs(ctx context.Context) error {
 				Namespace: instance.Namespace,
 			},
 		}
-		_, err := controllerutil.CreateOrUpdate(ctx, r.Client, &mirrPvc, func() error {
+		_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &mirrPvc, func() error {
 			// Configure the mirror PVC
 			if mirrPvc.CreationTimestamp.IsZero() {
 				mirrPvc.Spec = forge.MirrorPVCSpec(&shvolPvc, r.MirrorPVCStorageClassName)
 			}
 			mirrPvc.SetLabels(forge.UpdateShVolMirrorPVCLabels(mirrPvc.Labels))
 
-			return controllerutil.SetControllerReference(instance, &mirrPvc, r.Scheme)
+			return ctrlutil.SetControllerReference(instance, &mirrPvc, r.Scheme)
 		})
 		if err != nil {
 			log.Error(err, "failed to enforce mirror sharedvolume", "SharedVolume", shvolPvc, "Environment", environment)

--- a/operators/pkg/instctrl/storage_test.go
+++ b/operators/pkg/instctrl/storage_test.go
@@ -27,7 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	ctrlUtil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	clctx "github.com/netgroup-polito/CrownLabs/operators/pkg/clcontext"
@@ -77,7 +77,7 @@ var _ = Describe("Storage enforcement", func() {
 		)
 
 		RemovePVC := func(pvc *corev1.PersistentVolumeClaim) {
-			ctrlUtil.RemoveFinalizer(pvc, "kubernetes.io/pvc-protection")
+			ctrlutil.RemoveFinalizer(pvc, "kubernetes.io/pvc-protection")
 			Expect(reconciler.Update(ctx, pvc.DeepCopy())).To(Succeed())
 			_ = reconciler.Delete(ctx, pvc)
 		}

--- a/operators/pkg/utils/client.go
+++ b/operators/pkg/utils/client.go
@@ -21,7 +21,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -63,25 +63,25 @@ func PatchObject[T interface {
 
 // NewK8sClient initializes the global k8s client.
 func NewK8sClient() (client.Client, error) {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(clv1alpha2.AddToScheme(scheme))
+	rscheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(rscheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(rscheme))
 
 	kubeconfig, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("k8s config error: %w", err)
 	}
 
-	return client.New(restcfg.SetRateLimiter(kubeconfig), client.Options{Scheme: scheme})
+	return client.New(restcfg.SetRateLimiter(kubeconfig), client.Options{Scheme: rscheme})
 }
 
 // NewK8sClientWithConfig initializes a k8s client with the provided configuration.
 func NewK8sClientWithConfig(kubeconfig *rest.Config) (client.Client, error) {
-	scheme := runtime.NewScheme()
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(clv1alpha2.AddToScheme(scheme))
+	rscheme := runtime.NewScheme()
+	utilruntime.Must(scheme.AddToScheme(rscheme))
+	utilruntime.Must(clv1alpha2.AddToScheme(rscheme))
 
-	return client.New(restcfg.SetRateLimiter(kubeconfig), client.Options{Scheme: scheme})
+	return client.New(restcfg.SetRateLimiter(kubeconfig), client.Options{Scheme: rscheme})
 }
 
 // GetRestConfig returns the basic Kubernetes REST config.

--- a/operators/pkg/utils/common.go
+++ b/operators/pkg/utils/common.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clv1alpha1 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
-	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 )
 
 // ParseDockerDirectory returns a valid Docker image directory.
@@ -70,7 +70,7 @@ func CheckSelectorLabel(ctx context.Context, k8sClient client.Client, namespaceN
 }
 
 // CheckNamespaceTargetLabel checks if the given namespace has the specified target label where to perform reconciliation.
-func CheckNamespaceTargetLabel(ctx context.Context, k8sClient client.Client, namespaceName string, targetLabel common.KVLabel) (bool, error) {
+func CheckNamespaceTargetLabel(ctx context.Context, k8sClient client.Client, namespaceName string, targetLabel ctrlcommon.KVLabel) (bool, error) {
 	namespaceLookupKey := types.NamespacedName{Name: namespaceName}
 	var ns corev1.Namespace
 

--- a/operators/pkg/utils/logs.go
+++ b/operators/pkg/utils/logs.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -37,8 +37,8 @@ func LogConstructor(logger logr.Logger, ctrlname string) func(*reconcile.Request
 }
 
 // FromResult returns a logger level, given the result of a CreateOrUpdate operation.
-func FromResult(result controllerutil.OperationResult) int {
-	if result == controllerutil.OperationResultNone {
+func FromResult(result ctrlutil.OperationResult) int {
+	if result == ctrlutil.OperationResultNone {
 		return LogDebugLevel
 	}
 	return LogInfoLevel

--- a/operators/pkg/utils/nfs.go
+++ b/operators/pkg/utils/nfs.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +29,7 @@ import (
 )
 
 // NFSDriveProvisioning enforces a job to provision the passed PVC, changing its owner and adding it a label when done.
-func NFSDriveProvisioning(ctx context.Context, log logr.Logger, c client.Client, pvc *v1.PersistentVolumeClaim, owner metav1.Object) (bool, error) {
+func NFSDriveProvisioning(ctx context.Context, log logr.Logger, c client.Client, pvc *corev1.PersistentVolumeClaim, owner metav1.Object) (bool, error) {
 	log = log.WithName("provisioning-job")
 
 	val, found := pvc.Labels[forge.ProvisionJobLabel]

--- a/operators/pkg/utils/tests/fail_not_found.go
+++ b/operators/pkg/utils/tests/fail_not_found.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // IsNotFoundErrorMatcher is a custom matcher to check when kubernetes resources do not exist.
@@ -35,7 +35,7 @@ func FailBecauseNotFound() types.GomegaMatcher {
 func (s *IsNotFoundErrorMatcher) Match(actual interface{}) (success bool, err error) {
 	switch e := actual.(type) {
 	case error:
-		return errors.IsNotFound(e), nil
+		return kerrors.IsNotFound(e), nil
 	default:
 		return false, fmt.Errorf("IsNotFoundErrorMatcher can match errors only")
 	}


### PR DESCRIPTION
# Description

This PR configures `golangci-lint`'s plugin `importas` to enforce some conventions on import aliases in the Go codebase.