### PR TITLE
Refactor PVCProvisioningJob + bugfix

### DIFF
--- a/operators/pkg/controller/sharedvolume/reconciler.go
+++ b/operators/pkg/controller/sharedvolume/reconciler.go
@@ -38,6 +38,7 @@ import (
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	ctrlcommon "github.com/netgroup-polito/CrownLabs/operators/pkg/controller/common"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/storage"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -232,7 +233,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		shvolume.Status.PVName = pv.Name
 		shvolume.Status.Phase = clv1alpha2.SharedVolumePhaseProvisioning
 
-		done, err := utils.NFSDriveProvisioning(ctx, log, r.Client, &pvc, &shvolume)
+		done, err := storage.RunPVCProvisioning(ctx, log, r.Client, &pvc, &shvolume)
 		if err != nil {
 			return ctrl.Result{}, err
 		} else if done {

--- a/operators/pkg/controller/tenant/mydrive.go
+++ b/operators/pkg/controller/tenant/mydrive.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	clv1alpha2 "github.com/netgroup-polito/CrownLabs/operators/api/v1alpha2"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/storage"
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
@@ -43,7 +43,7 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 		log.Error(err, "Unable to create or update PVC for tenant")
 		return err
 	}
-	log.Info("PVC created/updated")
+	log.Info("PVC enforced")
 
 	switch pvc.Status.Phase {
 	case corev1.ClaimBound:
@@ -52,18 +52,13 @@ func (r *Reconciler) enforcePersonalStorage(ctx context.Context, log logr.Logger
 			log.Error(err, "Unable to create or update PVC Mirror for tenant")
 			return err
 		} else if created {
-			log.Info("PVC Mirror created/updated")
+			log.Info("PVC Mirror enforced")
 		} else {
 			log.Info("Tenant namespace does not exist, skipping PVC Mirror creation")
 		}
 
-		val, found := pvc.Labels[forge.ProvisionJobLabel]
-		if !found || val != forge.ProvisionJobValueOk {
-			err = r.launchPVCProvisionJob(ctx, log, tn, pvc)
-			if err != nil {
-				log.Error(err, "Unable to manage PVC Provisioning Job for tenant")
-				return err
-			}
+		if _, err := storage.RunPVCProvisioning(ctx, log, r.Client, pvc, tn); err != nil {
+			return err
 		}
 	case corev1.ClaimPending:
 		log.Info("PVC pending for tenant")
@@ -157,50 +152,4 @@ func (r *Reconciler) enforceMyDrivePVCMirror(
 	}
 
 	return true, nil
-}
-
-func (r *Reconciler) launchPVCProvisionJob(
-	ctx context.Context,
-	log logr.Logger,
-	tn *clv1alpha2.Tenant,
-	pvc *corev1.PersistentVolumeClaim,
-) error {
-	chownJob := batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pvc.Name + "-provision",
-			Namespace: pvc.Namespace,
-		},
-	}
-	labelToSet := forge.ProvisionJobValuePending
-
-	_, err := ctrlutil.CreateOrUpdate(ctx, r.Client, &chownJob, func() error {
-		if chownJob.CreationTimestamp.IsZero() {
-			log.Info("PVC Provisioning Job created for tenant")
-			// Configure the provisioning job
-			forge.ConfigureMyDriveProvisioningJob(&chownJob, pvc)
-		} else if chownJob.Labels[forge.ProvisionJobLabel] == forge.ProvisionJobValuePending {
-			if chownJob.Status.Succeeded == 1 {
-				labelToSet = forge.ProvisionJobValueOk
-				log.Info("PVC Provisioning Job completed for tenant")
-			} else if chownJob.Status.Failed == 1 {
-				log.Info("PVC Provisioning Job failed for tenant")
-			}
-		}
-
-		return ctrlutil.SetControllerReference(tn, &chownJob, r.Scheme)
-	})
-	if err != nil {
-		return fmt.Errorf("unable to create or update PVC Provisioning Job: %w", err)
-	}
-	log.Info("PVC Provisioning Job launched")
-
-	// Update the PVC label
-	if err := utils.PatchObject(ctx, r.Client, pvc, func(p *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
-		forge.UpdatePVCProvisioningJobLabel(p, labelToSet)
-		return p
-	}); err != nil {
-		return fmt.Errorf("unable to update PVC Provisioning Job label: %w", err)
-	}
-
-	return nil
 }

--- a/operators/pkg/controller/tenant/mydrive_test.go
+++ b/operators/pkg/controller/tenant/mydrive_test.go
@@ -178,19 +178,13 @@ var _ = Describe("MyDrive management", func() {
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
 					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						VolumeName: "pv-" + tnName,
-					},
 				}
 
 				// Create a job that has succeeded
 				job := &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      forge.MyDrivePVCName(tnName) + "-provision",
