### PR TITLE
chore: refactor NamespacedName utility methods

### DIFF
--- a/operators/pkg/controller/instance/webhook/validator.go
+++ b/operators/pkg/controller/instance/webhook/validator.go
@@ -48,7 +48,7 @@ func validateQuota(ctx context.Context, instance *v1alpha2.Instance, cl client.C
 
 	// Get the instance's template
 	instanceTemplate := &v1alpha2.Template{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: instance.Spec.Template.Name, Namespace: instance.Spec.Template.Namespace}, instanceTemplate); err != nil {
+	if err := cl.Get(ctx, forge.NamespacedNameFromGenericRef(instance.Spec.Template), instanceTemplate); err != nil {
 		return warnings, fmt.Errorf("failed to get instance template: %w", err)
 	}
 

--- a/operators/pkg/controller/sharedvolume/reconciler.go
+++ b/operators/pkg/controller/sharedvolume/reconciler.go
@@ -302,10 +302,7 @@ func (r *Reconciler) getDeletingSharedVolumes(ctx context.Context, obj client.Ob
 	var enqueues []ctrl.Request
 	var shvols clv1alpha2.SharedVolumeList
 
-	log := ctrl.LoggerFrom(ctx, "woken-by-template", types.NamespacedName{
-		Namespace: obj.GetNamespace(),
-		Name:      obj.GetName(),
-	})
+	log := ctrl.LoggerFrom(ctx, "woken-by-template", forge.NamespacedNameFromObject(obj))
 
 	filter := client.MatchingFields{
 		phaseFieldIndex: string(clv1alpha2.SharedVolumePhaseDeleting),
@@ -317,7 +314,7 @@ func (r *Reconciler) getDeletingSharedVolumes(ctx context.Context, obj client.Ob
 
 	for i := range shvols.Items {
 		enqueues = append(enqueues, ctrl.Request{
-			NamespacedName: forge.NamespacedNameFromSharedVolume(&shvols.Items[i]),
+			NamespacedName: forge.NamespacedNameFromObject(&shvols.Items[i]),
 		})
 	}
 

--- a/operators/pkg/controller/sharedvolume/reconciler_test.go
+++ b/operators/pkg/controller/sharedvolume/reconciler_test.go
@@ -55,12 +55,12 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 
 	RunReconciler := func() error {
 		_, err := shvolReconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: forge.NamespacedNameFromSharedVolume(&shvol),
+			NamespacedName: forge.NamespacedNameFromObject(&shvol),
 		})
 		if err != nil {
 			return err
 		}
-		return k8sClient.Get(ctx, forge.NamespacedNameFromSharedVolume(&shvol), &shvol)
+		return k8sClient.Get(ctx, forge.NamespacedNameFromObject(&shvol), &shvol)
 	}
 
 	PVCNamespacedName := func(shvol *clv1alpha2.SharedVolume) types.NamespacedName {
@@ -252,7 +252,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 						})
 
 						It("Should smoothly delete the shared volume", func() {
-							err := k8sClient.Get(ctx, forge.NamespacedNameFromSharedVolume(&shvol), &shvol)
+							err := k8sClient.Get(ctx, forge.NamespacedNameFromObject(&shvol), &shvol)
 							Expect(kerrors.IsNotFound(err)).To(BeTrue())
 						})
 
@@ -278,7 +278,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 						})
 
 						It("Should not delete the shared volume and transition to Deleting", func() {
-							err := k8sClient.Get(ctx, forge.NamespacedNameFromSharedVolume(&shvol), &shvol)
+							err := k8sClient.Get(ctx, forge.NamespacedNameFromObject(&shvol), &shvol)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(shvol.Status.Phase).To(Equal(clv1alpha2.SharedVolumePhaseDeleting))
 						})
