### PR TITLE
Resolved DV ownership conflict with KubeVirt

### DIFF
--- a/operators/pkg/instctrl/statusinspection.go
+++ b/operators/pkg/instctrl/statusinspection.go
@@ -35,7 +35,8 @@ func (r *InstanceReconciler) RetrievePhaseFromVM(vm *virtv1.VirtualMachine, vmi 
 			return clv1alpha2.EnvironmentPhaseResourceQuotaExceeded
 		}
 		return clv1alpha2.EnvironmentPhaseStarting
-	case virtv1.VirtualMachineStatusProvisioning:
+	case virtv1.VirtualMachineStatusProvisioning,
+		virtv1.VirtualMachineStatusWaitingForVolumeBinding:
 		return clv1alpha2.EnvironmentPhaseImporting
 
 	case virtv1.VirtualMachineStatusStopping:

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -17,7 +17,6 @@ package instctrl
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -83,16 +82,9 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
-		// Filter the OwnerReferences to remove any controller that is not the current instance, to avoid "stealing" the resource from other controllers.
-		var filteredOwners []metav1.OwnerReference
-		for _, owner := range dv.OwnerReferences {
-			if owner.Controller != nil && *owner.Controller && owner.UID != instance.UID {
-				// If the owner is a controller and it is not the current instance, we skip it.
-				continue
-			}
-			filteredOwners = append(filteredOwners, owner)
-		}
-		dv.OwnerReferences = filteredOwners
+		
+		// Remove the owner
+		dv.OwnerReferences = nil
 
 		return ctrl.SetControllerReference(instance, &dv, r.Scheme)
 	})

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -83,6 +83,10 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
+		if dv.Annotations == nil {
+			dv.Annotations = make(map[string]string)
+		}
+		dv.Annotations["cdi.kubevirt.io/storage.bind.immediate.requested"] = "true"
 		// Set the owner reference to the instance, to ensure the correct garbage collection of the DataVolume when the instance is deleted.
 		// Used to ignore update of owner in case of DV already controlled by another object
 		if metav1.GetControllerOf(&dv) == nil {

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -82,7 +82,6 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
-		
 		// Remove the owner
 		dv.OwnerReferences = nil
 

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -83,13 +83,18 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
-		// Set the owner reference to the instance, to ensure the correct garbage collection of the DataVolume when the instance is deleted.
-		// Used to ignore update of owner in case of DV already controlled by another object
-		if metav1.GetControllerOf(&dv) == nil {
-			// Set the owner reference when the DataVolume is not already controlled by another object.
-			return ctrl.SetControllerReference(instance, &dv, r.Scheme)
+		// Filter the OwnerReferences to remove any controller that is not the current instance, to avoid "stealing" the resource from other controllers.
+		var filteredOwners []metav1.OwnerReference
+		for _, owner := range dv.OwnerReferences {
+			if owner.Controller != nil && *owner.Controller && owner.UID != instance.UID {
+				// If the owner is a controller and it is not the current instance, we skip it.
+				continue
+			}
+			filteredOwners = append(filteredOwners, owner)
 		}
-		return nil
+		dv.OwnerReferences = filteredOwners
+
+		return ctrl.SetControllerReference(instance, &dv, r.Scheme)
 	})
 	if errDV != nil {
 		log.Error(errDV, "failed to enforce datavolume", "datavolume", klog.KObj(&dv))
@@ -115,6 +120,10 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 		// either rejected by the webhook or cause the restart of the child VMI, with consequent possible data loss.
 		if vm.CreationTimestamp.IsZero() {
 			vm.Spec = forge.VirtualMachineSpec(instance, template, environment, mountInfos)
+		}
+		// If DataVolumeTemplates are present, they are removed from the VM specifications, as they are not needed anymore. In fact, the DataVolume is already created and managed by the controller.
+		if len(vm.Spec.DataVolumeTemplates) > 0 {
+			vm.Spec.DataVolumeTemplates = nil
 		}
 		// Afterwards, the only modification to the specifications is performed to configure the running flag.
 		vm.Spec.Running = ptr.To(instance.Spec.Running)

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -90,9 +90,7 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			return ctrl.SetControllerReference(instance, &dv, r.Scheme)
 		}
 		return nil
-
 	})
-
 	if errDV != nil {
 		log.Error(errDV, "failed to enforce datavolume", "datavolume", klog.KObj(&dv))
 		return errDV

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -17,6 +17,7 @@ package instctrl
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	virtv1 "kubevirt.io/api/core/v1"
@@ -83,7 +84,13 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			dv.Spec = forgedDV
 		}
 		// Set the owner reference to the instance, to ensure the correct garbage collection of the DataVolume when the instance is deleted.
