### PR TITLE
Destruction after inactivity (frontend)

### DIFF
--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -24,6 +24,10 @@ frontend-app:
       clientId: <client-id>
       realm: <realm>
       providerUrl: https://auth.example.com/auth/
+    defaultTimeouts:
+      inactivityTimeout: "15d"
+      destroyAfterInactivity: "never"
+      deleteAfter: "never"
 
 qlkube:
   replicaCount: 1

--- a/frontend/deploy/frontend-app/templates/configmap.yaml
+++ b/frontend/deploy/frontend-app/templates/configmap.yaml
@@ -16,3 +16,6 @@ data:
     window.VITE_APP_CROWNLABS_GROUPS_ADMIN_CLAIM="{{ .Values.configuration.oidc.adminClaim }}";
     window.VITE_APP_CROWNLABS_GRAFANA_DASHBOARD_URL="{{ .Values.configuration.backend.grafana }}";
     window.VITE_APP_CROWNLABS_BASTION_HOST="{{ .Values.configuration.backend.bastion }}";
+    window.VITE_APP_DEFAULT_INACTIVITY_TIMEOUT="{{ .Values.configuration.defaultTimeouts.inactivityTimeout }}";
+    window.VITE_APP_DEFAULT_DESTROY_AFTER_INACTIVITY="{{ .Values.configuration.defaultTimeouts.destroyAfterInactivity }}";
+    window.VITE_APP_DEFAULT_DELETE_AFTER="{{ .Values.configuration.defaultTimeouts.deleteAfter }}";

--- a/frontend/deploy/frontend-app/values.yaml
+++ b/frontend/deploy/frontend-app/values.yaml
@@ -26,6 +26,10 @@ configuration:
   mydrive:
     templateName: mydrive
     workspaceName: utilities
+  defaultTimeouts:
+    inactivityTimeout: "15d"
+    destroyAfterInactivity: "never"
+    deleteAfter: "never"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
@@ -3,7 +3,7 @@ import { useState, useContext, useEffect, useCallback, useMemo } from 'react';
 import { Modal, Form, Input, InputNumber, Select, Tooltip, Checkbox, Collapse, theme, Typography, Space, Flex } from 'antd';
 import { Button } from 'antd';
 import type { CreateTemplateMutation } from '../../../generated-types';
-import { InfoCircleOutlined } from '@ant-design/icons';
+import { InfoCircleOutlined, CheckSquareFilled, CloseSquareFilled } from '@ant-design/icons';
 import type { RuleObject } from 'antd/es/form';
 import {
   useNodesLabelsQuery,
@@ -53,23 +53,34 @@ export interface IModalCreateTemplateProps {
   isPersonal?: boolean;
 }
 
+const STATUS_ICON_COLORS = {
+  on: '#52c41a',
+  off: '#c1c1c1ff',
+};
+
+const StatusIcon = ({ active }: { active: boolean }) => (
+  active
+    ? <CheckSquareFilled style={{ color: STATUS_ICON_COLORS.on }} />
+    : <CloseSquareFilled style={{ color: STATUS_ICON_COLORS.off }} />
+);
+
 const TimeUnitOptions = [
-    { label: 'Minutes', value: 'm' },
-    { label: 'Hours', value: 'h' },
-    { label: 'Days', value: 'd' },
-  ];
+  { label: 'Minutes', value: 'm' },
+  { label: 'Hours', value: 'h' },
+  { label: 'Days', value: 'd' },
+];
 
 const parseTimeoutString = (s?: string) => {
-    if (!s || s === 'never') return { value: 0, unit: '' }
-    const m = String(s).trim().match(/^(\d+)\s*([mhd])$/i)
-    if (!m) return { value: 0, unit: '' }
-    
-    const unitOpt = TimeUnitOptions.find(
-      opt => opt.value === m[2].toLowerCase(),
-    );
+  if (!s || s === 'never') return { value: 0, unit: '' }
+  const m = String(s).trim().match(/^(\d+)\s*([mhd])$/i)
+  if (!m) return { value: 0, unit: '' }
 
-    return { value: Number(m[1]), unit: unitOpt ? unitOpt.value : ''}
-  };
+  const unitOpt = TimeUnitOptions.find(
+    opt => opt.value === m[2].toLowerCase(),
+  );
+
+  return { value: Number(m[1]), unit: unitOpt ? unitOpt.value : '' }
+};
 
 const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
   const {
@@ -229,12 +240,13 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
       nodeSelectorObject = null;
     }
 
