### PR TITLE
PMP support for Block volumes mirroring

### DIFF
--- a/operators/pkg/controller/pmp/provisioner.go
+++ b/operators/pkg/controller/pmp/provisioner.go
@@ -165,6 +165,12 @@ func (p *PvcMirrorProvisioner) Provision(ctx context.Context, options controller
 		return nil, controller.ProvisioningFinished, &controller.IgnoredError{Reason: "PV's CSI spec is missing"}
 	}
 
+	// Compare actual and requested VolumeMode
+	if ptr.Deref(originPV.Spec.VolumeMode, corev1.PersistentVolumeFilesystem) != ptr.Deref(mirrorPVC.Spec.VolumeMode, corev1.PersistentVolumeFilesystem) {
+		p.Logger.Error(errStopProvision, "Requested PVC's VolumeMode differs from the actual in the origin PV")
+		return nil, controller.ProvisioningFinished, &controller.IgnoredError{Reason: "Requested PVC's VolumeMode differs from the actual in the origin PV"}
+	}
+
 	// Create mirror PV
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -186,6 +192,7 @@ func (p *PvcMirrorProvisioner) Provision(ctx context.Context, options controller
 			},
 			MountOptions:     originPV.Spec.MountOptions,
 			StorageClassName: options.StorageClass.Name,
+			VolumeMode:       originPV.Spec.VolumeMode,
 		},
 	}
 
@@ -232,5 +239,10 @@ func (p *PvcMirrorProvisioner) Start(ctx context.Context) error {
 // ShouldDelete is the DeletionGuard interface function that returns whether deleting the PV should be attempted.
 func (p *PvcMirrorProvisioner) ShouldDelete(context.Context, *corev1.PersistentVolume) bool {
 	// If needed, checks to be done before deleting a PV can be added here
+	return true
+}
+
+// SupportsBlock is the BlockProvisioner interface function that returns whether this provisioner supports block volume provisioning.
+func (p *PvcMirrorProvisioner) SupportsBlock(context.Context) bool {
 	return true
 }

--- a/operators/pkg/controller/pmp/provisioner_test.go
+++ b/operators/pkg/controller/pmp/provisioner_test.go
@@ -91,9 +91,11 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 			pvSource        corev1.PersistentVolumeSource
 			resRequirements corev1.VolumeResourceRequirements
 			origVolumeName  string
+			origVolumeMode  corev1.PersistentVolumeMode
 			pvcOrigPhase    corev1.PersistentVolumeClaimPhase
 			pvcAccessMode   corev1.PersistentVolumeAccessMode
 			mirrDataSrcRef  *corev1.TypedObjectReference
+			mirrVolumeMode  corev1.PersistentVolumeMode
 
 			isPVCOrigCreated bool
 			isPVOrigCreated  bool
@@ -175,12 +177,16 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 				},
 			}
 
-			isPVCOrigCreated = false
-			isPVOrigCreated = false
-
 			AddObject(&nsOrigin)
 			AddObject(&nsTarget)
 			AddObject(&sc)
+		})
+
+		BeforeEach(func() {
+			isPVCOrigCreated = false
+			isPVOrigCreated = false
+			origVolumeMode = corev1.PersistentVolumeFilesystem
+			mirrVolumeMode = corev1.PersistentVolumeFilesystem
 		})
 
 		JustBeforeEach(func() {
@@ -201,6 +207,7 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 					PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
 					PersistentVolumeSource:        pvSource,
 					StorageClassName:              scName,
+					VolumeMode:                    &origVolumeMode,
 				},
 			}
 			pvcOrig = corev1.PersistentVolumeClaim{
@@ -230,6 +237,7 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 					DataSourceRef:    mirrDataSrcRef,
 					StorageClassName: &scName,
 					Resources:        resRequirements,
+					VolumeMode:       &mirrVolumeMode,
 				},
 			}
 			provisionOptions = controller.ProvisionOptions{
@@ -418,15 +426,33 @@ var _ = Describe("The PVC Mirror Provisioner methods", func() {
 											}
 										})
 
-										It("should successfully provision the mirror PV", func() {
-											ExpectNoError()
-											Expect(pvMirr).ToNot(BeNil())
-											Expect(pvMirr.Labels).To(HaveLen(3))
-											Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvLabel, pvOrigName))
-											Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvcNamespaceLabel, originNsName))
-											Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvcNameLabel, pvcOrigName))
-											Expect(pvMirr.Spec.CSI).ToNot(BeNil())
-											Expect(pvMirr.Spec.CSI.VolumeHandle).To(Equal("/nfs/path"))
+										When("the volumeModes (actual and requested) match", func() {
+											BeforeEach(func() {
+												origVolumeMode = corev1.PersistentVolumeFilesystem
+												mirrVolumeMode = corev1.PersistentVolumeFilesystem
+											})
+
+											It("should successfully provision the mirror PV", func() {
+												ExpectNoError()
+												Expect(pvMirr).ToNot(BeNil())
+												Expect(pvMirr.Labels).To(HaveLen(3))
+												Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvLabel, pvOrigName))
+												Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvcNamespaceLabel, originNsName))
+												Expect(pvMirr.Labels).To(HaveKeyWithValue(pmp.MirroredPvcNameLabel, pvcOrigName))
+												Expect(pvMirr.Spec.CSI).ToNot(BeNil())
+												Expect(pvMirr.Spec.CSI.VolumeHandle).To(Equal("/nfs/path"))
+											})
+										})
+
+										When("the volumeModes (actual and requested) don't match", func() {
+											BeforeEach(func() {
+												origVolumeMode = corev1.PersistentVolumeBlock
+												mirrVolumeMode = corev1.PersistentVolumeFilesystem
+											})
+
+											It("should return an ignored error", func() {
+												ExpectIgnoredError()
+											})
 										})
 									})
 


### PR DESCRIPTION
# Description

This PR adds support for mirroring of PVs that have `VolumeMode = Block`.
It could have been useful to #1094, but in the end it wasn't actually used.

# How was this tested?

Edited the existing tests to check the added logic.