### PR TITLE
Gateway API: Implement HTTPRoute for qlkube and unify domains

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -17,7 +17,7 @@ frontend-app:
     path: /
   configuration:
     backend:
-      graphql: https://graphql.example.com
+      graphql: /graph
       grafana: https://grafana.example.com/d/example
       bastion: ssh.example.com
     oidc:
@@ -31,6 +31,11 @@ qlkube:
     repository: crownlabs/qlkube
   rbacResourcesName: crownlabs-qlkube
   ingress:
+    hostname: qlkube.crownlabs.example.com
+  httproute:
+    gateway:
+      # name: crownlabs-gw
+      # namespace: envoy-gateway-system
     hostname: qlkube.crownlabs.example.com
   harborToken: {}
   configuration:

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -32,11 +32,6 @@ qlkube:
   rbacResourcesName: crownlabs-qlkube
   ingress:
     hostname: qlkube.crownlabs.example.com
-  httproute:
-    gateway:
-      # name: crownlabs-gw
-      # namespace: envoy-gateway-system
-    hostname: qlkube.crownlabs.example.com
   harborToken: {}
   configuration:
     exposedAPIs:

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -31,7 +31,7 @@ qlkube:
     repository: crownlabs/qlkube
   rbacResourcesName: crownlabs-qlkube
   ingress:
-    hostname: qlkube.crownlabs.example.com
+    hostname: crownlabs.example.com
   harborToken: {}
   configuration:
     exposedAPIs:

--- a/frontend/deploy/frontend-app/values.yaml
+++ b/frontend/deploy/frontend-app/values.yaml
@@ -14,7 +14,7 @@ configuration:
   mountPath: /usr/share/nginx/html
   fileName: config.js
   backend:
-    graphql: https://graphql.example.com
+    graphql: /graph
     grafana: https://grafana.example.com/d/example
     bastion: ssh.example.com
   oidc:

--- a/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
+++ b/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
@@ -32,7 +32,15 @@ if (import.meta.env.DEV) {
 }
 
 const httpUri = VITE_APP_CROWNLABS_GRAPHQL_URL;