-    
+
     const parsedTemplate = {
       ...template,
       allowPublicExposure: isPublicExposureEnabled,
       description: template.description || template.name,
       inactivityTimeout: timeouts.inactivityTimeout.value === 0 ? 'never' : `${timeouts.inactivityTimeout.value}${timeouts.inactivityTimeout.unit}`,
+      destroyAfterInactivity: timeouts.destroyAfterInactivity.value === 0 ? 'never' : `${timeouts.destroyAfterInactivity.value}${timeouts.destroyAfterInactivity.unit}`,
       deleteAfter: timeouts.deleteAfter.value === 0 ? 'never' : `${timeouts.deleteAfter.value}${timeouts.deleteAfter.unit}`,
       environments: template.environments.map(env => ({
         ...env,
@@ -245,10 +257,11 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
     try {
       setShow(false);
       await submitHandler(parsedTemplate);
-      
+
       form.resetFields();
       setTimeouts({
         inactivityTimeout: { value: 0, unit: '' },
+        destroyAfterInactivity: { value: 0, unit: '' },
         deleteAfter: { value: 0, unit: '' },
       });
       setNodeSelectorMode('Disabled');
@@ -279,35 +292,33 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
 
   const [timeouts, setTimeouts] = useState(
     {
-    inactivityTimeout: { value: parseTimeoutString(template?.inactivityTimeout).value ?? 0, unit: parseTimeoutString(template?.inactivityTimeout).unit ?? '' },
-    deleteAfter: { value: parseTimeoutString(template?.deleteAfter).value ?? 0, unit: parseTimeoutString(template?.deleteAfter).unit ?? '' },
-  });
-
-    const {
-      data: labelsData,
-      loading: loadingLabels,
-      error: labelsError,
-    } = useNodesLabelsQuery({ 
-      fetchPolicy: 'cache-first',
-      skip: !show, // Only fetch when modal is open
+      inactivityTimeout: { value: parseTimeoutString(template?.inactivityTimeout).value ?? 0, unit: parseTimeoutString(template?.inactivityTimeout).unit ?? '' },
+      destroyAfterInactivity: { value: parseTimeoutString(template?.destroyAfterInactivity).value ?? 0, unit: parseTimeoutString(template?.destroyAfterInactivity).unit ?? '' },
+      deleteAfter: { value: parseTimeoutString(template?.deleteAfter).value ?? 0, unit: parseTimeoutString(template?.deleteAfter).unit ?? '' },
     });
+
+  const {
+    data: labelsData,
+    loading: loadingLabels,
+    error: labelsError,
+  } = useNodesLabelsQuery({
+    fetchPolicy: 'cache-first',
+    skip: !show, // Only fetch when modal is open
+  });
 
 
   useEffect(() => {
-  if (!show) return;
+    if (!show) return;
 
-  if (template) {
-    const initial = getInitialValues(template);
-    form.setFieldsValue(initial);
-    setTimeouts({
-      inactivityTimeout: parseTimeoutString(initial.inactivityTimeout),
-      deleteAfter: parseTimeoutString(initial.deleteAfter),
-    });
-    setAutomaticStoppingEnabled(
-      (initial.inactivityTimeout) !== 'never' ||
-        (initial.deleteAfter) !== 'never',
-    );
-    setIsPublicExposureEnabled(initial.allowPublicExposure ?? false);
+    if (template) {
+      const initial = getInitialValues(template);
+      form.setFieldsValue(initial);
+      setTimeouts({
+        inactivityTimeout: parseTimeoutString(initial.inactivityTimeout),
+        destroyAfterInactivity: parseTimeoutString(initial.destroyAfterInactivity),
+        deleteAfter: parseTimeoutString(initial.deleteAfter),
+      });
+      setIsPublicExposureEnabled(initial.allowPublicExposure ?? false);
       // Set node selector mode and labels based on template
       if (template.nodeSelector) {
         if (Object.keys(template.nodeSelector).length === 0) {
@@ -337,20 +348,20 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
         setSelectedLabels([]);
       }
 
-  } else {
-    form.resetFields();
-    form.setFieldsValue(getInitialValues(undefined));
-    setTimeouts({
-      inactivityTimeout: { value: 0, unit: '' },
-      deleteAfter: { value: 0, unit: '' },
-    });
-    setAutomaticStoppingEnabled(false);
-    setNodeSelectorMode(NodeSelectorOptionMap['NodeSelectorDisabled']);
-    setSelectedLabels([]);
-    setIsPublicExposureEnabled(false);
-  }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-}, [template, show, form, labelsData]);
+    } else {
+      form.resetFields();
+      form.setFieldsValue(getInitialValues(undefined));
+      setTimeouts({
+        inactivityTimeout: { value: 0, unit: '' },
+        destroyAfterInactivity: { value: 0, unit: '' },
+        deleteAfter: { value: 0, unit: '' },
+      });
+      setNodeSelectorMode(NodeSelectorOptionMap['NodeSelectorDisabled']);
+      setSelectedLabels([]);
+      setIsPublicExposureEnabled(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [template, show, form, labelsData]);
 
   const NodeSelectorOptionMap: { [key: string]: string } = {
     'NodeSelectorDisabled': 'Automatic',
@@ -363,44 +374,43 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
     'FixedSelection': 'Select specific node labels to constrain where instances can run',
   };
 
-  const [automaticStoppingEnabled, setAutomaticStoppingEnabled] = useState(false);
   const [nodeSelectorMode, setNodeSelectorMode] = useState<string>(NodeSelectorOptionMap['NodeSelectorDisabled']);
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [isPublicExposureEnabled, setIsPublicExposureEnabled] = useState(false);
 
-  
-const handleSelectorLabelChange = useCallback((values: string[]) => {
-  
-  // Filter out duplicate keys - keep only the last selected value for each key
-  const seenKeys = new Map<string, string>();
-  const filteredValues: string[] = [];
-  
-  // Process in reverse to keep the most recent selection for each key
-  for (let i = values.length - 1; i >= 0; i--) {
-    try {
-      const labelPair = JSON.parse(values[i]);
-      const key = Object.keys(labelPair)[0];
-      
-      if (!seenKeys.has(key)) {
-        seenKeys.set(key, values[i]);
-        filteredValues.unshift(values[i]); // Add to beginning to maintain order
+
+  const handleSelectorLabelChange = useCallback((values: string[]) => {
+
+    // Filter out duplicate keys - keep only the last selected value for each key
+    const seenKeys = new Map<string, string>();
+    const filteredValues: string[] = [];
+
+    // Process in reverse to keep the most recent selection for each key
+    for (let i = values.length - 1; i >= 0; i--) {
+      try {
+        const labelPair = JSON.parse(values[i]);
+        const key = Object.keys(labelPair)[0];
+
+        if (!seenKeys.has(key)) {
+          seenKeys.set(key, values[i]);
+          filteredValues.unshift(values[i]); // Add to beginning to maintain order
+        }
+      } catch (e) {
+        console.error('Error parsing label:', e);
       }
-    } catch (e) {
-      console.error('Error parsing label:', e);
     }
-  }
-  setSelectedLabels(filteredValues);
-}, []);
+    setSelectedLabels(filteredValues);
+  }, []);
 
-const handleNodeSelectorModeChange = useCallback((value: string) => {
-  setNodeSelectorMode(value);
-  if (value === NodeSelectorOptionMap['NodeSelectorDisabled']) {
-    setSelectedLabels([]);
-  }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-}, []);
+  const handleNodeSelectorModeChange = useCallback((value: string) => {
+    setNodeSelectorMode(value);
+    if (value === NodeSelectorOptionMap['NodeSelectorDisabled']) {
+      setSelectedLabels([]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const handleTimeoutValueChange = (value: number | null, field: 'inactivityTimeout' | 'deleteAfter') => {
+  const handleTimeoutValueChange = (value: number | null, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
     setTimeouts(prevTimeouts => ({
       ...prevTimeouts,
       [field]: {
@@ -409,13 +419,13 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
       },
     }));
     form.setFieldValue(field, {
-    value,
-    unit: timeouts[field].unit,
+      value,
+      unit: timeouts[field].unit,
     });
-    form.validateFields(['inactivityTimeout', 'deleteAfter']).catch(() => {});
+    form.validateFields(['inactivityTimeout', 'destroyAfterInactivity', 'deleteAfter']).catch(() => { });
   }
 
-  const handleTimeUnitChange = (value: string, field: 'inactivityTimeout' | 'deleteAfter') => {
+  const handleTimeUnitChange = (value: string, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
     setTimeouts(prevTimeouts => ({
       ...prevTimeouts,
       [field]: {
@@ -424,29 +434,29 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
       },
     }));
     form.setFieldValue(field, {
-    value: timeouts[field].value,
-    unit: value,
+      value: timeouts[field].value,
+      unit: value,
     });
-    form.validateFields(['inactivityTimeout', 'deleteAfter']).catch(() => {});
+    form.validateFields(['inactivityTimeout', 'destroyAfterInactivity', 'deleteAfter']).catch(() => { });
   }
 
-  const isTimeUnitDisabled = (field: 'inactivityTimeout' | 'deleteAfter') => {
+  const isTimeUnitDisabled = (field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
     return timeouts[field].value === 0;
   };
-  
-  const validateTimeout = async (_: RuleObject, _val: { value: number; unit: string } ) => {
-    if (_val.value === undefined || _val.value === 0) {
-      return true; 
+
+  const validateTimeout = async (_: RuleObject, _val: { value: number; unit: string } | undefined) => {
+    if (!_val || _val.value === undefined || _val.value === 0) {
+      return true;
     }
 
     if (TimeUnitOptions.map(option => option.value).includes(_val.unit) === false) {
       throw new Error("Insert a valid time unit");
-    } 
+    }
     return true;
   };
 
-  const validateTimeoutOrder = async (_: RuleObject , _val: { value: number; unit: string } | undefined, field: 'inactivityTimeout' | 'deleteAfter') => {
-   
+  const validateTimeoutOrder = async (_: RuleObject, _val: { value: number; unit: string } | undefined, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
+
     const toMinutes = (t: { value: number; unit: string } | undefined) => {
       if (!t) return undefined;
       if (t.value === 0) return Infinity;
@@ -454,8 +464,8 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
       const mul = u === 'h' ? 60 : u === 'd' ? 1440 : 1;
       return Number(t.value) * mul;
     };
-    
-    const current =  form.getFieldValue(field);
+
+    const current = form.getFieldValue(field);
     const inactivity = field === 'inactivityTimeout' ? current : form.getFieldValue('inactivityTimeout') as { value: number; unit: string } | undefined;
     const deleteAfter = field === 'deleteAfter' ? current : form.getFieldValue('deleteAfter') as { value: number; unit: string } | undefined;
 
@@ -468,13 +478,13 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
 
     if (typeof inactivityMin !== 'number' || typeof deleteAfterMin !== 'number') return;
 
-    if (inactivityMin >= deleteAfterMin) {
+    if (!isTimeUnitDisabled('inactivityTimeout') && inactivityMin >= deleteAfterMin) {
       throw new Error('Inactivity must be smaller than Expiration');
     }
     return;
   };
 
-  const [infoNumberTemplate, setInfoNumberTemplate] = useState<number>(template?.environments?.length ?? 1 );
+  const [infoNumberTemplate, setInfoNumberTemplate] = useState<number>(template?.environments?.length ?? 1);
 
 
   // Memoize processed labels to avoid recalculating on every render
@@ -488,7 +498,7 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
         },
       ];
     }
-    
+
     return labelsData?.labels?.map(({ key, value }) => ({
       value: JSON.stringify({ [key]: value }),
       label: `${cleanupLabels(key)}=${value}`,
@@ -498,67 +508,66 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
   // Helper function to map camelCase keys back to original format
   const findOriginalLabelKey = (camelCaseKey: string, value: string): { key: string; value: string } | null => {
     if (!labelsData?.labels) return null;
-    
+
     // First, try exact match (in case the key wasn't camelCased)
     const exactMatch = labelsData.labels.find(
       label => label.key === camelCaseKey && label.value === value
     );
     if (exactMatch) return exactMatch;
-    
+
     // Otherwise, find by matching cleaned version
     const cleanedCamelCase = cleanupLabels(camelCaseKey);
     const match = labelsData.labels.find(
       label => cleanupLabels(label.key) === cleanedCamelCase && label.value === value
     );
-    
+
     return match || null;
   };
 
-    const handleEnablingCleanUp = (enabled: boolean) => {
-      setAutomaticStoppingEnabled(enabled);
-      if (!enabled) {
-        // If disabling, reset timeouts to 0
-        setTimeouts({
-          inactivityTimeout: { value: 0, unit: '' },
-          deleteAfter: { value: 0, unit: '' },
-        });
-        form.setFieldValue('inactivityTimeout', { value: 0, unit: '' });
-        form.setFieldValue('deleteAfter', { value: 0, unit: '' });
-        form.validateFields(['inactivityTimeout', 'deleteAfter']).catch(() => {});
-      }
-    };
-
   const automaticInstanceSavingResource = <>
-  <Checkbox className="mb-4" checked={automaticStoppingEnabled} onChange={e => handleEnablingCleanUp(e.target.checked)}>Enable automatic clean-up</Checkbox>
-        
-      <Form.Item
-        label="Max Inactivity"
-        name="inactivityTimeout"
-        required={isTimeUnitDisabled('inactivityTimeout') ? false : true}
-        validateTrigger="onChange"
-        rules={[{ validator: validateTimeout }, { validator: (rule, value) => validateTimeoutOrder(rule, value, 'inactivityTimeout') }]}
-        {...formItemLayout}> 
-        
+    <style>{`
+      .right-align-error .ant-form-item-explain-error {
+        text-align: right;
+      }
+      .multiline-label .ant-form-item-label > label {
+        height: auto !important;
+        white-space: normal !important;
+        align-items: flex-start !important;
+      }
+    `}</style>
+    <Typography.Paragraph type="secondary" italic className="mb-4">
+      Set the value to 0 to disable the corresponding feature
+    </Typography.Paragraph>
+    <Form.Item
+      className="right-align-error multiline-label"
+      colon={false}
+      label={<div className="flex flex-col text-left"><span>Power off if inactive for:</span><Typography.Text keyboard className="w-max mt-1">Stop</Typography.Text></div>}
+      name="inactivityTimeout"
+      validateTrigger="onChange"
+      rules={[{ validator: validateTimeout }, { validator: (rule, value) => validateTimeoutOrder(rule, value, 'inactivityTimeout') }]}
+      {...formItemLayout}>
+
+      <div className="flex flex-1 w-full items-center justify-between">
+        <Tooltip title={<><p>Instances based on this template are stopped / deleted (based on their persistency) if they're not accessed within this time (in certain special cases, activity might not be correctly detected, see <a href='https://github.com/netgroup-polito/CrownLabs/blob/master/operators/pkg/instautoctrl/README.md#instance-inactive-termination-controller'>here</a> for further technical information).</p> <p> <b>Set 0 to disable the feature.</b></p></>}>
+          <InfoCircleOutlined className='ml-2' />
+        </Tooltip>
         <div className="flex gap-4 items-center">
-          <Tooltip title={<><p>Instances based on this template are stopped / deleted (based on their persistency) if they're not accessed within this time (in certain special cases, activity might not be correctly detected, see <a href='https://github.com/netgroup-polito/CrownLabs/blob/master/operators/pkg/instautoctrl/README.md#instance-inactive-termination-controller'>here</a> for further technical information).</p> <p> <b>Set 0 to disable the feature.</b></p></>}>
-            <InfoCircleOutlined className='ml-2'/>
-          </Tooltip>
           <InputNumber
             onChange={value => handleTimeoutValueChange(value, 'inactivityTimeout')}
             min={0}
             max={60}
-            defaultValue={timeouts.inactivityTimeout.value }
-            disabled={!automaticStoppingEnabled}
+            defaultValue={timeouts.inactivityTimeout.value}
           >
           </InputNumber>
 
           <Select
+            style={{ width: 130 }}
             onChange={value => handleTimeUnitChange(value, 'inactivityTimeout')}
-            disabled={isTimeUnitDisabled('inactivityTimeout') || !automaticStoppingEnabled}
+            disabled={isTimeUnitDisabled('inactivityTimeout')}
             placeholder="Select Time unit"
             getPopupContainer={trigger => trigger.parentElement || document.body}
             defaultValue={parseTimeoutString(template?.inactivityTimeout).unit}
-            
+
           >
             {TimeUnitOptions.map(option => (
               <Select.Option key={option.value} value={option.value}>
@@ -567,33 +576,75 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
             ))}
           </Select>
         </div>
-      </Form.Item>
+      </div>
+    </Form.Item>
 
-      <Form.Item
-        label="Max Lifetime"
-        name="deleteAfter"
-        required={isTimeUnitDisabled('deleteAfter') ? false : true}
-        validateTrigger="onChange"
-        rules={[{ validator: validateTimeout }]}
-        {...formItemLayout}> 
-        
+    <Form.Item
+      className="right-align-error multiline-label"
+      colon={false}
+      label={<div className="flex flex-col text-left"><span>Delete if powered off for:</span><Typography.Text keyboard className="w-max mt-1">Delete</Typography.Text></div>}
+      name="destroyAfterInactivity"
+      validateTrigger="onChange"
+      rules={[{ validator: validateTimeout }]}
+      {...formItemLayout}>
+
+      <div className="flex flex-1 w-full items-center justify-between">
+        <Tooltip title={<><p>Instances based on this template are deleted if they're not powered on within this time.</p> <b>Set 0 to disable the feature.</b></>}>
+          <InfoCircleOutlined className='ml-2' />
+        </Tooltip>
         <div className="flex gap-4 items-center">
-          <Tooltip title={<><p>Time, since the creation, after which instances based on this template are automatically deleted. Users will be preemptively alerted through email to take actions.</p> <p><b>Set 0 to disable the feature.</b></p></>}>
-          
-            <InfoCircleOutlined className='ml-2'/>
-          </Tooltip>
+          <InputNumber
+            onChange={value => handleTimeoutValueChange(value, 'destroyAfterInactivity')}
+            min={0}
+            max={60}
+            defaultValue={timeouts.destroyAfterInactivity.value}
+          >
+          </InputNumber>
+
+          <Select
+            style={{ width: 130 }}
+            onChange={value => handleTimeUnitChange(value, 'destroyAfterInactivity')}
+            disabled={isTimeUnitDisabled('destroyAfterInactivity')}
+            placeholder="Select Time unit"
+            getPopupContainer={trigger => trigger.parentElement || document.body}
+            defaultValue={parseTimeoutString(template?.destroyAfterInactivity).unit}
+          >
+            {TimeUnitOptions.map(option => (
+              <Select.Option key={option.value} value={option.value}>
+                {option.label}
+              </Select.Option>
+            ))}
+          </Select>
+        </div>
+      </div>
+    </Form.Item>
+    <Form.Item
+      className="right-align-error multiline-label"
+      colon={false}
+      label={<div className="flex flex-col text-left"><span>Delete regardless of activity after:</span><Typography.Text keyboard className="w-max mt-1">Expiration</Typography.Text></div>}
+      name="deleteAfter"
+      validateTrigger="onChange"
+      rules={[{ validator: validateTimeout }]}
+      {...formItemLayout}>
+
+      <div className="flex flex-1 w-full items-center justify-between">
+        <Tooltip title={<><p>Time, since the creation, after which instances based on this template are automatically deleted. Users will be preemptively alerted through email to take actions.</p> <p><b>Set 0 to disable the feature.</b></p></>}>
+
+          <InfoCircleOutlined className='ml-2' />
+        </Tooltip>
+        <div className="flex gap-4 items-center">
           <InputNumber
             onChange={value => handleTimeoutValueChange(value, 'deleteAfter')}
             min={0}
             max={60}
             defaultValue={timeouts.deleteAfter.value}
-            disabled={!automaticStoppingEnabled}
           >
           </InputNumber>
 
           <Select
+            style={{ width: 130 }}
             onChange={value => handleTimeUnitChange(value, 'deleteAfter')}
-            disabled={isTimeUnitDisabled('deleteAfter') || !automaticStoppingEnabled}
+            disabled={isTimeUnitDisabled('deleteAfter')}
             placeholder="Select Time unit"
             getPopupContainer={trigger => trigger.parentElement || document.body}
             defaultValue={parseTimeoutString(template?.deleteAfter).unit}
@@ -605,85 +656,86 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
             ))}
           </Select>
         </div>
-      </Form.Item>
-      </>
+      </div>
+    </Form.Item>
+  </>
 
   const environmentListForm = <>
-  <EnvironmentList
-          availableImages={availableImages}
-          resources={{
-            cpu: cpuInterval,
-            ram: ramInterval,
-            disk: diskInterval,
-          }}
-          sharedVolumes={sharedVolumes}
-          setInfoNumberTemplate={setInfoNumberTemplate}
-          isPersonal={isPersonal === undefined ? false : isPersonal}
-        /></>
-  
+    <EnvironmentList
+      availableImages={availableImages}
+      resources={{
+        cpu: cpuInterval,
+        ram: ramInterval,
+        disk: diskInterval,
+      }}
+      sharedVolumes={sharedVolumes}
+      setInfoNumberTemplate={setInfoNumberTemplate}
+      isPersonal={isPersonal === undefined ? false : isPersonal}
+    /></>
+
 
 
 
   const advancedFeaturesForm = <>
-    {/* TODO: public exporsure, nodeselector, template description */ }
+    {/* TODO: public exporsure, nodeselector, template description */}
     <Form.Item
       name="description"
       className="mb-4"
       required={false}
       label="Description"
       {...formItemLayout}
-      >
-    <Input.TextArea
-      rows={2}
-      placeholder="Insert template description"
-      maxLength={250}
-    />
+    >
+      <Input.TextArea
+        rows={2}
+        placeholder="Insert template description"
+        maxLength={250}
+      />
     </Form.Item>
-          <Form.Item
-            name="allowPublicExposure"
-            valuePropName="checked"
-            className="gap-6 ">
-              <Checkbox onChange={(e) => setIsPublicExposureEnabled(e.target.checked)} className='ml-4'>
-                Port Exposure / Port Forwarding{' '}
-                <Tooltip title="Allow instances based on this template to be publicly accessible via Public IP">
-                  <InfoCircleOutlined />
-                </Tooltip>
-              </Checkbox>
-          </Form.Item>
-        
-   <Flex justify='space-around' className="mb-0 gap-2"  {...formItemLayout} align="center">
-    <Space direction='vertical' style={{width:"50%"}}>
-      <Typography.Paragraph className="mb-0">Server Type: <Tooltip title="Allow instances based on this template to be scheduled on specific nodes"><InfoCircleOutlined className='ml-1' /></Tooltip></Typography.Paragraph>
-      <Select 
-        style={{width:"100%"}} 
-        value={nodeSelectorMode}
-        onChange={handleNodeSelectorModeChange}
+    <Form.Item
+      name="allowPublicExposure"
+      valuePropName="checked"
+      className="gap-6 ">
+      <Checkbox onChange={(e) => setIsPublicExposureEnabled(e.target.checked)} className='ml-4'>
+        Port Exposure / Port Forwarding{' '}
+        <Tooltip title="Allow instances based on this template to be publicly accessible via Public IP">
+          <InfoCircleOutlined />
+        </Tooltip>
+      </Checkbox>
+    </Form.Item>
 
-      >
-        {NodeSelectorOptionMap && Object.entries(NodeSelectorOptionMap).map(([key, label]) => (
-          <Select.Option key={label} value={label}>
-            <Tooltip title={nodeSelectorTooltips[key]} placement="left">
-              <span>{label}</span>
-            </Tooltip>
-          </Select.Option>
-        ))}
-      </Select>
-    </Space>
-    <Space direction='vertical'  style={{width:"50%"}}>
-       {nodeSelectorMode === NodeSelectorOptionMap['FixedSelection'] && (<>
-      <Typography.Paragraph className="mb-0">Labels: <Tooltip title={<span>Select on which node types instances based on this template can be scheduled. This option is enabled only if <strong>Fixed</strong> is selected. For the same tag, only one value can be selected (e.g. nodeSize=big and nodeSize=small cannot be selected simultaneously).</span>}><InfoCircleOutlined className='ml-1' /></Tooltip></Typography.Paragraph>
-       <Select
-          disabled={nodeSelectorMode !== NodeSelectorOptionMap['FixedSelection']}
-          style={{width:"100%"}}
-          mode="multiple"
-          placeholder="Select"
-          onChange={handleSelectorLabelChange}
-          options={getNodeLabelsOptions}
-          value={selectedLabels}
-          status={nodeSelectorMode === NodeSelectorOptionMap['FixedSelection'] && selectedLabels.length === 0 ? 'error' : undefined}
-        />
-      </>)}
-    </Space>
+    <Flex justify='space-around' className="mb-0 gap-2"  {...formItemLayout} align="center">
+      <Space direction='vertical' style={{ width: "50%" }}>
+        <Typography.Paragraph className="mb-0">Server Type: <Tooltip title="Allow instances based on this template to be scheduled on specific nodes"><InfoCircleOutlined className='ml-1' /></Tooltip></Typography.Paragraph>
+        <Select
+          style={{ width: "100%" }}
+          value={nodeSelectorMode}
+          onChange={handleNodeSelectorModeChange}
+
+        >
+          {NodeSelectorOptionMap && Object.entries(NodeSelectorOptionMap).map(([key, label]) => (
+            <Select.Option key={label} value={label}>
+              <Tooltip title={nodeSelectorTooltips[key]} placement="left">
+                <span>{label}</span>
+              </Tooltip>
+            </Select.Option>
+          ))}
+        </Select>
+      </Space>
+      <Space direction='vertical' style={{ width: "50%" }}>
+        {nodeSelectorMode === NodeSelectorOptionMap['FixedSelection'] && (<>
+          <Typography.Paragraph className="mb-0">Labels: <Tooltip title={<span>Select on which node types instances based on this template can be scheduled. This option is enabled only if <strong>Fixed</strong> is selected. For the same tag, only one value can be selected (e.g. nodeSize=big and nodeSize=small cannot be selected simultaneously).</span>}><InfoCircleOutlined className='ml-1' /></Tooltip></Typography.Paragraph>
+          <Select
+            disabled={nodeSelectorMode !== NodeSelectorOptionMap['FixedSelection']}
+            style={{ width: "100%" }}
+            mode="multiple"
+            placeholder="Select"
+            onChange={handleSelectorLabelChange}
+            options={getNodeLabelsOptions}
+            value={selectedLabels}
+            status={nodeSelectorMode === NodeSelectorOptionMap['FixedSelection'] && selectedLabels.length === 0 ? 'error' : undefined}
+          />
+        </>)}
+      </Space>
     </Flex>
 
   </>
@@ -696,13 +748,13 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
     borderRadius: token.borderRadiusLG,
     border: `1px solid ${token.colorBorderSecondary}`,
     padding: '0px 10px',
-    
+
   };
 
   return (
-    
+
     <Modal
-    
+
       destroyOnHidden={true}
       styles={{ body: { paddingBottom: '5px' } }}
       centered
@@ -735,34 +787,34 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
         >
           <Input placeholder="Insert template name" allowClear />
         </Form.Item>
-        
-          <Collapse size="small" bordered={false} ghost accordion items={[
-   {
-    key: '1',
-    label: <Typography.Text strong>Virtual Machines / Containers</Typography.Text>,
-    children: environmentListForm,
-    style: panelStyle,
-    forceRender: true,
-    extra: <Text keyboard>{infoNumberTemplate ? infoNumberTemplate == 1 ? '1 environment' : `${infoNumberTemplate} environments` : 'No environments'}</Text>
-  },
-  {
-    key: '2',
-    label: <Typography.Text strong>Automatic Clean-up</Typography.Text>,
-    children: automaticInstanceSavingResource,
-    style: panelStyle,
-    forceRender: true,
-    extra: <><Text keyboard>{automaticStoppingEnabled && !isTimeUnitDisabled('inactivityTimeout') ? 'Inactivity ON' : 'Inactivity OFF'}</Text> <Text keyboard>{automaticStoppingEnabled && !isTimeUnitDisabled('deleteAfter') ? 'Expiration ON' : 'Expiration OFF'}</Text></>
-  },
-  {
-    key: '3',
-    label: <Typography.Text strong>Advanced Features</Typography.Text>,
-    children: advancedFeaturesForm,
-    forceRender: true,
-    style: panelStyle,
-    extra: <><Text keyboard>{isPublicExposureEnabled ? 'Exposure ON' : 'Exposure OFF'}</Text> <Text keyboard>{nodeSelectorMode !== NodeSelectorOptionMap['NodeSelectorDisabled'] ? 'Node Selector ON' : 'Node Selector OFF'}</Text></>
-  },
-]} defaultActiveKey={['1']}  />
-        
+
+        <Collapse size="small" bordered={false} ghost accordion items={[
+          {
+            key: '1',
+            label: <Typography.Text strong>Virtual Machines / Containers</Typography.Text>,
+            children: environmentListForm,
+            style: panelStyle,
+            forceRender: true,
+            extra: <Text keyboard>{infoNumberTemplate ? infoNumberTemplate == 1 ? '1 environment' : `${infoNumberTemplate} environments` : 'No environments'}</Text>
+          },
+          {
+            key: '2',
+            label: <Typography.Text strong>Automatic Clean-up</Typography.Text>,
+            children: automaticInstanceSavingResource,
+            style: panelStyle,
+            forceRender: true,
+            extra: <><Text keyboard>Stop <StatusIcon active={!isTimeUnitDisabled('inactivityTimeout')} /></Text> <Text keyboard>Delete <StatusIcon active={!isTimeUnitDisabled('destroyAfterInactivity')} /></Text> <Text keyboard>Expiration <StatusIcon active={!isTimeUnitDisabled('deleteAfter')} /></Text></>
+          },
+          {
+            key: '3',
+            label: <Typography.Text strong>Advanced Features</Typography.Text>,
+            children: advancedFeaturesForm,
+            forceRender: true,
+            style: panelStyle,
+            extra: <><Text keyboard>Exposure <StatusIcon active={isPublicExposureEnabled} /></Text> <Text keyboard>Node Selector <StatusIcon active={nodeSelectorMode !== NodeSelectorOptionMap['NodeSelectorDisabled']} /></Text></>
+          },
+        ]} defaultActiveKey={['1']} />
+
 
         <div className="flex justify-end gap-2">
           <Button type="default" onClick={() => closehandler()}>
@@ -781,17 +833,17 @@ const handleNodeSelectorModeChange = useCallback((value: string) => {
               const environments = form.getFieldValue('environments') as TemplateForm['environments'];
 
               const hasTemplateName = templateName && templateName.trim() !== '';
-              
+
               // ALL environments must have all required fields filled
-              const hasValidEnvironments = environments && environments.length > 0 && 
-                environments.every(env => 
+              const hasValidEnvironments = environments && environments.length > 0 &&
+                environments.every(env =>
                   env.name && env.name.trim() !== '' &&
                   env.environmentType &&
                   env.image && env.image.trim() !== ''
                 );
 
               // Node selector validation
-              const nodeSelectorValid = nodeSelectorMode !== NodeSelectorOptionMap['FixedSelection'] || 
+              const nodeSelectorValid = nodeSelectorMode !== NodeSelectorOptionMap['FixedSelection'] ||
                 selectedLabels.length > 0;
 
               const isDisabled = hasErrors || !hasTemplateName || !hasValidEnvironments || !nodeSelectorValid;

--- a/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
@@ -82,6 +82,10 @@ const parseTimeoutString = (s?: string) => {
   return { value: Number(m[1]), unit: unitOpt ? unitOpt.value : 'd' }
 };
 
+/** Read an optional runtime config variable injected by Helm via configmap. */
+const getDefaultTimeout = (name: string): string =>
+  (window as unknown as Record<string, unknown>)[name] as string ?? 'never';
+
 const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
   const {
     show,
@@ -292,9 +296,15 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
 
   const [timeouts, setTimeouts] = useState(
     {
-      inactivityTimeout: { value: parseTimeoutString(template?.inactivityTimeout).value ?? 0, unit: parseTimeoutString(template?.inactivityTimeout).unit ?? '' },
-      destroyAfterInactivity: { value: parseTimeoutString(template?.destroyAfterInactivity).value ?? 0, unit: parseTimeoutString(template?.destroyAfterInactivity).unit ?? '' },
-      deleteAfter: { value: parseTimeoutString(template?.deleteAfter).value ?? 0, unit: parseTimeoutString(template?.deleteAfter).unit ?? '' },
+      inactivityTimeout: template
+        ? { value: parseTimeoutString(template.inactivityTimeout).value ?? 0, unit: parseTimeoutString(template.inactivityTimeout).unit }
+        : parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_INACTIVITY_TIMEOUT')),
+      destroyAfterInactivity: template
+        ? { value: parseTimeoutString(template.destroyAfterInactivity).value ?? 0, unit: parseTimeoutString(template.destroyAfterInactivity).unit }
+        : parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_DESTROY_AFTER_INACTIVITY')),
+      deleteAfter: template
+        ? { value: parseTimeoutString(template.deleteAfter).value ?? 0, unit: parseTimeoutString(template.deleteAfter).unit }
+        : parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_DELETE_AFTER')),
     });
 
   const {
@@ -352,9 +362,9 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
       form.resetFields();
       form.setFieldsValue(getInitialValues(undefined));
       setTimeouts({
-        inactivityTimeout: { value: 0, unit: 'd' },
-        destroyAfterInactivity: { value: 0, unit: 'd' },
-        deleteAfter: { value: 0, unit: 'd' },
+        inactivityTimeout: parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_INACTIVITY_TIMEOUT')),
+        destroyAfterInactivity: parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_DESTROY_AFTER_INACTIVITY')),
+        deleteAfter: parseTimeoutString(getDefaultTimeout('VITE_APP_DEFAULT_DELETE_AFTER')),
       });
       setNodeSelectorMode(NodeSelectorOptionMap['NodeSelectorDisabled']);
       setSelectedLabels([]);

--- a/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
@@ -421,33 +421,24 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
   }, []);
 
   const handleTimeoutValueChange = (value: number | null, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
+    const numValue = value ? Number(value) : 0;
+    const unit = timeouts[field].unit;
     setTimeouts(prevTimeouts => ({
       ...prevTimeouts,
-      [field]: {
-        value: value ? Number(value) : 0,
-        unit: prevTimeouts[field].unit,
-      },
+      [field]: { value: numValue, unit },
     }));
-    form.setFieldValue(field, {
-      value,
-      unit: timeouts[field].unit,
-    });
-    form.validateFields(['inactivityTimeout', 'destroyAfterInactivity', 'deleteAfter']).catch(() => { });
+    form.setFieldsValue({ [field]: { value: numValue, unit } });
+    form.validateFields([field]).catch(() => { });
   }
 
-  const handleTimeUnitChange = (value: string, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
+  const handleTimeUnitChange = (newUnit: string, field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {
+    const val = timeouts[field].value;
     setTimeouts(prevTimeouts => ({
       ...prevTimeouts,
-      [field]: {
-        value: prevTimeouts[field].value,
-        unit: value,
-      },
+      [field]: { value: val, unit: newUnit },
     }));
-    form.setFieldValue(field, {
-      value: timeouts[field].value,
-      unit: value,
-    });
-    form.validateFields(['inactivityTimeout', 'destroyAfterInactivity', 'deleteAfter']).catch(() => { });
+    form.setFieldsValue({ [field]: { value: val, unit: newUnit } });
+    form.validateFields([field]).catch(() => { });
   }
 
   const isTimeUnitDisabled = (field: 'inactivityTimeout' | 'destroyAfterInactivity' | 'deleteAfter') => {

--- a/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/ModalCreateTemplate.tsx
@@ -71,15 +71,15 @@ const TimeUnitOptions = [
 ];
 
 const parseTimeoutString = (s?: string) => {
-  if (!s || s === 'never') return { value: 0, unit: '' }
+  if (!s || s === 'never') return { value: 0, unit: 'd' }
   const m = String(s).trim().match(/^(\d+)\s*([mhd])$/i)
-  if (!m) return { value: 0, unit: '' }
+  if (!m) return { value: 0, unit: 'd' }
 
   const unitOpt = TimeUnitOptions.find(
     opt => opt.value === m[2].toLowerCase(),
   );
 
-  return { value: Number(m[1]), unit: unitOpt ? unitOpt.value : '' }
+  return { value: Number(m[1]), unit: unitOpt ? unitOpt.value : 'd' }
 };
 
 const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
@@ -352,9 +352,9 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
       form.resetFields();
       form.setFieldsValue(getInitialValues(undefined));
       setTimeouts({
-        inactivityTimeout: { value: 0, unit: '' },
-        destroyAfterInactivity: { value: 0, unit: '' },
-        deleteAfter: { value: 0, unit: '' },
+        inactivityTimeout: { value: 0, unit: 'd' },
+        destroyAfterInactivity: { value: 0, unit: 'd' },
+        deleteAfter: { value: 0, unit: 'd' },
       });
       setNodeSelectorMode(NodeSelectorOptionMap['NodeSelectorDisabled']);
       setSelectedLabels([]);
@@ -555,7 +555,6 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
           <InputNumber
             onChange={value => handleTimeoutValueChange(value, 'inactivityTimeout')}
             min={0}
-            max={60}
             defaultValue={timeouts.inactivityTimeout.value}
           >
           </InputNumber>
@@ -596,7 +595,6 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
           <InputNumber
             onChange={value => handleTimeoutValueChange(value, 'destroyAfterInactivity')}
             min={0}
-            max={60}
             defaultValue={timeouts.destroyAfterInactivity.value}
           >
           </InputNumber>
@@ -636,7 +634,6 @@ const ModalCreateTemplate: FC<IModalCreateTemplateProps> = ({ ...props }) => {
           <InputNumber
             onChange={value => handleTimeoutValueChange(value, 'deleteAfter')}
             min={0}
-            max={60}
             defaultValue={timeouts.deleteAfter.value}
           >
           </InputNumber>

--- a/frontend/src/components/workspaces/ModalCreateTemplate/types.ts
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/types.ts
@@ -17,6 +17,7 @@ export type TemplateForm = {
   environments: TemplateFormEnv[];
   deleteAfter: string;
   inactivityTimeout: string;
+  destroyAfterInactivity: string;
   allowPublicExposure: boolean;
   nodeSelector?: Record<string, string> | null;
 };

--- a/frontend/src/components/workspaces/ModalCreateTemplate/utils.ts
+++ b/frontend/src/components/workspaces/ModalCreateTemplate/utils.ts
@@ -24,6 +24,7 @@ export const getDefaultTemplate = (resources: Resources): Template => {
     environments: [getDefaultTemplateEnvironment(resources, 0)],
     deleteAfter: 'never',
     inactivityTimeout: 'never',
+    destroyAfterInactivity: 'never',
     allowPublicExposure: false,
   };
 };

--- a/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
@@ -91,7 +91,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
           }),
         )
         .sort((a, b) => a.name.localeCompare(b.name)) ?? [];
-       
+
     return templates;
   }, [templateListData?.templateList?.templates]);
 
@@ -198,7 +198,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
 
   const templates = useMemo(() => {
     const joined = joinInstancesAndTemplates(dataTemplate, ownedInstances);
-  
+
 
     // build map of original GraphQL templates by metadata.name for reliable lookup
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -244,10 +244,10 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
           environmentType: env.environmentType,
           resources: {
             reservedCPUPercentage:
-             env.reservedCpu,
+              env.reservedCpu,
             cpu: env.cpu,
             memory: `${env.ram}Gi`,
-            disk: env.disk ? `${env.disk}Gi` : undefined, 
+            disk: env.disk ? `${env.disk}Gi` : undefined,
           },
           image: env.image,
           disableControls: env.disableControls,
@@ -271,13 +271,30 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
         | { op: 'replace' | 'add'; path: string; value: unknown }
         | { op: 'remove'; path: string }
       > = [
-        { op: 'replace', path: '/spec/environmentList', value: environmentList },
-        { op: 'replace', path: '/spec/prettyName', value: t.name },
-        { op: 'replace', path: '/spec/deleteAfter', value: t.deleteAfter },
-        { op: 'replace', path: '/spec/inactivityTimeout', value: t.inactivityTimeout },
-        { op: 'replace', path: '/spec/allowPublicExposure', value: t.allowPublicExposure },
-        { op: 'replace', path: '/spec/description', value: t.description },
-      ];
+          {
+            op: 'replace',
+            path: '/spec/environmentList',
+            value: environmentList,
+          },
+          { op: 'replace', path: '/spec/prettyName', value: t.name },
+          { op: 'replace', path: '/spec/deleteAfter', value: t.deleteAfter },
+          {
+            op: 'replace',
+            path: '/spec/inactivityTimeout',
+            value: t.inactivityTimeout,
+          },
+          {
+            op: 'replace',
+            path: '/spec/destroyAfterInactivity',
+            value: t.destroyAfterInactivity,
+          },
+          {
+            op: 'replace',
+            path: '/spec/allowPublicExposure',
+            value: t.allowPublicExposure,
+          },
+          { op: 'replace', path: '/spec/description', value: t.description },
+        ];
 
       // nodeSelector logic:
       // - if undefined: not touched by user, keep existing value (don't patch)
@@ -368,6 +385,7 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
                     deleteAfter: template.deleteAfter,
                     allowPublicExposure: template.allowPublicExposure,
                     inactivityTimeout: template.inactivityTimeout,
+                    destroyAfterInactivity: template.destroyAfterInactivity,
                     environments: template.environmentList.map(env => ({
                       name: env.name,
                       persistent: env.persistent,
@@ -384,9 +402,9 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
                       image:
                         env.environmentType === EnvironmentType.VirtualMachine
                           ? getImageNameNoVer(env.image)
-                              .split('/')
-                              .slice(-2)
-                              .join('/') ?? ''
+                            .split('/')
+                            .slice(-2)
+                            .join('/') ?? ''
                           : env.image,
                       registry:
                         env.environmentType !== EnvironmentType.CloudVm ? getImageNameNoVer(env.image).split('/').slice(0)[0] ?? '' : '',

--- a/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
@@ -5,6 +5,7 @@ import {
   SelectOutlined,
   AppstoreAddOutlined,
   DockerOutlined,
+  ClockCircleOutlined,
 } from '@ant-design/icons';
 import { Space, Tooltip, Dropdown, Badge } from 'antd';
 import { Button } from 'antd';
@@ -95,7 +96,10 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
   workspaceAvailableQuota,
 }) => {
   const canCreate = canCreateInstance(template, workspaceAvailableQuota);
-  
+
+  const hasInactivity =
+    (template.inactivityTimeout && template.inactivityTimeout !== 'never') ||
+    (template.destroyAfterInactivity && template.destroyAfterInactivity !== 'never');
   const {
     data: labelsData,
     loading: loadingLabels,
@@ -280,6 +284,36 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                                 )}
                               </div>
                             )}
+                            {hasInactivity && (
+                              <Tooltip
+                                title={
+                                  <div className="text-left">
+                                    {(template.inactivityTimeout !== 'never' || template.destroyAfterInactivity !== 'never') && (
+                                      <>
+                                        These instances will be: <br />
+                                      </>
+                                    )}
+                                    {template.inactivityTimeout !== 'never' && (
+                                      <>
+                                        - powered off after <b>{template.inactivityTimeout}</b> of inactivity<br />
+                                      </>
+                                    )}
+                                    {template.destroyAfterInactivity !== 'never' && (
+                                      <>
+                                        - deleted after being stopped for <b>{template.destroyAfterInactivity}</b>
+                                      </>
+                                    )}
+                                  </div>
+                                }
+                              >
+                                <div className="flex items-center">
+                                  <ClockCircleOutlined
+                                    className="warning-color-fg ml-1"
+                                    style={{ fontSize: '14px' }}
+                                  />
+                                </div>
+                              </Tooltip>
+                            )}
                           </div>
                         </div>
                       ))}
@@ -308,7 +342,7 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                 <Space>
                   {template.description != '' ? (
                     <Tooltip title={<span>{template.description}</span>}>{template.name}</Tooltip>
-                  ) : (template.name)} 
+                  ) : (template.name)}
                   {!template.hasMultipleEnvironments &&
                     template.allowPublicExposure && (
                       <Tooltip title="Public Port Exposure - This template allows exposing internal ports to external networks for remote access">
@@ -342,6 +376,33 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                   </div>
                 </Tooltip>
               )}
+              {hasInactivity && (
+                <Tooltip
+                  title={
+                    <div className="text-left">
+                      {(template.inactivityTimeout !== 'never' || template.destroyAfterInactivity !== 'never') && (
+                        <>
+                          These instances will be: <br />
+                        </>
+                      )}
+                      {template.inactivityTimeout !== 'never' && (
+                        <>
+                          - powered off after <b>{template.inactivityTimeout}</b> of inactivity<br />
+                        </>
+                      )}
+                      {template.destroyAfterInactivity !== 'never' && (
+                        <>
+                          - deleted after being stopped for <b>{template.destroyAfterInactivity}</b>
+                        </>
+                      )}
+                    </div>
+                  }
+                >
+                  <div className="ml-3 flex items-center">
+                    <ClockCircleOutlined style={{ fontSize: '18px', color: '#f8cf8d' }} />
+                  </div>
+                </Tooltip>
+              )}
               {template.nodeSelector && (
                 <div className="ml-3 flex items-center">
                   <NodeSelectorIcon
@@ -363,7 +424,7 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
           ) : (
             ''
           )}
-          
+
           <Tooltip
             placement="left"
             title={
@@ -420,17 +481,16 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                     </div>
                     <div>
                       {template.persistent
-                        ? ` DISK: ${
-                            convertToGiB(template.resources.disk) ||
-                            'unavailable'
-                          }GiB`
+                        ? ` DISK: ${convertToGiB(template.resources.disk) ||
+                        'unavailable'
+                        }GiB`
                         : ``}
                     </div>
                   </>
                 )}
               </>
             }
-          > 
+          >
             <Button type="link" color="orange" size="middle" className="px-0">
               Info
             </Button>
@@ -514,29 +574,29 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                 items:
                   loadingLabels || labelsError
                     ? [
-                        {
-                          key: 'error',
-                          label: loadingLabels
-                            ? 'Loading labels...'
-                            : 'Error loading labels',
-                          disabled: true,
-                        },
-                      ]
+                      {
+                        key: 'error',
+                        label: loadingLabels
+                          ? 'Loading labels...'
+                          : 'Error loading labels',
+                        disabled: true,
+                      },
+                    ]
                     : labelsData?.labels?.map(({ key, value }) => ({
-                        key: JSON.stringify({ [key]: value }),
-                        label: `${cleanupLabels(key)}=${value}`,
-                        disabled: loadingLabels,
-                        onClick: () => {
-                          setCreateDisabled(true);
-                          createInstance(template.id, JSON.parse(key))
-                            .then(() => {
-                              refreshClock();
-                              setTimeout(setCreateDisabled, 400, false);
-                              expandRow(template.id, true);
-                            })
-                            .catch(() => setCreateDisabled(false));
-                        },
-                      })) || [],
+                      key: JSON.stringify({ [key]: value }),
+                      label: `${cleanupLabels(key)}=${value}`,
+                      disabled: loadingLabels,
+                      onClick: () => {
+                        setCreateDisabled(true);
+                        createInstance(template.id, JSON.parse(key))
+                          .then(() => {
+                            refreshClock();
+                            setTimeout(setCreateDisabled, 400, false);
+                            expandRow(template.id, true);
+                          })
+                          .catch(() => setCreateDisabled(false));
+                      },
+                    })) || [],
               }}
               onClick={createInstanceHandler}
               disabled={createDisabled || !canCreate}

--- a/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
+++ b/frontend/src/components/workspaces/WorkspaceContainer/WorkspaceContainer.tsx
@@ -102,6 +102,7 @@ const WorkspaceContainer: FC<IWorkspaceContainerProps> = ({ ...props }) => {
         environmentList: environmentList,
         deleteAfter: t.deleteAfter,
         inactivityTimeout: t.inactivityTimeout,
+        destroyAfterInactivity: t.destroyAfterInactivity,
         allowPublicExposure: t.allowPublicExposure,
         ...(t.nodeSelector !== null && { nodeSelector: t.nodeSelector }),
       },

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -334,6 +334,8 @@ export type IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput = {
   dryRun?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately. */
   gracePeriodSeconds?: InputMaybe<Scalars['BigInt']['input']>;
+  /** if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it */
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   /** Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds */
   kind?: InputMaybe<Scalars['String']['input']>;
   /** Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. */
@@ -1475,6 +1477,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha1CollectionWorkspaceArgs = {
 export type MutationDeleteCrownlabsPolitoItV1alpha1ImageListArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   orphanDependents?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1486,6 +1489,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha1ImageListArgs = {
 export type MutationDeleteCrownlabsPolitoItV1alpha1WorkspaceArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   orphanDependents?: InputMaybe<Scalars['Boolean']['input']>;
@@ -1576,6 +1580,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha2CollectionTenantArgs = {
 export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedInstanceArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
@@ -1588,6 +1593,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedInstanceArgs = {
 export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedInstanceSnapshotArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
@@ -1600,6 +1606,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedInstanceSnapshotArg
 export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedSharedVolumeArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
@@ -1612,6 +1619,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedSharedVolumeArgs = 
 export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedTemplateArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   namespace: Scalars['String']['input'];
@@ -1624,6 +1632,7 @@ export type MutationDeleteCrownlabsPolitoItV1alpha2NamespacedTemplateArgs = {
 export type MutationDeleteCrownlabsPolitoItV1alpha2TenantArgs = {
   dryRun?: InputMaybe<Scalars['String']['input']>;
   gracePeriodSeconds?: InputMaybe<Scalars['Int']['input']>;
+  ignoreStoreReadErrorWithClusterBreakingPotential?: InputMaybe<Scalars['Boolean']['input']>;
   ioK8sApimachineryPkgApisMetaV1DeleteOptionsInput?: InputMaybe<IoK8sApimachineryPkgApisMetaV1DeleteOptionsInput>;
   name: Scalars['String']['input'];
   orphanDependents?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2089,7 +2098,12 @@ export type MutationReplaceCrownlabsPolitoItV1alpha2TenantStatusArgs = {
   pretty?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** The namespace containing all CrownLabs related objects of the Workspace. This is the namespace that groups multiple related templates, together with all the accessory resources (e.g. RBACs) created by the tenant operator. */
+/**
+ * The namespace containing all CrownLabs related objects of the Workspace.
+ * This is the namespace that groups multiple related templates, together
+ * with all the accessory resources (e.g. RBACs) created by the tenant
+ * operator.
+ */
 export type Namespace = {
   __typename?: 'Namespace';
   /** Whether the creation succeeded or not. */
@@ -2098,7 +2112,12 @@ export type Namespace = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
-/** The namespace containing all CrownLabs related objects of the Workspace. This is the namespace that groups multiple related templates, together with all the accessory resources (e.g. RBACs) created by the tenant operator. */
+/**
+ * The namespace containing all CrownLabs related objects of the Workspace.
+ * This is the namespace that groups multiple related templates, together
+ * with all the accessory resources (e.g. RBACs) created by the tenant
+ * operator.
+ */
 export type NamespaceInput = {
   /** Whether the creation succeeded or not. */
   created: Scalars['Boolean']['input'];
@@ -2106,7 +2125,12 @@ export type NamespaceInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** The namespace containing all CrownLabs related objects of the Tenant. This is the namespace that groups his/her own Instances, together with all the accessory resources (e.g. RBACs, resource quota, network policies, ...) created by the tenant-operator. */
+/**
+ * The namespace containing all CrownLabs related objects of the Tenant.
+ * This is the namespace that groups his/her own Instances, together with
+ * all the accessory resources (e.g. RBACs, resource quota, network policies,
+ * ...) created by the tenant-operator.
+ */
 export type PersonalNamespace = {
   __typename?: 'PersonalNamespace';
   /** Whether the creation succeeded or not. */
@@ -2115,7 +2139,12 @@ export type PersonalNamespace = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
-/** The namespace containing all CrownLabs related objects of the Tenant. This is the namespace that groups his/her own Instances, together with all the accessory resources (e.g. RBACs, resource quota, network policies, ...) created by the tenant-operator. */
+/**
+ * The namespace containing all CrownLabs related objects of the Tenant.
+ * This is the namespace that groups his/her own Instances, together with
+ * all the accessory resources (e.g. RBACs, resource quota, network policies,
+ * ...) created by the tenant-operator.
+ */
 export type PersonalNamespaceInput = {
   /** Whether the creation succeeded or not. */
   created: Scalars['Boolean']['input'];
@@ -2123,7 +2152,10 @@ export type PersonalNamespaceInput = {
   name?: InputMaybe<Scalars['String']['input']>;
 };
 
-/** The amount of resources associated with the Tenant's personal workspace. If defined, the personal workspace is enabled. */
+/**
+ * The amount of resources associated with the Tenant's
+ * personal workspace. If defined, the personal workspace is enabled.
+ */
 export type PersonalWorkspace = {
   __typename?: 'PersonalWorkspace';
   /** The maximum amount of CPU required by this Workspace. */
@@ -2134,7 +2166,10 @@ export type PersonalWorkspace = {
   memory: Scalars['JSON']['output'];
 };
 
-/** The amount of resources associated with the Tenant's personal workspace. If defined, the personal workspace is enabled. */
+/**
+ * The amount of resources associated with the Tenant's
+ * personal workspace. If defined, the personal workspace is enabled.
+ */
 export type PersonalWorkspaceInput = {
   /** The maximum amount of CPU required by this Workspace. */
   cpu: Scalars['JSON']['input'];
@@ -2863,7 +2898,10 @@ export enum Role {
   User = 'user'
 }
 
-/** The namespace that can be freely used by the Tenant to play with Kubernetes. This namespace is created only if the .spec.CreateSandbox flag is true. */
+/**
+ * The namespace that can be freely used by the Tenant to play with Kubernetes.
+ * This namespace is created only if the .spec.CreateSandbox flag is true.
+ */
 export type SandboxNamespace = {
   __typename?: 'SandboxNamespace';
   /** Whether the creation succeeded or not. */
@@ -2872,7 +2910,10 @@ export type SandboxNamespace = {
   name?: Maybe<Scalars['String']['output']>;
 };
 
-/** The namespace that can be freely used by the Tenant to play with Kubernetes. This namespace is created only if the .spec.CreateSandbox flag is true. */
+/**
+ * The namespace that can be freely used by the Tenant to play with Kubernetes.
+ * This namespace is created only if the .spec.CreateSandbox flag is true.
+ */
 export type SandboxNamespaceInput = {
   /** Whether the creation succeeded or not. */
   created: Scalars['Boolean']['input'];
@@ -3097,6 +3138,11 @@ export type Spec6 = {
   deleteAfter?: Maybe<Scalars['String']['output']>;
   /** A textual description of the Template. */
   description: Scalars['String']['output'];
+  /**
+   * The maximum period of time a persistent instance can remain powered off
+   * after being stopped for inactivity, before being completely deleted.
+   */
+  destroyAfterInactivity?: Maybe<Scalars['String']['output']>;
   /** The list of environments (i.e. VMs or containers) that compose the Template. */
   environmentList: Array<Maybe<EnvironmentListListItem>>;
   /**
@@ -3130,6 +3176,11 @@ export type Spec6Input = {
   deleteAfter?: InputMaybe<Scalars['String']['input']>;
   /** A textual description of the Template. */
   description: Scalars['String']['input'];
+  /**
+   * The maximum period of time a persistent instance can remain powered off
+   * after being stopped for inactivity, before being completely deleted.
+   */
+  destroyAfterInactivity?: InputMaybe<Scalars['String']['input']>;
   /** The list of environments (i.e. VMs or containers) that compose the Template. */
   environmentList: Array<InputMaybe<EnvironmentListListItemInput>>;
   /**
@@ -3155,9 +3206,15 @@ export type Spec7 = {
   __typename?: 'Spec7';
   /** Whether a personal workspace should be created for the tenant */
   createPersonalWorkspace?: Maybe<Scalars['Boolean']['output']>;
-  /** Whether a sandbox namespace should be created to allow the Tenant play with Kubernetes. */
+  /**
+   * Whether a sandbox namespace should be created to allow the Tenant play
+   * with Kubernetes.
+   */
   createSandbox?: Maybe<Scalars['Boolean']['output']>;
-  /** The email associated with the Tenant, which will be used to log-in into the system. */
+  /**
+   * The email associated with the Tenant, which will be used to log-in
+   * into the system.
+   */
   email: Scalars['String']['output'];
   /** The first name of the Tenant. */
   firstName: Scalars['String']['output'];
@@ -3165,13 +3222,22 @@ export type Spec7 = {
   lastLogin?: Maybe<Scalars['String']['output']>;
   /** The last name of the Tenant. */
   lastName: Scalars['String']['output'];
-  /** The amount of resources associated with the Tenant's personal workspace. If defined, the personal workspace is enabled. */
+  /**
+   * The amount of resources associated with the Tenant's
+   * personal workspace. If defined, the personal workspace is enabled.
+   */
   personalWorkspace?: Maybe<PersonalWorkspace>;
-  /** The list of the SSH public keys associated with the Tenant. These will be used to enable to access the remote environments through the SSH protocol. */
+  /**
+   * The list of the SSH public keys associated with the Tenant. These will be
+   * used to enable to access the remote environments through the SSH protocol.
+   */
   publicKeys?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The amount of resources associated with this Tenant, if defined it overrides the one computed from the workspaces the tenant is enrolled in. */
   quota?: Maybe<Quota2>;
-  /** The list of the Workspaces the Tenant is subscribed to, along with his/her role in each of them. */
+  /**
+   * The list of the Workspaces the Tenant is subscribed to, along with his/her
+   * role in each of them.
+   */
   workspaces?: Maybe<Array<Maybe<WorkspacesListItem>>>;
 };
 
@@ -3179,9 +3245,15 @@ export type Spec7 = {
 export type Spec7Input = {
   /** Whether a personal workspace should be created for the tenant */
   createPersonalWorkspace?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Whether a sandbox namespace should be created to allow the Tenant play with Kubernetes. */
+  /**
+   * Whether a sandbox namespace should be created to allow the Tenant play
+   * with Kubernetes.
+   */
   createSandbox?: InputMaybe<Scalars['Boolean']['input']>;
-  /** The email associated with the Tenant, which will be used to log-in into the system. */
+  /**
+   * The email associated with the Tenant, which will be used to log-in
+   * into the system.
+   */
   email: Scalars['String']['input'];
   /** The first name of the Tenant. */
   firstName: Scalars['String']['input'];
@@ -3189,13 +3261,22 @@ export type Spec7Input = {
   lastLogin?: InputMaybe<Scalars['String']['input']>;
   /** The last name of the Tenant. */
   lastName: Scalars['String']['input'];
-  /** The amount of resources associated with the Tenant's personal workspace. If defined, the personal workspace is enabled. */
+  /**
+   * The amount of resources associated with the Tenant's
+   * personal workspace. If defined, the personal workspace is enabled.
+   */
   personalWorkspace?: InputMaybe<PersonalWorkspaceInput>;
-  /** The list of the SSH public keys associated with the Tenant. These will be used to enable to access the remote environments through the SSH protocol. */
+  /**
+   * The list of the SSH public keys associated with the Tenant. These will be
+   * used to enable to access the remote environments through the SSH protocol.
+   */
   publicKeys?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The amount of resources associated with this Tenant, if defined it overrides the one computed from the workspaces the tenant is enrolled in. */
   quota?: InputMaybe<Quota2Input>;
-  /** The list of the Workspaces the Tenant is subscribed to, along with his/her role in each of them. */
+  /**
+   * The list of the Workspaces the Tenant is subscribed to, along with his/her
+   * role in each of them.
+   */
   workspaces?: InputMaybe<Array<InputMaybe<WorkspacesListItemInput>>>;
 };
 
@@ -3210,21 +3291,47 @@ export type SpecInput = {
 /** WorkspaceStatus reflects the most recently observed status of the Workspace. */
 export type Status2 = {
   __typename?: 'Status2';
-  /** The namespace containing all CrownLabs related objects of the Workspace. This is the namespace that groups multiple related templates, together with all the accessory resources (e.g. RBACs) created by the tenant operator. */
+  /**
+   * The namespace containing all CrownLabs related objects of the Workspace.
+   * This is the namespace that groups multiple related templates, together
+   * with all the accessory resources (e.g. RBACs) created by the tenant
+   * operator.
+   */
   namespace?: Maybe<Namespace>;
-  /** Whether all subscriptions and resource creations succeeded or an error occurred. In case of errors, the other status fields provide additional information about which problem occurred. */
+  /**
+   * Whether all subscriptions and resource creations succeeded or an error
+   * occurred. In case of errors, the other status fields provide additional
+   * information about which problem occurred.
+   */
   ready?: Maybe<Scalars['Boolean']['output']>;
-  /** The list of the subscriptions to external services (e.g. Keycloak, ...), indicating for each one whether it succeeded or an error occurred. */
+  /**
+   * The list of the subscriptions to external services (e.g. Keycloak,
+   * ...), indicating for each one whether it succeeded or an error
+   * occurred.
+   */
   subscription?: Maybe<Scalars['JSON']['output']>;
 };
 
 /** WorkspaceStatus reflects the most recently observed status of the Workspace. */
 export type Status2Input = {
-  /** The namespace containing all CrownLabs related objects of the Workspace. This is the namespace that groups multiple related templates, together with all the accessory resources (e.g. RBACs) created by the tenant operator. */
+  /**
+   * The namespace containing all CrownLabs related objects of the Workspace.
+   * This is the namespace that groups multiple related templates, together
+   * with all the accessory resources (e.g. RBACs) created by the tenant
+   * operator.
+   */
   namespace?: InputMaybe<NamespaceInput>;
-  /** Whether all subscriptions and resource creations succeeded or an error occurred. In case of errors, the other status fields provide additional information about which problem occurred. */
+  /**
+   * Whether all subscriptions and resource creations succeeded or an error
+   * occurred. In case of errors, the other status fields provide additional
+   * information about which problem occurred.
+   */
   ready?: InputMaybe<Scalars['Boolean']['input']>;
-  /** The list of the subscriptions to external services (e.g. Keycloak, ...), indicating for each one whether it succeeded or an error occurred. */
+  /**
+   * The list of the subscriptions to external services (e.g. Keycloak,
+   * ...), indicating for each one whether it succeeded or an error
+   * occurred.
+   */
   subscription?: InputMaybe<Scalars['JSON']['input']>;
 };
 
@@ -3336,42 +3443,84 @@ export type Status5Input = {
 /** TenantStatus reflects the most recently observed status of the Tenant. */
 export type Status7 = {
   __typename?: 'Status7';
-  /** The list of Workspaces that are throwing errors during subscription. This mainly happens if .spec.Workspaces contains references to Workspaces which do not exist. */
+  /**
+   * The list of Workspaces that are throwing errors during subscription.
+   * This mainly happens if .spec.Workspaces contains references to Workspaces
+   * which do not exist.
+   */
   failingWorkspaces?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   /** The status of Keycloak authentication flow */
   keycloak?: Maybe<Keycloak>;
-  /** The namespace containing all CrownLabs related objects of the Tenant. This is the namespace that groups his/her own Instances, together with all the accessory resources (e.g. RBACs, resource quota, network policies, ...) created by the tenant-operator. */
+  /**
+   * The namespace containing all CrownLabs related objects of the Tenant.
+   * This is the namespace that groups his/her own Instances, together with
+   * all the accessory resources (e.g. RBACs, resource quota, network policies,
+   * ...) created by the tenant-operator.
+   */
   personalNamespace: PersonalNamespace;
   /** Whether a personal workspace has been created for the tenant. */
   personalWorkspaceCreated?: Maybe<Scalars['Boolean']['output']>;
   /** The amount of resources associated with this Tenant, either inherited from the Workspaces in which he/she is enrolled, or manually overridden. */
   quota?: Maybe<Quota3>;
-  /** Whether all subscriptions and resource creations succeeded or an error occurred. In case of errors, the other status fields provide additional information about which problem occurred. Will be set to true even when personal workspace is intentionally deleted. */
+  /**
+   * Whether all subscriptions and resource creations succeeded or an error
+   * occurred. In case of errors, the other status fields provide additional
+   * information about which problem occurred.
+   * Will be set to true even when personal workspace is intentionally deleted.
+   */
   ready: Scalars['Boolean']['output'];
-  /** The namespace that can be freely used by the Tenant to play with Kubernetes. This namespace is created only if the .spec.CreateSandbox flag is true. */
+  /**
+   * The namespace that can be freely used by the Tenant to play with Kubernetes.
+   * This namespace is created only if the .spec.CreateSandbox flag is true.
+   */
   sandboxNamespace: SandboxNamespace;
-  /** The list of the subscriptions to external services (e.g. Keycloak, ...), indicating for each one whether it succeeded or an error occurred. */
-  subscriptions: Scalars['JSON']['output'];
+  /**
+   * The list of the subscriptions to external services (e.g. Keycloak,
+   * ...), indicating for each one whether it succeeded or an error
+   * occurred.
+   */
+  subscriptions?: Maybe<Scalars['JSON']['output']>;
 };
 
 /** TenantStatus reflects the most recently observed status of the Tenant. */
 export type Status7Input = {
-  /** The list of Workspaces that are throwing errors during subscription. This mainly happens if .spec.Workspaces contains references to Workspaces which do not exist. */
+  /**
+   * The list of Workspaces that are throwing errors during subscription.
+   * This mainly happens if .spec.Workspaces contains references to Workspaces
+   * which do not exist.
+   */
   failingWorkspaces?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   /** The status of Keycloak authentication flow */
   keycloak?: InputMaybe<KeycloakInput>;
-  /** The namespace containing all CrownLabs related objects of the Tenant. This is the namespace that groups his/her own Instances, together with all the accessory resources (e.g. RBACs, resource quota, network policies, ...) created by the tenant-operator. */
+  /**
+   * The namespace containing all CrownLabs related objects of the Tenant.
+   * This is the namespace that groups his/her own Instances, together with
+   * all the accessory resources (e.g. RBACs, resource quota, network policies,
+   * ...) created by the tenant-operator.
+   */
   personalNamespace: PersonalNamespaceInput;
   /** Whether a personal workspace has been created for the tenant. */
   personalWorkspaceCreated?: InputMaybe<Scalars['Boolean']['input']>;
   /** The amount of resources associated with this Tenant, either inherited from the Workspaces in which he/she is enrolled, or manually overridden. */
   quota?: InputMaybe<Quota3Input>;
-  /** Whether all subscriptions and resource creations succeeded or an error occurred. In case of errors, the other status fields provide additional information about which problem occurred. Will be set to true even when personal workspace is intentionally deleted. */
+  /**
+   * Whether all subscriptions and resource creations succeeded or an error
+   * occurred. In case of errors, the other status fields provide additional
+   * information about which problem occurred.
+   * Will be set to true even when personal workspace is intentionally deleted.
+   */
   ready: Scalars['Boolean']['input'];
-  /** The namespace that can be freely used by the Tenant to play with Kubernetes. This namespace is created only if the .spec.CreateSandbox flag is true. */
+  /**
+   * The namespace that can be freely used by the Tenant to play with Kubernetes.
+   * This namespace is created only if the .spec.CreateSandbox flag is true.
+   */
   sandboxNamespace: SandboxNamespaceInput;
-  /** The list of the subscriptions to external services (e.g. Keycloak, ...), indicating for each one whether it succeeded or an error occurred. */
-  subscriptions: Scalars['JSON']['input'];
+  /**
+   * The list of the subscriptions to external services (e.g. Keycloak,
+   * ...), indicating for each one whether it succeeded or an error
+   * occurred.
+   */
+  subscriptions?: InputMaybe<Scalars['JSON']['input']>;
 };
 
 export type Subscription = {
@@ -3541,7 +3690,10 @@ export type WorkspaceWrapperTenantV1alpha2 = {
   itPolitoCrownlabsV1alpha1Workspace?: Maybe<ItPolitoCrownlabsV1alpha1Workspace>;
 };
 
-/** TenantWorkspaceEntry contains the information regarding one of the Workspaces the Tenant is subscribed to, including his/her role. */
+/**
+ * TenantWorkspaceEntry contains the information regarding one of the Workspaces
+ * the Tenant is subscribed to, including his/her role.
+ */
 export type WorkspacesListItem = {
   __typename?: 'WorkspacesListItem';
   /** The Workspace the Tenant is subscribed to. */
@@ -3551,7 +3703,10 @@ export type WorkspacesListItem = {
   workspaceWrapperTenantV1alpha2?: Maybe<WorkspaceWrapperTenantV1alpha2>;
 };
 
-/** TenantWorkspaceEntry contains the information regarding one of the Workspaces the Tenant is subscribed to, including his/her role. */
+/**
+ * TenantWorkspaceEntry contains the information regarding one of the Workspaces
+ * the Tenant is subscribed to, including his/her role.
+ */
 export type WorkspacesListItemInput = {
   /** The Workspace the Tenant is subscribed to. */
   name: Scalars['String']['input'];
@@ -3657,12 +3812,13 @@ export type CreateTemplateMutationVariables = Exact<{
   deleteAfter?: InputMaybe<Scalars['String']['input']>;
   descriptionTemplate: Scalars['String']['input'];
   inactivityTimeout?: InputMaybe<Scalars['String']['input']>;
+  destroyAfterInactivity?: InputMaybe<Scalars['String']['input']>;
   allowPublicExposure?: InputMaybe<Scalars['Boolean']['input']>;
   nodeSelector?: InputMaybe<Scalars['JSON']['input']>;
 }>;
 
 
-export type CreateTemplateMutation = { __typename?: 'Mutation', createdTemplate?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, deleteAfter?: string | null, inactivityTimeout?: string | null, allowPublicExposure?: boolean | null, nodeSelector?: any | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number } } | null> } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null };
+export type CreateTemplateMutation = { __typename?: 'Mutation', createdTemplate?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, deleteAfter?: string | null, inactivityTimeout?: string | null, destroyAfterInactivity?: string | null, allowPublicExposure?: boolean | null, nodeSelector?: any | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number } } | null> } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null };
 
 export type CreateWorkspaceMutationVariables = Exact<{
   name: Scalars['String']['input'];
@@ -3764,7 +3920,7 @@ export type WorkspaceTemplatesQueryVariables = Exact<{
 }>;
 
 
-export type WorkspaceTemplatesQuery = { __typename?: 'Query', templateList?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateList', templates: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, deleteAfter?: string | null, inactivityTimeout?: string | null, nodeSelector?: any | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, environmentType: EnvironmentType, mountMyDriveVolume: boolean, image: string, guiEnabled?: boolean | null, disableControls?: boolean | null, rewriteURL?: boolean | null, persistent?: boolean | null, containerStartupOptions?: { __typename?: 'ContainerStartupOptions', sourceArchiveURL?: string | null, contentPath?: string | null, startupArgs?: Array<string | null> | null, enforceWorkdir?: boolean | null } | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number }, sharedVolumeMounts?: Array<{ __typename?: 'SharedVolumeMountsListItem', mountPath: string, readOnly: boolean, sharedVolume: { __typename?: 'SharedVolume', name: string, namespace?: string | null } } | null> | null } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null> } | null };
+export type WorkspaceTemplatesQuery = { __typename?: 'Query', templateList?: { __typename?: 'ItPolitoCrownlabsV1alpha2TemplateList', templates: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, deleteAfter?: string | null, inactivityTimeout?: string | null, destroyAfterInactivity?: string | null, nodeSelector?: any | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, environmentType: EnvironmentType, mountMyDriveVolume: boolean, image: string, guiEnabled?: boolean | null, disableControls?: boolean | null, rewriteURL?: boolean | null, persistent?: boolean | null, containerStartupOptions?: { __typename?: 'ContainerStartupOptions', sourceArchiveURL?: string | null, contentPath?: string | null, startupArgs?: Array<string | null> | null, enforceWorkdir?: boolean | null } | null, resources: { __typename?: 'Resources', cpu: number, disk?: any | null, memory: any, reservedCPUPercentage: number }, sharedVolumeMounts?: Array<{ __typename?: 'SharedVolumeMountsListItem', mountPath: string, readOnly: boolean, sharedVolume: { __typename?: 'SharedVolume', name: string, namespace?: string | null } } | null> | null } | null>, workspaceCrownlabsPolitoItWorkspaceRef?: { __typename?: 'WorkspaceCrownlabsPolitoItWorkspaceRef', name: string } | null } | null, metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null } | null } | null> } | null };
 
 export type TenantQueryVariables = Exact<{
   tenantId: Scalars['String']['input'];
@@ -4370,16 +4526,17 @@ export type CreateSharedVolumeMutationHookResult = ReturnType<typeof useCreateSh
 export type CreateSharedVolumeMutationResult = Apollo.MutationResult<CreateSharedVolumeMutation>;
 export type CreateSharedVolumeMutationOptions = Apollo.BaseMutationOptions<CreateSharedVolumeMutation, CreateSharedVolumeMutationVariables>;
 export const CreateTemplateDocument = gql`
-    mutation createTemplate($workspaceId: String!, $workspaceNamespace: String!, $templateName: String!, $environmentList: [EnvironmentListListItemInput!]!, $templateId: String = "template-", $deleteAfter: String, $descriptionTemplate: String!, $inactivityTimeout: String, $allowPublicExposure: Boolean, $nodeSelector: JSON) {
+    mutation createTemplate($workspaceId: String!, $workspaceNamespace: String!, $templateName: String!, $environmentList: [EnvironmentListListItemInput!]!, $templateId: String = "template-", $deleteAfter: String, $descriptionTemplate: String!, $inactivityTimeout: String, $destroyAfterInactivity: String, $allowPublicExposure: Boolean, $nodeSelector: JSON) {
   createdTemplate: createCrownlabsPolitoItV1alpha2NamespacedTemplate(
     namespace: $workspaceNamespace
-    itPolitoCrownlabsV1alpha2TemplateInput: {kind: "Template", apiVersion: "crownlabs.polito.it/v1alpha2", spec: {prettyName: $templateName, description: $descriptionTemplate, deleteAfter: $deleteAfter, inactivityTimeout: $inactivityTimeout, environmentList: $environmentList, allowPublicExposure: $allowPublicExposure, nodeSelector: $nodeSelector, workspaceCrownlabsPolitoItWorkspaceRef: {name: $workspaceId}}, metadata: {generateName: $templateId, namespace: $workspaceNamespace}}
+    itPolitoCrownlabsV1alpha2TemplateInput: {kind: "Template", apiVersion: "crownlabs.polito.it/v1alpha2", spec: {prettyName: $templateName, description: $descriptionTemplate, deleteAfter: $deleteAfter, inactivityTimeout: $inactivityTimeout, destroyAfterInactivity: $destroyAfterInactivity, environmentList: $environmentList, allowPublicExposure: $allowPublicExposure, nodeSelector: $nodeSelector, workspaceCrownlabsPolitoItWorkspaceRef: {name: $workspaceId}}, metadata: {generateName: $templateId, namespace: $workspaceNamespace}}
   ) {
     spec {
       prettyName
       description
       deleteAfter
       inactivityTimeout
+      destroyAfterInactivity
       allowPublicExposure
       nodeSelector
       environmentList {
@@ -4424,6 +4581,7 @@ export type CreateTemplateMutationFn = Apollo.MutationFunction<CreateTemplateMut
  *      deleteAfter: // value for 'deleteAfter'
  *      descriptionTemplate: // value for 'descriptionTemplate'
  *      inactivityTimeout: // value for 'inactivityTimeout'
+ *      destroyAfterInactivity: // value for 'destroyAfterInactivity'
  *      allowPublicExposure: // value for 'allowPublicExposure'
  *      nodeSelector: // value for 'nodeSelector'
  *   },
@@ -5147,6 +5305,7 @@ export const WorkspaceTemplatesDocument = gql`
         allowPublicExposure
         deleteAfter
         inactivityTimeout
+        destroyAfterInactivity
         nodeSelector
         environmentList {
           name

--- a/frontend/src/graphql-components/mutation/createTemplate.mutation.graphql
+++ b/frontend/src/graphql-components/mutation/createTemplate.mutation.graphql
@@ -7,6 +7,7 @@ mutation createTemplate(
   $deleteAfter: String
   $descriptionTemplate: String!
   $inactivityTimeout: String
+  $destroyAfterInactivity: String
   $allowPublicExposure: Boolean
   $nodeSelector: JSON
 ) {
@@ -20,6 +21,7 @@ mutation createTemplate(
         description: $descriptionTemplate
         deleteAfter: $deleteAfter
         inactivityTimeout: $inactivityTimeout
+        destroyAfterInactivity: $destroyAfterInactivity
         environmentList: $environmentList
         allowPublicExposure: $allowPublicExposure
         nodeSelector: $nodeSelector
@@ -33,6 +35,7 @@ mutation createTemplate(
       description
       deleteAfter
       inactivityTimeout
+      destroyAfterInactivity
       allowPublicExposure
       nodeSelector
       environmentList {

--- a/frontend/src/graphql-components/query/templates.query.graphql
+++ b/frontend/src/graphql-components/query/templates.query.graphql
@@ -9,6 +9,7 @@ query workspaceTemplates($workspaceNamespace: String!) {
         allowPublicExposure
         deleteAfter
         inactivityTimeout
+        destroyAfterInactivity
         nodeSelector
         environmentList {
           name

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -77,6 +77,7 @@ export type Template = {
   hasMultipleEnvironments: boolean;
   deleteAfter: string;
   inactivityTimeout: string;
+  destroyAfterInactivity: string;
 };
 
 export type Instance = {

--- a/frontend/src/utils/instanceSubscriptionHandler.ts
+++ b/frontend/src/utils/instanceSubscriptionHandler.ts
@@ -58,7 +58,7 @@ export function handleInstanceUpdate(
   switch (objType) {
     case SubObjType.Deletion:
       instances = instances.filter(matchK8sObject(instance, true));
-      notify = false;
+      notify = true;
       break;
     case SubObjType.Addition:
       instances = [...instances, instance];

--- a/frontend/src/utilsLogic.tsx
+++ b/frontend/src/utilsLogic.tsx
@@ -100,6 +100,7 @@ export const makeGuiTemplate = (
     description: tq.original.spec?.description ?? '',
     deleteAfter: tq.original.spec?.deleteAfter ?? 'never',
     inactivityTimeout: tq.original.spec?.inactivityTimeout ?? 'never',
+    destroyAfterInactivity: tq.original.spec?.destroyAfterInactivity ?? 'never',
     persistent: hasPersistent,
     nodeSelector: tq.original.spec?.nodeSelector,
     resources: {
@@ -233,9 +234,9 @@ const hasActivePublicExposure = (
 
   return Boolean(
     (spec?.ports && spec.ports.length > 0) ||
-      (status?.ports &&
-        status.ports.length > 0 &&
-        safePhaseConversion(status.phase) !== Phase.Off),
+    (status?.ports &&
+      status.ports.length > 0 &&
+      safePhaseConversion(status.phase) !== Phase.Off),
   );
 };
 
@@ -720,6 +721,7 @@ export const getTemplatesMapped = (
       hasMultipleEnvironments: hasMultipleEnvironments ?? false,
       deleteAfter: '',
       inactivityTimeout: '',
+      destroyAfterInactivity: '',
     };
   });
 };
@@ -776,7 +778,11 @@ const makeNotificationContent = (
               <i>
                 {status === Phase2.Ready
                   ? ' running'
-                  : status === Phase2.Off && ' stopped'}
+                  : status === Phase2.Off
+                  ? ' stopped'
+                  : status === 'Deleted'
+                  ? ' deleted'
+                  : ''}
               </i>
             </div>
             {instanceUrl && (
@@ -809,23 +815,31 @@ export const notifyStatus = (
   if (!instance) {
     throw new Error('notifyStatus error: instance parameter is undefined');
   }
-  if (updateType !== UpdateType.Deleted) {
-    const { name, namespace } = instance.metadata ?? {};
-    const { prettyName } = instance.spec ?? {};
-    const { url, environments } = instance.status ?? {};
-    const { prettyName: templateName } =
-      instance.spec?.templateCrownlabsPolitoItTemplateRef?.templateWrapper
-        ?.itPolitoCrownlabsV1alpha2Template?.spec ?? {};
+  const { name, namespace } = instance.metadata ?? {};
+  const { prettyName } = instance.spec ?? {};
+  const { url, environments } = instance.status ?? {};
+  const { prettyName: templateName } =
+    instance.spec?.templateCrownlabsPolitoItTemplateRef?.templateWrapper
+      ?.itPolitoCrownlabsV1alpha2Template?.spec ?? {};
 
-    // Only set URL for single-environment instances
-    let iUrl;
-    if (url && environments && environments.length == 1) {
-      const firstEnvName = environments[0]?.name;
-      if (firstEnvName) {
-        const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
-        iUrl = `${baseUrl}/${firstEnvName}/`;
-      }
+  if (updateType === UpdateType.Deleted) {
+    notify(
+      'warning',
+      `${namespace}/${name}/deleted`,
+      makeNotificationContent(templateName, prettyName || name, 'Deleted'),
+    );
+    return;
+  }
+
+  // Only set URL for single-environment instances
+  let iUrl;
+  if (url && environments && environments.length == 1) {
+    const firstEnvName = environments[0]?.name;
+    if (firstEnvName) {
+      const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+      iUrl = `${baseUrl}/${firstEnvName}/`;
     }
+  }
 
     switch (status) {
       case Phase2.Off:
@@ -852,16 +866,14 @@ export const notifyStatus = (
         }
         break;
     }
-  }
 };
 
 export const filterUser = (instance: Instance, search: string) => {
   if (!search) {
     return true;
   }
-  const composedString = `${
-    instance.tenantId
-  }${instance.tenantDisplayName?.replace(/\s+/g, '')}`.toLowerCase();
+  const composedString = `${instance.tenantId
+    }${instance.tenantDisplayName?.replace(/\s+/g, '')}`.toLowerCase();
   return composedString.includes(search);
 };
 


### PR DESCRIPTION
This pull request enhances the template creation modal by introducing a new timeout option ("Delete if powered off for") and refactoring the existing timeout management to be more flexible and user-friendly. The changes include improvements to the UI for clarity, removal of unnecessary toggles, and support for the new timeout in both the form and the underlying data structures.

**Timeout management improvements:**

* Added a new `destroyAfterInactivity` timeout option to templates, allowing instances to be deleted if they remain powered off for a specified duration. This includes support in the form state, validation, and submission logic (`ModalCreateTemplate.tsx`, `types.ts`, `utils.ts`, `TemplatesTableLogic.tsx`). [[1]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR249) [[2]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR296) [[3]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR318-L309) [[4]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR356-L347) [[5]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR264) [[6]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL403-R413) [[7]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL415-R428) [[8]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL430-R448) [[9]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL448-R458) [[10]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL471-R481) [[11]](diffhunk://#diff-05369823c00ff18dea246fdbdc84ac6b38619486db1ebb733edeca93adde9ad6R20) [[12]](diffhunk://#diff-f0bd76718647a4241292157cd6909e6f78b4ab5a70f853fd07b8c43630d98d34R27) [[13]](diffhunk://#diff-b7622a6aabc19642dece6d601d91db7e6bc7f91d0d570f1efe69976998758365L274-R295)
* Refactored timeout input UI: removed the "Enable automatic clean-up" checkbox, making timeouts always visible and configurable. Setting a timeout value to 0 now disables the corresponding feature. [[1]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL517-R566) [[2]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR579-R647) [[3]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR659)

**User interface enhancements:**

* Improved form layout and labeling for the timeout fields, using clearer descriptions and grouping, and added contextual tooltips for each timeout option. [[1]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL517-R566) [[2]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR579-R647) [[3]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR659)
* Introduced the `StatusIcon` component to visually indicate the active/inactive state of each timeout and advanced feature, replacing text-based status indicators in the panel headers. [[1]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL6-R6) [[2]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caR56-R66) [[3]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL754-R814)

**Code cleanup and validation:**

* Simplified and generalized timeout-related handlers and validation logic to support the new timeout and improve maintainability. [[1]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL403-R413) [[2]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL415-R428) [[3]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL430-R448) [[4]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL448-R458) [[5]](diffhunk://#diff-a8566bd71582f691c13b10223bfa5c52cea2cc4a1f993f8e6fa4c054ef79f4caL471-R481)

These changes collectively make timeout configuration more flexible and intuitive for users creating or editing templates.