-						Namespace: "mydrive-pvcs",
-						Labels: map[string]string{
-							forge.ProvisionJobLabel: forge.ProvisionJobValuePending,
-						},
+						Name:              forge.MyDrivePVCName(tnName) + "-provision",
+						Namespace:         "mydrive-pvcs",
 						CreationTimestamp: metav1.Now(),
 					},
 					Status: batchv1.JobStatus{
@@ -199,6 +193,9 @@ var _ = Describe("MyDrive management", func() {
 				}
 
 				BeforeEach(func() {
+					// Clean up the outer version of the object
+					removeObjFromObjectsList(pvc)
+
 					addObjToObjectsList(pvc)
 					addObjToObjectsList(job)
 				})
@@ -210,16 +207,13 @@ var _ = Describe("MyDrive management", func() {
 				})
 
 				It("Should update the PVC label to ok", func() {
-					pvc := &corev1.PersistentVolumeClaim{}
 					Eventually(func() string {
-						err := cl.Get(ctx, client.ObjectKey{
-							Name:      forge.MyDrivePVCName(tnName),
-							Namespace: "mydrive-pvcs",
-						}, pvc)
+						gotPvc := &corev1.PersistentVolumeClaim{}
+						err := cl.Get(ctx, forge.NamespacedNameFromObject(pvc), gotPvc)
 						if err != nil {
 							return ""
 						}
-						return pvc.Labels[forge.ProvisionJobLabel]
+						return gotPvc.Labels[forge.ProvisionJobLabel]
 					}, timeout, interval).Should(Equal(forge.ProvisionJobValueOk))
 				})
 			})
@@ -238,19 +232,13 @@ var _ = Describe("MyDrive management", func() {
 					Status: corev1.PersistentVolumeClaimStatus{
 						Phase: corev1.ClaimBound,
 					},
-					Spec: corev1.PersistentVolumeClaimSpec{
-						VolumeName: "pv-" + tnName,
-					},
 				}
 
 				// Create a job that has failed
 				job := &batchv1.Job{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      forge.MyDrivePVCName(tnName) + "-provision",
-						Namespace: "mydrive-pvcs",
-						Labels: map[string]string{
-							forge.ProvisionJobLabel: forge.ProvisionJobValuePending,
-						},
+						Name:              forge.MyDrivePVCName(tnName) + "-provision",
+						Namespace:         "mydrive-pvcs",
 						CreationTimestamp: metav1.Now(),
 					},
 					Status: batchv1.JobStatus{
@@ -259,6 +247,9 @@ var _ = Describe("MyDrive management", func() {
 				}
 
 				BeforeEach(func() {
+					// Clean up the outer version of the object
+					removeObjFromObjectsList(pvc)
+
 					addObjToObjectsList(pvc)
 					addObjToObjectsList(job)
 				})
@@ -270,16 +261,13 @@ var _ = Describe("MyDrive management", func() {
 				})
 
 				It("Should keep the PVC label as pending", func() {
-					pvc := &corev1.PersistentVolumeClaim{}
 					Consistently(func() string {
-						err := cl.Get(ctx, client.ObjectKey{
-							Name:      forge.MyDrivePVCName(tnName),
-							Namespace: "mydrive-pvcs",
-						}, pvc)
+						gotPvc := &corev1.PersistentVolumeClaim{}
+						err := cl.Get(ctx, forge.NamespacedNameFromObject(pvc), gotPvc)
 						if err != nil {
 							return ""
 						}
-						return pvc.Labels[forge.ProvisionJobLabel]
+						return gotPvc.Labels[forge.ProvisionJobLabel]
 					}, 2*time.Second, 250*time.Millisecond).Should(Equal(forge.ProvisionJobValuePending))
 				})
 			})

--- a/operators/pkg/forge/storage.go
+++ b/operators/pkg/forge/storage.go
@@ -193,18 +193,13 @@ func MyDrivePVCSpec(storageClassName string, storageSize resource.Quantity) core
 }
 
 // UpdatePVCProvisioningJobLabel updates the provisioning job label for a PVC.
-func UpdatePVCProvisioningJobLabel(pvc *corev1.PersistentVolumeClaim, value string) {
-	if pvc.Labels == nil {
-		pvc.Labels = make(map[string]string)
+func UpdatePVCProvisioningJobLabel(labels map[string]string, value string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string, 1)
 	}
-	pvc.Labels[ProvisionJobLabel] = value
-}
+	labels[ProvisionJobLabel] = value
 
-// ConfigureMyDriveProvisioningJob configures a Job for provisioning a PVC.
-func ConfigureMyDriveProvisioningJob(job *batchv1.Job, pvc *corev1.PersistentVolumeClaim) {
-	// Set job spec using PVCProvisioningJobSpec
-	jobSpec := PVCProvisioningJobSpec(pvc)
-	job.Spec = jobSpec
+	return labels
 }
 
 // MirrorPVCSpec forges the spec for the PVC that will mirror the "origin" one.