-const wsUri = httpUri.replace(/^http?/, 'ws') + '/subscription';
+const getWsUri = (baseUri: string) => {
+  if (baseUri.startsWith('http')) {
+    return baseUri.replace(/^http/, 'ws') + '/subscription';
+  }
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${wsProtocol}//${window.location.host}${baseUri}/subscription`;
+};
+const wsUri = getWsUri(httpUri);
+
 export interface Definition {
   kind: string;
   operation?: string;

--- a/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
+++ b/frontend/src/graphql-components/apolloClientSetup/ApolloClientSetup.tsx
@@ -32,14 +32,7 @@ if (import.meta.env.DEV) {
 }
 
 const httpUri = VITE_APP_CROWNLABS_GRAPHQL_URL;
-const getWsUri = (baseUri: string) => {
-  if (baseUri.startsWith('http')) {
-    return baseUri.replace(/^http/, 'ws') + '/subscription';
-  }
-  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  return `${wsProtocol}//${window.location.host}${baseUri}/subscription`;
-};
-const wsUri = getWsUri(httpUri);
+const wsUri = new URL(`${httpUri}/subscription`, window.location.href).href.replace(/^http/, 'ws');
 
 export interface Definition {
   kind: string;

--- a/qlkube/deploy/qlkube/templates/deployment.yaml
+++ b/qlkube/deploy/qlkube/templates/deployment.yaml
@@ -34,13 +34,15 @@ spec:
           env:
           - name: CROWNLABS_QLKUBE_PORT
             value: "8080"
+          - name: BASE_URL
+            value: {{ .Values.ingress.path | quote }}
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: {{ printf "%s/healthz" (trimSuffix "/" .Values.ingress.path) }}
               port: http
             failureThreshold: 5
             initialDelaySeconds: 10

--- a/qlkube/deploy/qlkube/templates/httproute.yaml
+++ b/qlkube/deploy/qlkube/templates/httproute.yaml
@@ -14,8 +14,6 @@ spec:
 {{- if .Values.httproute.gateway.namespace }}
       namespace: {{ .Values.httproute.gateway.namespace }}
 {{- end }}
-  hostnames:
-    - {{ .Values.httproute.hostname }}
   rules:
     - matches:
         - path:

--- a/qlkube/deploy/qlkube/templates/httproute.yaml
+++ b/qlkube/deploy/qlkube/templates/httproute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.global.gatewayApiMode }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "qlkube.fullname" . }}
+  labels:
+    {{- include "qlkube.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.httproute.gateway.name }}
+      sectionName: https
+{{- if .Values.httproute.gateway.namespace }}
+      namespace: {{ .Values.httproute.gateway.namespace }}
+{{- end }}
+  hostnames:
+    - {{ .Values.httproute.hostname }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httproute.path }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ include "qlkube.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+{{- end }}

--- a/qlkube/deploy/qlkube/templates/httproute.yaml
+++ b/qlkube/deploy/qlkube/templates/httproute.yaml
@@ -18,7 +18,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: {{ .Values.httproute.path }}
+            value: {{ .Values.ingress.path }}
       backendRefs:
         - group: ""
           kind: Service

--- a/qlkube/deploy/qlkube/templates/ingress.yaml
+++ b/qlkube/deploy/qlkube/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.gatewayApiMode }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -24,3 +25,4 @@ spec:
     - hosts:
       - {{ .Values.ingress.hostname }}
       secretName: {{ .Values.ingress.secret }}
+{{- end }}

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -78,6 +78,8 @@ service:
   type: ClusterIP
   port: 8080
 
+global: {}
+
 ingress:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-production
@@ -92,7 +94,6 @@ ingress:
 httproute:
   gateway:
     name: crownlabs-main
-  hostname: qlkube.crownlabs.example.com
   path: /graph
 
 resources:

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -82,7 +82,6 @@ global: {}
 
 ingress:
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -87,14 +87,14 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 
-  hostname: qlkube.crownlabs.example.com
+  # Note: this hostname is not used in Gateway API mode
+  hostname: crownlabs.example.com
   path: /graph
-  secret: qlkube-certificate
+  secret: frontend-app-certificate
 
 httproute:
   gateway:
     name: crownlabs-main
-  path: /graph
 
 resources:
   limits:

--- a/qlkube/deploy/qlkube/values.yaml
+++ b/qlkube/deploy/qlkube/values.yaml
@@ -86,8 +86,14 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 
   hostname: qlkube.crownlabs.example.com
-  path: /
+  path: /graph
   secret: qlkube-certificate
+
+httproute:
+  gateway:
+    name: crownlabs-main
+  hostname: qlkube.crownlabs.example.com
+  path: /graph
 
 resources:
   limits:

--- a/qlkube/package.json
+++ b/qlkube/package.json
@@ -43,6 +43,7 @@
     "@graphql-tools/wrap": "10.0.5",
     "@kubernetes/client-node": "^1.4.0",
     "compression": "^1.8.1",
+    "cors": "^2.8.5",
     "dotenv": "^9.0.2",
     "express": "^5.2.1",
     "globals": "^15.12.0",

--- a/qlkube/package.json
+++ b/qlkube/package.json
@@ -43,7 +43,6 @@
     "@graphql-tools/wrap": "10.0.5",
     "@kubernetes/client-node": "^1.4.0",
     "compression": "^1.8.1",
-    "cors": "^2.8.5",
     "dotenv": "^9.0.2",
     "express": "^5.2.1",
     "globals": "^15.12.0",

--- a/qlkube/src/index.js
+++ b/qlkube/src/index.js
@@ -9,6 +9,7 @@ const { printSchema } = require('graphql');
 const { createServer } = require('http');
 const { WebSocketServer } = require('ws');
 const { useServer } = require('graphql-ws/lib/use/ws');
+const cors = require('cors');
 const repl = require('repl');
 const { setupSubscriptions } = require('./decorateSubscription');
 const { getOpenApiSpec } = require('./oas');
@@ -182,6 +183,7 @@ async function main() {
 
   app.use(
     basePath,
+    cors(),
     express.json(),
     expressMiddleware(server, {
       context: async ({ req }) => {

--- a/qlkube/src/index.js
+++ b/qlkube/src/index.js
@@ -9,7 +9,6 @@ const { printSchema } = require('graphql');
 const { createServer } = require('http');
 const { WebSocketServer } = require('ws');
 const { useServer } = require('graphql-ws/lib/use/ws');
-const cors = require('cors');
 const repl = require('repl');
 const { setupSubscriptions } = require('./decorateSubscription');
 const { getOpenApiSpec } = require('./oas');
@@ -61,9 +60,11 @@ async function main() {
   const app = express();
   const httpServer = createServer(app);
 
+  const basePath = process.env.BASE_URL || '/graph';
+
   app.use(compression());
 
-  app.get('/schema', (req, res) => {
+  app.get(`${basePath}/schema`, (req, res) => {
     res.setHeader('content-type', 'text/plain');
     res.send(
       printSchema(schema)
@@ -72,15 +73,19 @@ async function main() {
         .join('\n'),
     );
   });
-  app.get('/healthz', (req, res) => {
+  app.get(`${basePath}/healthz`, (req, res) => {
     res.sendStatus(200);
   });
-  app.get('/', (req, res) => {
+  app.get(`${basePath}/playground`, (req, res) => {
     res.setHeader('content-type', 'text/html');
     res.send(`<html><head><title>CrownLabs GraphQL Playground</title></head><body>
       <div></div>
       <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script> 
-      <script>new window.EmbeddedSandbox({ target: 'div', initialEndpoint: document.location.href, initialSubscriptionEndpoint: document.location.href+'subscription' });</script>
+      <script>
+        const wsProtocol = document.location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = wsProtocol + '//' + document.location.host + '${basePath}/subscription';
+        new window.EmbeddedSandbox({ target: 'div', initialEndpoint: document.location.origin + '${basePath}', initialSubscriptionEndpoint: wsUrl });
+      </script>
       <style>html, body, body > div {height: 100%;body: 100%;margin: 0;padding: 0}</style>
       </body></html>`);
   });
@@ -143,7 +148,7 @@ async function main() {
     server: httpServer,
     // Pass a different path here if app.use
     // serves expressMiddleware at a different path
-    path: '/subscription',
+    path: `${basePath}/subscription`,
   });
 
   // Hand in the schema we just created and have the
@@ -176,8 +181,7 @@ async function main() {
   await server.start();
 
   app.use(
-    '/',
-    cors(),
+    basePath,
     express.json(),
     expressMiddleware(server, {
       context: async ({ req }) => {
@@ -191,8 +195,8 @@ async function main() {
 
   httpServer.listen({ port: PORT }, () => {
     logger.info({
-      url: `http://localhost:${PORT}/`,
-      subscriptions: `ws://localhost:${PORT}/subscription`,
+      url: `http://localhost:${PORT}${basePath}`,
+      subscriptions: `ws://localhost:${PORT}${basePath}/subscription`,
     }, '🚀 Server ready');
     repl.start('> ');
   });


### PR DESCRIPTION
# Description

This PR unifies the frontend and the backend (`qlkube`) under a single domain, significantly simplifying the infrastructure routing by leveraging the Kubernetes Gateway API (`HTTPRoute`). 

Traffic is now routed based on the path (e.g., `/` for the frontend and `/graph` for the backend), leading to a much cleaner and environment-agnostic architecture.

**Main Changes:**
- **Routing:** Moved the `qlkube` mount point in the Express server from the root `/` to `process.env.BASE_URL` (defaulting to `/graph`).
- **Frontend Apollo Client:** Refactored the Apollo Client setup in React. The WebSocket connection URI (`ws://` / `wss://`) is now dynamically parsed and built based on the browser's `window.location` when a relative path is provided.
- **GraphQL Sandbox:** Updated the Apollo Embedded Sandbox script in the Node server to dynamically build the subscription websocket endpoint directly from the browser's origin.
- **Kubernetes / Helm:** 
  - Aligned `qlkube` ingress hostname and TLS secret with the `frontend-app` to share a single TLS certificate.
  - Cleaned up the umbrella chart values (`deploy/crownlabs/values.yaml`) by removing redundancy. 
  - The `qlkube` subchart now safely defaults to the expected `HTTPRoute` logic, consuming the `ingress.path` parameter in a DRY way natively inherited by the deployment via the `BASE_URL` env variable.
