### PR TITLE
fix: standalone desktop proxy buffer size for filebrowser

### DIFF
--- a/provisioning/standalone/desktop/base/docker-compose.yaml
+++ b/provisioning/standalone/desktop/base/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   newdesktop:
     build: .
-    image: crownlabs/standalone-vnc-base:v0.1.0
+    image: crownlabs/standalone-vnc-base:v0.1.1
     restart: unless-stopped
     ports:
       - "8090:8080"

--- a/provisioning/standalone/desktop/base/root/etc/nginx/nginx.conf.tpl
+++ b/provisioning/standalone/desktop/base/root/etc/nginx/nginx.conf.tpl
@@ -27,6 +27,7 @@ http {
       # proxy_set_header Upgrade         $http_upgrade;
       # proxy_set_header Connection      "Upgrade";
       # proxy_set_header Host            $http_host;
+      client_max_body_size 50M;
     }
     
     location /${BASE_PATH} {

--- a/provisioning/standalone/desktop/blender/Dockerfile
+++ b/provisioning/standalone/desktop/blender/Dockerfile
@@ -1,4 +1,4 @@
-FROM crownlabs/standalone-vnc-base:v0.1.0
+FROM crownlabs/standalone-vnc-base:v0.1.1
 
 ARG BLENDER_VERSION_MAJOR="4.5"
 ARG BLENDER_VERSION_MINOR="4"

--- a/provisioning/standalone/desktop/blender/docker-compose.yaml
+++ b/provisioning/standalone/desktop/blender/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   newdesktop:
     build: .
-    image: crownlabs/standalone-vnc-blender:v0.1.0
+    image: crownlabs/standalone-vnc-blender:v0.1.1
     restart: unless-stopped
     ports:
       - "8090:8080"


### PR DESCRIPTION
This pull request updates the base and Blender desktop images to version `v0.1.1` and increases the maximum allowed client upload size in the Nginx configuration. These changes add support for larger file uploads.

**Docker image version updates:**
* Updated the base image reference in `docker-compose.yaml` and `Dockerfile` files to use `crownlabs/standalone-vnc-base:v0.1.1` instead of `v0.1.0`, ensuring the latest base is used. [[1]](diffhunk://#diff-31c7b2404d1192145d4fd32276382766fb83135ffced944edb4de3303b051bebL5-R5) [[2]](diffhunk://#diff-9c70643e97f60eea3792425200e8b5811ac91b305d3967475bb9a1c5dff6b8d0L1-R1)

**Nginx configuration improvement:**
* Set the `client_max_body_size` to `50M` in `nginx.conf.tpl` to allow larger file uploads via the web interface.