--- a/operators/pkg/forge/storage_test.go
+++ b/operators/pkg/forge/storage_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -427,53 +426,25 @@ var _ = Describe("External Volume Mounts and Provisioning Job forging", func() {
 
 	Describe("UpdatePVCProvisioningJobLabel", func() {
 		It("Should initialize labels if nil and set provisioning job label", func() {
-			pvc := &corev1.PersistentVolumeClaim{}
+			var labels map[string]string
 
-			forge.UpdatePVCProvisioningJobLabel(pvc, "job-123")
+			labels = forge.UpdatePVCProvisioningJobLabel(labels, "job-123")
 
-			Expect(pvc.Labels).ToNot(BeNil())
-			Expect(pvc.Labels).To(HaveKeyWithValue("crownlabs.polito.it/volume-provisioning", "job-123"))
+			Expect(labels).ToNot(BeNil())
+			Expect(labels).To(HaveKeyWithValue("crownlabs.polito.it/volume-provisioning", "job-123"))
 		})
 
 		It("Should update provisioning job label on existing labels", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"crownlabs.polito.it/volume-provisioning": "old-job",
-						"existing-label": "existing-value",
-					},
-				},
+			labels := map[string]string{
+				"crownlabs.polito.it/volume-provisioning": "old-job",
+				"existing-label": "existing-value",
 			}
 
-			forge.UpdatePVCProvisioningJobLabel(pvc, "job-456")
+			labels = forge.UpdatePVCProvisioningJobLabel(labels, "job-456")
 
-			Expect(pvc.Labels).ToNot(BeNil())
-			Expect(pvc.Labels).To(HaveKeyWithValue("existing-label", "existing-value"))
-			Expect(pvc.Labels).To(HaveKeyWithValue("crownlabs.polito.it/volume-provisioning", "job-456"))
-		})
-	})
-
-	Describe("ConfigureMyDriveProvisioningJob", func() {
-		It("Should configure the job spec using PVCProvisioningJobSpec", func() {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pvc",
-					Namespace: "test-namespace",
-				},
-			}
-			job := &batchv1.Job{}
-
-			forge.ConfigureMyDriveProvisioningJob(job, pvc)
-
-			// Verify that the spec is correctly configured
-			Expect(job.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
-			Expect(job.Spec.BackoffLimit).ToNot(BeNil())
-			Expect(*job.Spec.BackoffLimit).To(Equal(int32(forge.ProvisionJobMaxRetries)))
-			Expect(job.Spec.TTLSecondsAfterFinished).ToNot(BeNil())
-			Expect(*job.Spec.TTLSecondsAfterFinished).To(Equal(int32(forge.ProvisionJobTTLSeconds)))
-
-			// Verify that there is a container
-			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(labels).ToNot(BeNil())
+			Expect(labels).To(HaveKeyWithValue("existing-label", "existing-value"))
+			Expect(labels).To(HaveKeyWithValue("crownlabs.polito.it/volume-provisioning", "job-456"))
 		})
 	})
 

--- a/operators/pkg/forge/utils.go
+++ b/operators/pkg/forge/utils.go
@@ -37,27 +37,36 @@ func init() {
 	petname.NonDeterministicMode()
 }
 
-// ObjectMeta returns the namespace/name pair given an instance object.
-func ObjectMeta(instance *clv1alpha2.Instance) metav1.ObjectMeta {
+// ObjectMeta returns the namespace/name pair given a Kubernetes object.
+//
+// Note: Remember all k8s resource structs (e.g. Pod, Deployment, ...) do not implement the
+// metav1.Object interface, but any pointer to them does.
+func ObjectMeta(object metav1.Object) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      CanonicalName(instance.GetName()),
-		Namespace: instance.GetNamespace(),
+		Name:      CanonicalName(object.GetName()),
+		Namespace: object.GetNamespace(),
 	}
 }
 
-// ObjectMetaWithSuffix returns the namespace/name pair given an instance object and a name suffix.
-func ObjectMetaWithSuffix(instance *clv1alpha2.Instance, suffix string) metav1.ObjectMeta {
+// ObjectMetaWithSuffix returns the namespace/name pair given a Kubernetes object and a name suffix.
+//
+// Note: Remember all k8s resource structs (e.g. Pod, Deployment, ...) do not implement the
+// metav1.Object interface, but any pointer to them does.
+func ObjectMetaWithSuffix(object metav1.Object, suffix string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      CanonicalName(instance.GetName()) + StringSeparator + suffix,
-		Namespace: instance.GetNamespace(),
+		Name:      CanonicalName(object.GetName()) + StringSeparator + suffix,
+		Namespace: object.GetNamespace(),
 	}
 }
 