@@ -317,7 +317,7 @@ var _ = Describe("The sharedvolume-controller Reconcile method", Ordered, func()
 						})
 
 						It("Should transition to phase Error", func() {
-							Expect(k8sClient.Get(ctx, forge.NamespacedNameFromSharedVolume(&shvol), &shvol)).To(Succeed())
+							Expect(k8sClient.Get(ctx, forge.NamespacedNameFromObject(&shvol), &shvol)).To(Succeed())
 							Expect(shvol.Status.Phase).To(Equal(clv1alpha2.SharedVolumePhaseError))
 
 							Expect(k8sClient.Get(ctx, PVCNamespacedName(&shvol), &pvc)).To(Succeed())

--- a/operators/pkg/controller/tenant/reconciler.go
+++ b/operators/pkg/controller/tenant/reconciler.go
@@ -28,7 +28,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -42,6 +41,7 @@ import (
 	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha1"
 	"github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -360,9 +360,7 @@ func (r *Reconciler) WorkspaceNameToEnrolledTenants(
 	}
 	for idx := range tenants.Items {
 		enqueues = append(enqueues, ctrl.Request{
-			NamespacedName: types.NamespacedName{
-				Name: tenants.Items[idx].GetName(),
-			},
+			NamespacedName: forge.NamespacedNameFromObject(&tenants.Items[idx]),
 		})
 	}
 	return enqueues

--- a/operators/pkg/examagent/instance.go
+++ b/operators/pkg/examagent/instance.go
@@ -91,7 +91,7 @@ func (ih *InstanceHandler) HandleGet(w http.ResponseWriter, r *http.Request, log
 	inst := ih.EmptyInstanceFromRequest(r)
 	log = log.WithValues("instance", inst.Name)
 
-	if err := ih.Client.Get(r.Context(), forge.NamespacedName(inst), inst); err != nil {
+	if err := ih.Client.Get(r.Context(), forge.NamespacedNameFromObject(inst), inst); err != nil {
 		if errors.IsNotFound(err) {
 			log.Error(err, "instance not found")
 			WriteError(w, r, log, http.StatusNotFound, "The requested Instance does not exist.")

--- a/operators/pkg/forge/storage.go
+++ b/operators/pkg/forge/storage.go
@@ -92,7 +92,7 @@ func PVCMountInfosFromEnvironment(ctx context.Context, c client.Client) ([]corev
 	for _, mount := range env.SharedVolumeMounts {
 		// Check existence before mounting
 		var shvol clv1alpha2.SharedVolume
-		if err := c.Get(ctx, NamespacedNameFromMount(mount), &shvol); err != nil {
+		if err := c.Get(ctx, NamespacedNameFromGenericRef(mount.SharedVolumeRef), &shvol); err != nil {
 			return nil, fmt.Sprintf(
 				"unable to retrieve SharedVolume %q in namespace %q to mount for environment %%s",
 				mount.SharedVolumeRef.Name,

--- a/operators/pkg/forge/utils.go
+++ b/operators/pkg/forge/utils.go
@@ -53,14 +53,6 @@ func ObjectMetaWithSuffix(instance *clv1alpha2.Instance, suffix string) metav1.O
 	}
 }
 
-// NamespacedName returns the namespace/name pair given an instance object.
-func NamespacedName(instance *clv1alpha2.Instance) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      CanonicalName(instance.GetName()),
-		Namespace: instance.GetNamespace(),
-	}
-}
-
 // NamespacedNameWithSuffix returns the namespace/name pair given an instance object and a name suffix.
 func NamespacedNameWithSuffix(instance *clv1alpha2.Instance, suffix string) types.NamespacedName {
 	return types.NamespacedName{
@@ -77,19 +69,22 @@ func NamespacedNameToObjectMeta(namespacedName types.NamespacedName) metav1.Obje
 	}
 }
 
-// NamespacedNameFromSharedVolume returns the namespace/name pair of the passed SharedVolume.
-func NamespacedNameFromSharedVolume(shvol *clv1alpha2.SharedVolume) types.NamespacedName {
+// NamespacedNameFromObject returns the namespace/name pair of the passed Kubernetes object.
+//
+// Note: Remember all k8s resource structs (e.g. Pod, Deployment, ...) do not implement the
+// metav1.Object interface, but any pointer to them does.
+func NamespacedNameFromObject(obj metav1.Object) types.NamespacedName {
 	return types.NamespacedName{
-		Name:      shvol.Name,
-		Namespace: shvol.Namespace,
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}
 }
 
-// NamespacedNameFromMount returns the namespace/name pair of the SharedVolume contained in the passed SharedVolumeMountInfo.
-func NamespacedNameFromMount(mountInfo clv1alpha2.SharedVolumeMountInfo) types.NamespacedName {
+// NamespacedNameFromGenericRef returns the namespace/name pair of the passed reference.
+func NamespacedNameFromGenericRef(ref clv1alpha2.GenericRef) types.NamespacedName {
 	return types.NamespacedName{
-		Name:      mountInfo.SharedVolumeRef.Name,
-		Namespace: mountInfo.SharedVolumeRef.Namespace,
+		Name:      ref.Name,
+		Namespace: ref.Namespace,
 	}
 }
 

--- a/operators/pkg/forge/utils_test.go
+++ b/operators/pkg/forge/utils_test.go
@@ -80,30 +80,6 @@ var _ = Describe("Utils forging", func() {
 		)
 	})
 
-	Describe("The forge.NamespacedName function", func() {
-		type NamespaceNameCase struct {
-			InstanceNamespace string
-			InstanceName      string
-			ExpectedOutput    types.NamespacedName
-		}
-
-		DescribeTable("Correctly returns the expected object meta",
-			func(c NamespaceNameCase) {
-				Expect(forge.NamespacedName(ForgeInstance(c.InstanceNamespace, c.InstanceName))).To(Equal(c.ExpectedOutput))
-			},
-			Entry("When the instance name does not contain dots", NamespaceNameCase{
-				InstanceNamespace: "workspace-netgroup",
-				InstanceName:      "kubernetes-1234",
-				ExpectedOutput:    types.NamespacedName{Namespace: "workspace-netgroup", Name: "kubernetes-1234"},
-			}),
-			Entry("When the instance name does contain dots", NamespaceNameCase{
-				InstanceNamespace: "workspace-netgroup",
-				InstanceName:      "kuber.netes.1234",
-				ExpectedOutput:    types.NamespacedName{Namespace: "workspace-netgroup", Name: "kuber-netes-1234"},
-			}),
-		)
-	})
-
 	Describe("The forge.NamespacedNameWithSuffix function", func() {
 		const Suffix = "prime"
 
@@ -145,7 +121,7 @@ var _ = Describe("Utils forging", func() {
 		It("Should have a matching namespace", func() { Expect(objectMeta.Namespace).To(BeIdenticalTo(namespacedName.Namespace)) })
 	})
 
-	Describe("The forge.NamespacedNameFromSharedVolume function", func() {
+	Describe("The forge.NamespacedNameFromObject function", func() {
 		var (
 			shvol          clv1alpha2.SharedVolume
 			namespacedName types.NamespacedName
@@ -160,7 +136,7 @@ var _ = Describe("Utils forging", func() {
 			}
 		})
 		JustBeforeEach(func() {
-			namespacedName = forge.NamespacedNameFromSharedVolume(&shvol)
+			namespacedName = forge.NamespacedNameFromObject(&shvol)
 		})
 
 		It("Should have a matching name", func() {
@@ -172,29 +148,27 @@ var _ = Describe("Utils forging", func() {
 
 	})
 
-	Describe("The forge.NamespacedNameFromMount function", func() {
+	Describe("The forge.NamespacedNameFromGenericRef function", func() {
 		var (
-			mountInfo      clv1alpha2.SharedVolumeMountInfo
+			ref            clv1alpha2.GenericRef
 			namespacedName types.NamespacedName
 		)
 
 		BeforeEach(func() {
-			mountInfo = clv1alpha2.SharedVolumeMountInfo{
-				SharedVolumeRef: clv1alpha2.GenericRef{
-					Name:      "name",
-					Namespace: "namespace",
-				},
+			ref = clv1alpha2.GenericRef{
+				Name:      "name",
+				Namespace: "namespace",
 			}
 		})
 		JustBeforeEach(func() {
-			namespacedName = forge.NamespacedNameFromMount(mountInfo)
+			namespacedName = forge.NamespacedNameFromGenericRef(ref)
 		})
 
 		It("Should have a matching name", func() {
-			Expect(namespacedName.Name).To(Equal(mountInfo.SharedVolumeRef.Name))
+			Expect(namespacedName.Name).To(Equal(ref.Name))
 		})
 		It("Should have a matching namespace", func() {
-			Expect(namespacedName.Namespace).To(Equal(mountInfo.SharedVolumeRef.Namespace))
+			Expect(namespacedName.Namespace).To(Equal(ref.Namespace))
 		})
 
 	})

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -87,10 +87,7 @@ func (r *InstanceSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Check the current status of the InstanceSnapshot by checking
 	// the state of its assigned job.
-	jobName := types.NamespacedName{
-		Namespace: isnap.Namespace,
-		Name:      isnap.Name,
-	}
+	jobName := forge.NamespacedNameFromObject(isnap)
 	found := &batch.Job{}
 	err := r.Get(ctx, jobName, found)
 

--- a/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
+++ b/operators/pkg/instancesnapshot-controller/instancesnapshot_helpers.go
@@ -25,19 +25,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	crownlabsv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
 // ValidateRequest validates the InstanceSnapshot request, returns an error and if there's the need to try again.
 func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot) (bool, error) {
 	// First it is needed to check if the instance actually exists.
-	instanceName := types.NamespacedName{
-		Namespace: isnap.Spec.Instance.Namespace,
-		Name:      isnap.Spec.Instance.Name,
-	}
+	instanceName := forge.NamespacedNameFromGenericRef(isnap.Spec.Instance)
 	instance := &crownlabsv1alpha2.Instance{}
 
 	if err := r.Get(ctx, instanceName, instance); err != nil && errors.IsNotFound(err) {
@@ -53,10 +50,7 @@ func (r *InstanceSnapshotReconciler) ValidateRequest(ctx context.Context, isnap 
 	// - the vm is powered off, since it is not possible to steal the DataVolume if it is still running;
 	// - the environment is a persistent vm and not a container.
 
-	templateName := types.NamespacedName{
-		Namespace: instance.Spec.Template.Namespace,
-		Name:      instance.Spec.Template.Name,
-	}
+	templateName := forge.NamespacedNameFromGenericRef(instance.Spec.Template)
 	template := &crownlabsv1alpha2.Template{}
 
 	if err := r.Get(ctx, templateName, template); err != nil && errors.IsNotFound(err) {
@@ -118,10 +112,7 @@ func (r *InstanceSnapshotReconciler) GetJobStatus(job *batch.Job) (bool, batch.J
 // CreateSnapshottingJobDefinition generates the job to be created.
 func (r *InstanceSnapshotReconciler) CreateSnapshottingJobDefinition(ctx context.Context, isnap *crownlabsv1alpha2.InstanceSnapshot) (batch.Job, error) {
 	// Get the tenant name in order to set it as directory of the image
-	instanceName := types.NamespacedName{
-		Namespace: isnap.Spec.Instance.Namespace,
-		Name:      isnap.Spec.Instance.Name,
-	}
+	instanceName := forge.NamespacedNameFromGenericRef(isnap.Spec.Instance)
 	instance := &crownlabsv1alpha2.Instance{}
 
 	if err := r.Get(ctx, instanceName, instance); err != nil {

--- a/operators/pkg/instautoctrl/common.go
+++ b/operators/pkg/instautoctrl/common.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -171,10 +170,7 @@ func GetTenantFromInstance(ctx context.Context, c client.Client) (*clv1alpha2.Te
 func RetrieveEnvironmentList(ctx context.Context, c client.Client, instance *clv1alpha2.Instance) ([]*clv1alpha2.Environment, error) {
 	log := ctrl.LoggerFrom(ctx).V(utils.LogDebugLevel)
 
-	templateName := types.NamespacedName{
-		Namespace: instance.Spec.Template.Namespace,
-		Name:      instance.Spec.Template.Name,
-	}
+	templateName := forge.NamespacedNameFromGenericRef(instance.Spec.Template)
 
 	var template clv1alpha2.Template
 	if err := c.Get(ctx, templateName, &template); err != nil {
@@ -219,10 +215,7 @@ func getTemplateInstanceRequests(ctx context.Context, c client.Client, template 
 	for i := range instances.Items {
 		instance := &instances.Items[i]
 		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      instance.Name,
-				Namespace: instance.Namespace,
-			},
+			NamespacedName: forge.NamespacedNameFromObject(instance),
 		})
 	}
 
@@ -339,20 +332,14 @@ func GetInstanceTemplateTenant(ctx context.Context, req ctrl.Request, c client.C
 	}
 
 	var template clv1alpha2.Template
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      instance.Spec.Template.Name,
-		Namespace: instance.Spec.Template.Namespace,
-	}, &template); err != nil {
+	if err := c.Get(ctx, forge.NamespacedNameFromGenericRef(instance.Spec.Template), &template); err != nil {
 		log.Error(err, "Unable to fetch the instance template.")
 		return nil, nil, nil, fmt.Errorf("failed to fetch instance template %s/%s: %w",
 			instance.Spec.Template.Namespace, instance.Spec.Template.Name, err)
 	}
 
 	var tenant clv1alpha2.Tenant
-	if err := c.Get(ctx, types.NamespacedName{
-		Name:      instance.Spec.Tenant.Name,
-		Namespace: instance.Namespace,
-	}, &tenant); err != nil {
+	if err := c.Get(ctx, forge.NamespacedNameFromGenericRef(instance.Spec.Tenant), &tenant); err != nil {
 		log.Error(err, "Unable to fetch the instance tenant.")
 		return nil, nil, nil, fmt.Errorf("failed to fetch instance tenant %s/%s: %w",
 			instance.Namespace, instance.Spec.Tenant.Name, err)
@@ -378,10 +365,7 @@ func createNamespaceWatchHandlerWithIgnore(c client.Client, ignoreLabel string) 
 		for i := range instances.Items {
 			instance := &instances.Items[i]
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name:      instance.Name,
-					Namespace: instance.Namespace,
-				},
+				NamespacedName: forge.NamespacedNameFromObject(instance),
 			})
 		}
 		return requests

--- a/operators/pkg/instctrl/cloudinit_test.go
+++ b/operators/pkg/instctrl/cloudinit_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Generation of the cloud-init configuration", func() {
 			},
 		}
 
-		objectName = forge.NamespacedName(&instance)
+		objectName = forge.NamespacedNameFromObject(&instance)
 		secret = corev1.Secret{}
 
 		ownerRef = metav1.OwnerReference{

--- a/operators/pkg/instctrl/controller.go
+++ b/operators/pkg/instctrl/controller.go
@@ -205,10 +205,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}(instance.DeepCopy(), &instance)
 
 	// Retrieve the template associated with the current instance.
-	templateName := types.NamespacedName{
-		Namespace: instance.Spec.Template.Namespace,
-		Name:      instance.Spec.Template.Name,
-	}
+	templateName := forge.NamespacedNameFromGenericRef(instance.Spec.Template)
 	var template clv1alpha2.Template
 	if err := r.Get(ctx, templateName, &template); err != nil {
 		log.Error(err, "failed retrieving the instance template", "template", templateName)
@@ -220,7 +217,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	log.Info("successfully retrieved the instance template")
 
 	// Retrieve the tenant associated with the current instance.
-	tenantName := types.NamespacedName{Name: instance.Spec.Tenant.Name}
+	tenantName := forge.NamespacedNameFromGenericRef(instance.Spec.Tenant)
 	var tenant clv1alpha2.Tenant
 	if err := r.Get(ctx, tenantName, &tenant); err != nil {
 		log.Error(err, "failed retrieving the instance tenant", "tenant", tenantName)

--- a/operators/pkg/instctrl/controller_test.go
+++ b/operators/pkg/instctrl/controller_test.go
@@ -64,12 +64,12 @@ var _ = Describe("The instance-controller Reconcile method", func() {
 
 	RunReconciler := func() error {
 		_, err := instanceReconciler.Reconcile(ctx, reconcile.Request{
-			NamespacedName: forge.NamespacedName(&instance),
+			NamespacedName: forge.NamespacedNameFromObject(&instance),
 		})
 		if err != nil {
 			return err
 		}
-		return k8sClient.Get(ctx, forge.NamespacedName(&instance), &instance)
+		return k8sClient.Get(ctx, forge.NamespacedNameFromObject(&instance), &instance)
 	}
 
 	BeforeEach(func() {

--- a/operators/pkg/instctrl/virtualmachines_test.go
+++ b/operators/pkg/instctrl/virtualmachines_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Generation of the virtual machine and virtual machine instance
 			},
 		}
 
-		objectName = forge.NamespacedName(&instance)
+		objectName = forge.NamespacedNameFromObject(&instance)
 		objectNameEnv = forge.NamespacedNameWithSuffix(&instance, environmentName)
 
 		svc = corev1.Service{}

--- a/operators/pkg/utils/common.go
+++ b/operators/pkg/utils/common.go
@@ -52,7 +52,7 @@ func CheckLabels(ns *corev1.Namespace, matchLabels map[string]string) bool {
 // TODO: Delete this and CheckLabels when the instctrl and instautoctrl will be converted to a KVLabel selector.
 func CheckSelectorLabel(ctx context.Context, k8sClient client.Client, namespaceName string, matchLabels map[string]string) (bool, error) {
 	namespaceLookupKey := types.NamespacedName{Name: namespaceName}
-	ns := corev1.Namespace{}
+	var ns corev1.Namespace
 
 	// It performs reconciliation only if the resource belongs to whitelisted namespaces
 	// by checking the existence of keys in the namespace of the resource.
@@ -72,7 +72,7 @@ func CheckSelectorLabel(ctx context.Context, k8sClient client.Client, namespaceN
 // CheckNamespaceTargetLabel checks if the given namespace has the specified target label where to perform reconciliation.
 func CheckNamespaceTargetLabel(ctx context.Context, k8sClient client.Client, namespaceName string, targetLabel common.KVLabel) (bool, error) {
 	namespaceLookupKey := types.NamespacedName{Name: namespaceName}
-	ns := corev1.Namespace{}
+	var ns corev1.Namespace
 
 	if err := k8sClient.Get(ctx, namespaceLookupKey, &ns); err != nil {
 		return false, fmt.Errorf("error when retrieving namespace %q: %w", namespaceName, err)
@@ -85,7 +85,7 @@ func CheckNamespaceTargetLabel(ctx context.Context, k8sClient client.Client, nam
 // (which supports both equality and set-based requirements, i.e. =, !=, in, notin, exists).
 func CheckNamespaceWithSelector(ctx context.Context, k8sClient client.Client, namespaceName, selectorString string) (bool, error) {
 	namespaceLookupKey := types.NamespacedName{Name: namespaceName}
-	ns := corev1.Namespace{}
+	var ns corev1.Namespace
 
 	if err := k8sClient.Get(ctx, namespaceLookupKey, &ns); err != nil {
 		return false, fmt.Errorf("error when retrieving namespace %q: %w", namespaceName, err)


### PR DESCRIPTION
# Description

This PR aims to refactor the abundant creation of `types.NamespacedName` objects used to Get kubernetes objects, by generalizing already present utility functions.
 
# How Has This Been Tested?

Edited functions had their tests edited accordingly.