-		return ctrl.SetControllerReference(instance, &dv, r.Scheme)
+		// Used to ignore update of owner in case of DV already controlled by another object
+		if metav1.GetControllerOf(&dv) == nil {
+			// Set the owner reference when the DataVolume is not already controlled by another object.
+			return ctrl.SetControllerReference(instance, &dv, r.Scheme)
+		}
+		return nil
+
 	})
 
 	if errDV != nil {

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -82,7 +82,7 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
-		// Remove the owner
+		// Remove the owner, this line SHOULD BE removed after the deployment in production
 		dv.OwnerReferences = nil
 
 		return ctrl.SetControllerReference(instance, &dv, r.Scheme)

--- a/operators/pkg/instctrl/virtualmachines.go
+++ b/operators/pkg/instctrl/virtualmachines.go
@@ -83,10 +83,6 @@ func (r *InstanceReconciler) enforceVirtualMachine(ctx context.Context) error {
 			// Forge the DataVolume specifications only at creation time, as changing them later may be either rejected by the webhook or cause data loss.
 			dv.Spec = forgedDV
 		}
-		if dv.Annotations == nil {
-			dv.Annotations = make(map[string]string)
-		}
-		dv.Annotations["cdi.kubevirt.io/storage.bind.immediate.requested"] = "true"
 		// Set the owner reference to the instance, to ensure the correct garbage collection of the DataVolume when the instance is deleted.
 		// Used to ignore update of owner in case of DV already controlled by another object
 		if metav1.GetControllerOf(&dv) == nil {

--- a/operators/pkg/instctrl/virtualmachines_test.go
+++ b/operators/pkg/instctrl/virtualmachines_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Generation of the virtual machine and virtual machine instance
 					clientBuilder.WithObjects(&existingDV)
 				})
 
-				It("Should not fail and should steal the controller owner from the VirtualMachine", func() {
+				It("Should replace the VirtualMachine controller owner with the Instance owner", func() {
 					var dv cdiv1beta1.DataVolume
 
 					Expect(err).ToNot(HaveOccurred())

--- a/operators/pkg/instctrl/virtualmachines_test.go
+++ b/operators/pkg/instctrl/virtualmachines_test.go
@@ -417,12 +417,15 @@ var _ = Describe("Generation of the virtual machine and virtual machine instance
 					clientBuilder.WithObjects(&existingDV)
 				})
 
-				It("Should not fail and should preserve the existing controller owner", func() {
+				It("Should not fail and should steal the controller owner from the VirtualMachine", func() {
 					var dv cdiv1beta1.DataVolume
 
 					Expect(err).ToNot(HaveOccurred())
 					Expect(reconciler.Get(ctx, objectNameEnv, &dv)).To(Succeed())
-					Expect(dv.GetOwnerReferences()).To(ContainElement(metav1.OwnerReference{
+
+					Expect(dv.GetOwnerReferences()).To(ContainElement(ownerRef))
+
+					Expect(dv.GetOwnerReferences()).ToNot(ContainElement(metav1.OwnerReference{
 						APIVersion:         virtv1.GroupVersion.String(),
 						Kind:               "VirtualMachine",
 						Name:               objectNameEnv.Name,

--- a/operators/pkg/instctrl/virtualmachines_test.go
+++ b/operators/pkg/instctrl/virtualmachines_test.go
@@ -395,6 +395,44 @@ var _ = Describe("Generation of the virtual machine and virtual machine instance
 				})
 			})
 
+			When("the DataVolume is already controlled by a VirtualMachine", func() {
+				BeforeEach(func() {
+					existingDV := cdiv1beta1.DataVolume{
+						ObjectMeta: forge.NamespacedNameToObjectMeta(objectNameEnv),
+						Spec: cdiv1beta1.DataVolumeSpec{
+							PVC: &corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+							},
+						},
+					}
+					existingDV.SetCreationTimestamp(metav1.NewTime(time.Now()))
+					existingDV.SetOwnerReferences([]metav1.OwnerReference{{
+						APIVersion:         virtv1.GroupVersion.String(),
+						Kind:               "VirtualMachine",
+						Name:               objectNameEnv.Name,
+						UID:                types.UID("vm-owner"),
+						BlockOwnerDeletion: ptr.To(true),
+						Controller:         ptr.To(true),
+					}})
+					clientBuilder.WithObjects(&existingDV)
+				})
+
+				It("Should not fail and should preserve the existing controller owner", func() {
+					var dv cdiv1beta1.DataVolume
+
+					Expect(err).ToNot(HaveOccurred())
+					Expect(reconciler.Get(ctx, objectNameEnv, &dv)).To(Succeed())
+					Expect(dv.GetOwnerReferences()).To(ContainElement(metav1.OwnerReference{
+						APIVersion:         virtv1.GroupVersion.String(),
+						Kind:               "VirtualMachine",
+						Name:               objectNameEnv.Name,
+						UID:                types.UID("vm-owner"),
+						BlockOwnerDeletion: ptr.To(true),
+						Controller:         ptr.To(true),
+					}))
+				})
+			})
+
 			When("the environment image is invalid", func() {
 				BeforeEach(func() {
 					environment.EnvironmentType = clv1alpha2.ClassLocalVM


### PR DESCRIPTION
This PR fixes #1158 by changing the way DataVolumes are managed by the CrownLabs operator, moving from a passive to an active ownership approach.
Related to PR: #1094

Specifically, it introduces two main changes to the reconciliation loop:
1. **Removal of `DataVolumeTemplates`:** When forging the VirtualMachine spec, any existing `DataVolumeTemplates` are explicitly removed. This prevents KubeVirt's native controller from attempting to manage or recreate the volumes independently.
2. **Active Ownership Enforcement:** Instead of ignoring the `OwnerReference` when the DataVolume is already controlled by KubeVirt, the operator now actively filters out KubeVirt's controller reference and enforces the CrownLabs `Instance` as the sole legitimate controller.