-// NamespacedNameWithSuffix returns the namespace/name pair given an instance object and a name suffix.
-func NamespacedNameWithSuffix(instance *clv1alpha2.Instance, suffix string) types.NamespacedName {
+// NamespacedNameWithSuffix returns the namespace/name pair given a Kubernetes object and a name suffix.
+//
+// Note: Remember all k8s resource structs (e.g. Pod, Deployment, ...) do not implement the
+// metav1.Object interface, but any pointer to them does.
+func NamespacedNameWithSuffix(object metav1.Object, suffix string) types.NamespacedName {
 	return types.NamespacedName{
-		Name:      CanonicalName(instance.GetName()) + StringSeparator + suffix,
-		Namespace: instance.GetNamespace(),
+		Name:      CanonicalName(object.GetName()) + StringSeparator + suffix,
+		Namespace: object.GetNamespace(),
 	}
 }
 

--- a/operators/pkg/storage/provisioning.go
+++ b/operators/pkg/storage/provisioning.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package utils collects all the logic shared between different controllers
-package utils
+// Package storage collects all the logic behind the provisioning of attachable storage
+package storage
 
 import (
 	"context"
@@ -26,22 +26,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/netgroup-polito/CrownLabs/operators/pkg/forge"
+	"github.com/netgroup-polito/CrownLabs/operators/pkg/utils"
 )
 
-// NFSDriveProvisioning enforces a job to provision the passed PVC, changing its owner and adding it a label when done.
-func NFSDriveProvisioning(ctx context.Context, log logr.Logger, c client.Client, pvc *corev1.PersistentVolumeClaim, owner metav1.Object) (bool, error) {
+// RunPVCProvisioning enforces a job to provision the passed PVC, changing its owner and adding it a label when done.
+// Returns a bool as first parameter that represents whether the job has completed successfully.
+func RunPVCProvisioning(ctx context.Context, log logr.Logger, c client.Client, pvc *corev1.PersistentVolumeClaim, owner metav1.Object) (bool, error) {
 	log = log.WithName("provisioning-job")
 
 	val, found := pvc.Labels[forge.ProvisionJobLabel]
 	if !found || val != forge.ProvisionJobValueOk {
-		chownJob := batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: pvc.Name + "-provision", Namespace: pvc.Namespace}}
+		chownJob := batchv1.Job{
+			ObjectMeta: forge.ObjectMetaWithSuffix(pvc, "provision"),
+		}
 		labelToSet := forge.ProvisionJobValuePending
 
 		chownJobOpRes, err := ctrl.CreateOrUpdate(ctx, c, &chownJob, func() error {
 			if chownJob.CreationTimestamp.IsZero() {
 				log.Info("Created")
 				chownJob.Spec = forge.PVCProvisioningJobSpec(pvc)
-			} else if found && val == forge.ProvisionJobValuePending {
+			} else {
 				if chownJob.Status.Succeeded == 1 {
 					labelToSet = forge.ProvisionJobValueOk
 					log.Info("Completed")
@@ -58,16 +62,17 @@ func NFSDriveProvisioning(ctx context.Context, log logr.Logger, c client.Client,
 		}
 		log.Info("Job enforced", "result", chownJobOpRes)
 
-		if labelToSet != pvc.Labels[forge.ProvisionJobLabel] {
-			log.Info("PVC labels changed",
-				"previous", pvc.Labels[forge.ProvisionJobLabel], "current", labelToSet)
-
-			pvc.Labels[forge.ProvisionJobLabel] = labelToSet
-			if err := c.Update(ctx, pvc); err != nil {
-				log.Error(err, "Failed to update PVC labels")
-				return false, err
-			}
+		// Update the PVC label
+		if err := utils.PatchObject(ctx, c, pvc, func(pvc *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaim {
+			pvc.SetLabels(forge.UpdatePVCProvisioningJobLabel(pvc.Labels, labelToSet))
+			return pvc
+		}); err != nil {
+			log.Error(err, "unable to update PVC Provisioning Job label")
+			return false, err
 		}
+
+		log.Info("PVC labels changed",
+			"previous", val, "current", labelToSet)
 	}
 
 	if pvc.Labels[forge.ProvisionJobLabel] == forge.ProvisionJobValueOk {


### PR DESCRIPTION
# Description

This PR refactors the `PVCProvisioningJob` (chown job) by relocating it to a dedicated new package: `storage`. Additionally, it resolves a regression introduced in #947 regarding the PVC `volume-provisioning` (job status) label which was stuck on `pending` even if the job has completed successfully (pointed out by @air-31 on 2026-03-25).

The rationale behind the moving is that the previous location (`utils`) was prone to causing cyclic imports, making the codebase fragile and harder to maintain. This decoupling isolates storage provisioning logic cleanly.