### PR TITLE
Gateway API: Envoy SecurityPolicy enforcement for Instance authentication

### DIFF
--- a/deploy/crownlabs/templates/httproute-callback.yaml
+++ b/deploy/crownlabs/templates/httproute-callback.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.global.gateway.gatewayApiMode (.Values.global.gateway.securityPolicy.enabled | default true) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "crownlabs.fullname" . }}-instauth-callback
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.global.gateway.name }}
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: {{ .Values.global.gateway.securityPolicy.callback.path }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ include "crownlabs.fullname" . }}-secpol-dummy-backend
+          port: 80
+{{- end }}

--- a/deploy/crownlabs/templates/securitypolicy-gateway.yaml
+++ b/deploy/crownlabs/templates/securitypolicy-gateway.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.global.gateway.gatewayApiMode (.Values.global.gateway.securityPolicy.enabled | default true) }}
+{{- if .Values.global.gateway.securityPolicy.secret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.gateway.securityPolicy.secret.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- toYaml .Values.global.gateway.securityPolicy.secret.stringData | nindent 4 }}
+---
+{{- end }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.global.gateway.securityPolicy.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.global.gateway.name }}
+  {{- toYaml .Values.global.gateway.securityPolicy.spec | nindent 2 }}
+{{- end }}

--- a/deploy/crownlabs/templates/securitypolicy-public-routes.yaml
+++ b/deploy/crownlabs/templates/securitypolicy-public-routes.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.gateway.gatewayApiMode (.Values.global.gateway.securityPolicy.enabled | default true) }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .Values.global.gateway.securityPolicy.publicRoutes.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+spec:
+  # Intentionally empty to override the global Gateway-level SecurityPolicy and exempt
+  # public routes matching the target selector from authentication.
+  targetSelectors:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      matchLabels:
+        {{- toYaml .Values.global.gateway.securityPolicy.publicRoutes.targetSelector | nindent 8 }}
+{{- end }}

--- a/deploy/crownlabs/templates/service-dummy-callback.yaml
+++ b/deploy/crownlabs/templates/service-dummy-callback.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.global.gateway.gatewayApiMode (.Values.global.gateway.securityPolicy.enabled | default true) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "crownlabs.fullname" . }}-secpol-dummy-backend
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # Ignore kube-score check for this dummy service intentionally without target pods
+    # serving as a placeholder backend for authentication callbacks
+    kube-score/ignore: service-targets-pod
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+spec:
+  selector:
+    crownlabs.polito.it/dummy-backend: "true"
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+{{- end }}

--- a/deploy/crownlabs/values.yaml
+++ b/deploy/crownlabs/values.yaml
@@ -8,6 +8,28 @@ global:
     gatewayApiMode: true
     name: "crownlabs-main"
     hostname: crownlabs.example.com
+    securityPolicy:
+      enabled: true
+      name: "crownlabs-global"
+      publicRoutes:
+        name: "crownlabs-public-exclusion"
+        targetSelector:
+          "crownlabs.polito.it/public-route": "true"
+      callback:
+        path: "/app/instauth/callback"
+      secret:
+        enabled: true
+        name: "envoy-secpol-dummy-secret"
+        stringData:
+          client-secret: "dummy"
+      spec:
+        oidc:
+          provider:
+            issuer: "https://auth.ng.crownlabs.polito.it/realms/crownlabs"
+          clientID: "k8s"
+          clientSecret:
+            name: "envoy-secpol-dummy-secret"
+          redirectURL: "%REQ(x-forwarded-proto)%://%REQ(:authority)%/app/instauth/callback"
 
 createClusterRoles: true
 
@@ -306,7 +328,7 @@ gatewayAPI:
   allowedRoutesSimple:
     key: "crownlabs.polito.it/gw-access"
     value: "crownlabs-main-production"
-  # allowedRoutes: {}
+
 
 exam-agent:
   replicaCount: 1

--- a/frontend/deploy/frontend-app/templates/httproute.yaml
+++ b/frontend/deploy/frontend-app/templates/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "frontend-app.fullname" . }}
   labels:
     {{- include "frontend-app.labels" . | nindent 4 }}
+    crownlabs.polito.it/public-route: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/operators/cmd/instance-operator/main.go
+++ b/operators/cmd/instance-operator/main.go
@@ -182,7 +182,7 @@ func main() {
 	expositionCfg.GatewayAPIMode = gatewayAPIMode
 	log.Info("Gateway API mode selection", "enabled", gatewayAPIMode)
 	if gatewayAPIMode {
-		gwNs, gwName, err := forge.ParseGatewayParent(gatewayAPIRefsValues)
+		gwNs, gwName, err := forge.ParseNamespacedName(gatewayAPIRefsValues)
 		if err != nil {
 			log.Error(err, "invalid gateway parent format, expected 'namespace/name'")
 			os.Exit(1)

--- a/operators/deploy/bastion/templates/httproute.yaml
+++ b/operators/deploy/bastion/templates/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "bastion.fullname" . }}-webssh
   labels:
     {{- include "webssh.labels" . | nindent 4 }}
+    crownlabs.polito.it/public-route: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io

--- a/operators/pkg/forge/httproutes.go
+++ b/operators/pkg/forge/httproutes.go
@@ -52,18 +52,18 @@ type ExpositionConfig struct {
 	GatewayNamespace     string
 }
 
-// ParseGatewayParent parses a gateway parent reference of the form
+// ParseNamespacedName parses a reference of the form
 // "namespace/name" and returns the two components. Returns an error on invalid input.
-func ParseGatewayParent(raw string) (namespace, name string, err error) {
+func ParseNamespacedName(raw string) (namespace, name string, err error) {
 	raw = strings.TrimSpace(raw)
 	parts := strings.Split(raw, "/")
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid gateway parent reference: %q", raw)
+		return "", "", fmt.Errorf("invalid namespaced name reference: %q", raw)
 	}
 	trim := strings.TrimSpace
 	namespace, name = trim(parts[0]), trim(parts[1])
 	if namespace == "" || name == "" {
-		return "", "", fmt.Errorf("invalid gateway parent reference, empty namespace or name: %q", raw)
+		return "", "", fmt.Errorf("invalid namespaced name reference, empty namespace or name: %q", raw)
 	}
 	return namespace, name, nil
 }

--- a/operators/pkg/forge/httproutes_test.go
+++ b/operators/pkg/forge/httproutes_test.go
@@ -30,32 +30,32 @@ var _ = Describe("HTTPRoute helpers", func() {
 		host        = "crownlabs.example.com"
 	)
 
-	Describe("ParseGatewayParent behavior", func() {
-		It("ParseGatewayParent parses valid parent references", func() {
-			ns, name, err := forge.ParseGatewayParent("my-ns/my-gateway")
+	Describe("ParseNamespacedName behavior", func() {
+		It("ParseNamespacedName parses valid parent references", func() {
+			ns, name, err := forge.ParseNamespacedName("my-ns/my-gateway")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ns).To(Equal("my-ns"))
 			Expect(name).To(Equal("my-gateway"))
 		})
 
-		Context("ParseGatewayParent errors on invalid input", func() {
+		Context("ParseNamespacedName errors on invalid input", func() {
 			It("errors on empty string", func() {
-				_, _, err := forge.ParseGatewayParent("")
+				_, _, err := forge.ParseNamespacedName("")
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("errors on missing namespace", func() {
-				_, _, err := forge.ParseGatewayParent("/my-gateway")
+				_, _, err := forge.ParseNamespacedName("/my-gateway")
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("errors on missing name", func() {
-				_, _, err := forge.ParseGatewayParent("my-ns/")
+				_, _, err := forge.ParseNamespacedName("my-ns/")
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("errors on extra slashes", func() {
-				_, _, err := forge.ParseGatewayParent("my-ns/my-gateway/extra")
+				_, _, err := forge.ParseNamespacedName("my-ns/my-gateway/extra")
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/operators/pkg/instctrl/controller.go
+++ b/operators/pkg/instctrl/controller.go
@@ -390,18 +390,22 @@ func (r *InstanceReconciler) setInitialReadyTimeIfNecessary(ctx context.Context)
 func (r *InstanceReconciler) SetupWithManager(mgr ctrl.Manager, concurrency int) error {
 	mgr.GetLogger().Info("setup manager")
 
-	return ctrl.NewControllerManagedBy(mgr).
+	bld := ctrl.NewControllerManagedBy(mgr).
 		For(&clv1alpha2.Instance{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&virtv1.VirtualMachine{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
-		Owns(&gatewayv1.HTTPRoute{}).
 		// Here, we use Watches instead of Owns since we need to react also in case a VMI generated from a VM is updated,
 		// to correctly update the instance phase in case of persistent VMs with resource quota exceeded.
-		Watches(&virtv1.VirtualMachineInstance{}, handler.EnqueueRequestsFromMapFunc(r.vmiToInstance)).
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: concurrency,
-		}).
+		Watches(&virtv1.VirtualMachineInstance{}, handler.EnqueueRequestsFromMapFunc(r.vmiToInstance))
+
+	if r.ExpositionConfig.GatewayAPIMode {
+		bld = bld.Owns(&gatewayv1.HTTPRoute{})
+	}
+
+	return bld.WithOptions(controller.Options{
+		MaxConcurrentReconciles: concurrency,
+	}).
 		WithLogConstructor(utils.LogConstructor(mgr.GetLogger(), "Instance")).
 		Complete(r)
 }

--- a/operators/pkg/instctrl/exposition.go
+++ b/operators/pkg/instctrl/exposition.go
@@ -38,23 +38,23 @@ func (r *InstanceReconciler) EnforceInstanceExposition(ctx context.Context) erro
 	instance := clctx.InstanceFrom(ctx)
 
 	if instance.Spec.Running && r.ExpositionConfig.GatewayAPIMode {
-		return r.enforceInstanceExpositionHTTPRoutePresence(ctx)
+		return r.enforceHTTPRoutePresence(ctx)
 	}
 	if instance.Spec.Running && !r.ExpositionConfig.GatewayAPIMode {
-		return r.enforceInstanceExpositionIngressPresence(ctx)
+		return r.enforceIngressPresence(ctx)
 	}
 
 	return r.enforceInstanceExpositionAbsence(ctx)
 }
 
-// enforceInstanceExpositionHTTPRoutePresence ensures the presence of the HTTPRoute required to expose an environment.
-func (r *InstanceReconciler) enforceInstanceExpositionHTTPRoutePresence(ctx context.Context) error {
+// enforceHTTPRoutePresence ensures the presence of the HTTPRoute required to expose an environment.
+func (r *InstanceReconciler) enforceHTTPRoutePresence(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 	envIndex := clctx.EnvironmentIndexFrom(ctx)
 
-	svc, err := r.enforceInstanceExpositionServicePresence(ctx)
+	svc, err := r.enforceServicePresence(ctx)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionHTTPRoutePresence(ctx cont
 	}
 
 	// Destroy any Ingress
-	if err := r.enforceInstanceExpositionIngressAbsence(ctx); err != nil {
+	if err := r.enforceIngressAbsence(ctx); err != nil {
 		log.Error(err, "failed to remove conflicting ingress", "httproute", klog.KObj(&httpRoute))
 		return err
 	}
@@ -116,14 +116,14 @@ func (r *InstanceReconciler) enforceInstanceExpositionHTTPRoutePresence(ctx cont
 	return nil
 }
 
-// enforceInstanceExpositionIngressPresence ensures the presence of the Ingress required to expose an environment.
-func (r *InstanceReconciler) enforceInstanceExpositionIngressPresence(ctx context.Context) error {
+// enforceIngressPresence ensures the presence of the Ingress required to expose an environment.
+func (r *InstanceReconciler) enforceIngressPresence(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx)
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 	envIndex := clctx.EnvironmentIndexFrom(ctx)
 
-	svc, err := r.enforceInstanceExpositionServicePresence(ctx)
+	svc, err := r.enforceServicePresence(ctx)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (r *InstanceReconciler) enforceInstanceExpositionIngressPresence(ctx contex
 	instance.Status.Environments[envIndex].ExpositionAccepted = true
 
 	// Destroy any HTTPRoute
-	if err := r.enforceInstanceExpositionHTTPRouteAbsence(ctx); err != nil {
+	if err := r.enforceHTTPRouteAbsence(ctx); err != nil {
 		log.Error(err, "failed to remove conflicting httproute", "ingress", klog.KObj(&ingressGUI))
 		return err
 	}
@@ -179,8 +179,8 @@ func (r *InstanceReconciler) enforceInstanceExpositionIngressPresence(ctx contex
 	return nil
 }
 
-// enforceInstanceExpositionServicePresence ensures the presence of the Service required to expose an environment, and returns it.
-func (r *InstanceReconciler) enforceInstanceExpositionServicePresence(ctx context.Context) (*corev1.Service, error) {
+// enforceServicePresence ensures the presence of the Service required to expose an environment, and returns it.
+func (r *InstanceReconciler) enforceServicePresence(ctx context.Context) (*corev1.Service, error) {
 	log := ctrl.LoggerFrom(ctx)
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
@@ -240,23 +240,23 @@ func (r *InstanceReconciler) enforceInstanceExpositionAbsence(ctx context.Contex
 	instance.Status.Environments[envIndex].ExpositionAccepted = false
 
 	// Enforce Service absence
-	if err := r.enforceInstanceExpositionServiceAbsence(ctx); err != nil {
+	if err := r.enforceServiceAbsence(ctx); err != nil {
 		return err
 	}
 	// Enforce HTTPRoute absence
-	if err := r.enforceInstanceExpositionHTTPRouteAbsence(ctx); err != nil {
+	if err := r.enforceHTTPRouteAbsence(ctx); err != nil {
 		return err
 	}
 	// Enforce Ingress absence
-	if err := r.enforceInstanceExpositionIngressAbsence(ctx); err != nil {
+	if err := r.enforceIngressAbsence(ctx); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// enforceInstanceExpositionHTTPRouteAbsence removes the HTTPRoute exposed resource for the environment.
-func (r *InstanceReconciler) enforceInstanceExpositionHTTPRouteAbsence(ctx context.Context) error {
+// enforceHTTPRouteAbsence removes the HTTPRoute exposed resource for the environment.
+func (r *InstanceReconciler) enforceHTTPRouteAbsence(ctx context.Context) error {
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 
@@ -267,8 +267,8 @@ func (r *InstanceReconciler) enforceInstanceExpositionHTTPRouteAbsence(ctx conte
 	return nil
 }
 
-// enforceInstanceExpositionIngressAbsence removes the Ingress exposed resource for the environment.
-func (r *InstanceReconciler) enforceInstanceExpositionIngressAbsence(ctx context.Context) error {
+// enforceIngressAbsence removes the Ingress exposed resource for the environment.
+func (r *InstanceReconciler) enforceIngressAbsence(ctx context.Context) error {
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 
@@ -279,8 +279,8 @@ func (r *InstanceReconciler) enforceInstanceExpositionIngressAbsence(ctx context
 	return nil
 }
 
-// enforceInstanceExpositionServiceAbsence removes the Service exposed resource for the environment.
-func (r *InstanceReconciler) enforceInstanceExpositionServiceAbsence(ctx context.Context) error {
+// enforceServiceAbsence removes the Service exposed resource for the environment.
+func (r *InstanceReconciler) enforceServiceAbsence(ctx context.Context) error {
 	instance := clctx.InstanceFrom(ctx)
 	environment := clctx.EnvironmentFrom(ctx)
 

--- a/operators/pkg/instctrl/exposition_test.go
+++ b/operators/pkg/instctrl/exposition_test.go
@@ -100,277 +100,267 @@ var _ = Describe("Exposition helpers", func() {
 		ctx = clctx.EnvironmentIndexInto(ctx, index)
 	})
 
-	Context("When instance is running", func() {
+	When("instance is running", func() {
 		BeforeEach(func() { instance.Spec.Running = true })
 
-		It("creates Service and updates instance status with ClusterIP", func() {
-			err := reconciler.EnforceInstanceExposition(ctx)
-			Expect(err).ToNot(HaveOccurred())
-
-			svc := corev1.Service{}
-			Expect(reconciler.Client.Get(ctx, serviceName, &svc)).To(Succeed())
-			Expect(instance.Status.Environments[index].IP).To(Equal(clusterIP))
-		})
-
-		It("updates instance status with empty string when Service is headless and no Pod exists", func() {
-			reconciler.Client = FakeClientWrapped{Client: clientBuilder.Build(), serviceClusterIP: "None"}
-
-			err := reconciler.EnforceInstanceExposition(ctx)
-			Expect(err).ToNot(HaveOccurred())
-
-			svc := corev1.Service{}
-			Expect(reconciler.Client.Get(ctx, serviceName, &svc)).To(Succeed())
-			Expect(instance.Status.Environments[index].IP).To(Equal(""))
-		})
-
-		It("updates instance status with Pod IP when Service is headless and Pod exists (Container)", func() {
-			// Mock pod for container environment
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-xxxxx", serviceName.Name),
-					Namespace: serviceName.Namespace,
-					Labels:    forge.EnvironmentSelectorLabels(&instance, &environment),
-				},
-				Status: corev1.PodStatus{
-					PodIP: "10.244.50.60",
-				},
-			}
-			reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(pod).Build(), serviceClusterIP: "None"}
-
-			err := reconciler.EnforceInstanceExposition(ctx)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(instance.Status.Environments[index].IP).To(Equal("10.244.50.60"))
-		})
-
-		It("updates instance status with Pod IP when Service is headless and VM pod exists", func() {
-			// Mock environment as VM
-			vmEnv := clv1alpha2.Environment{Name: "vm-env", EnvironmentType: clv1alpha2.ClassVM}
-			vmInstance := instance
-			vmInstance.Status.Environments = []clv1alpha2.InstanceStatusEnv{{}}
-			vmServiceName := forge.NamespacedNameWithSuffix(&vmInstance, vmEnv.Name)
-
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("virt-launcher-%s-xxxxx", vmServiceName.Name),
-					Namespace: vmServiceName.Namespace,
-					Labels:    forge.EnvironmentSelectorLabels(&vmInstance, &vmEnv),
-				},
-				Status: corev1.PodStatus{
-					PodIP: "10.244.100.200",
-				},
-			}
-			reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(pod).Build(), serviceClusterIP: "None"}
-
-			vmCtx := ctrl.LoggerInto(context.Background(), logr.Discard())
-			vmCtx, _ = clctx.InstanceInto(vmCtx, &vmInstance)
-			vmCtx, _ = clctx.EnvironmentInto(vmCtx, &vmEnv)
-			vmCtx, _ = clctx.TemplateInto(vmCtx, &template)
-			vmCtx = clctx.EnvironmentIndexInto(vmCtx, 0)
-
-			err := reconciler.EnforceInstanceExposition(vmCtx)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(vmInstance.Status.Environments[0].IP).To(Equal("10.244.100.200"))
-		})
-
-		Context("Gateway API mode enabled", func() {
-			BeforeEach(func() { reconciler.ExpositionConfig.GatewayAPIMode = true })
-
-			It("creates HTTPRoute", func() {
+		Describe("Service creation", func() {
+			It("should create the Service and update instance status with the ClusterIP", func() {
 				err := reconciler.EnforceInstanceExposition(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+				svc := corev1.Service{}
+				Expect(reconciler.Client.Get(ctx, serviceName, &svc)).To(Succeed())
 				Expect(instance.Status.Environments[index].IP).To(Equal(clusterIP))
 			})
 
-			It("returns without creating resources if env index out of range", func() {
-				index = 10
-				ctx = clctx.EnvironmentIndexInto(ctx, index)
+			It("should update instance status with empty string when Service is headless and no Pod exists", func() {
+				reconciler.Client = FakeClientWrapped{Client: clientBuilder.Build(), serviceClusterIP: "None"}
 
 				err := reconciler.EnforceInstanceExposition(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(HaveOccurred())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+				svc := corev1.Service{}
+				Expect(reconciler.Client.Get(ctx, serviceName, &svc)).To(Succeed())
+				Expect(instance.Status.Environments[index].IP).To(Equal(""))
 			})
 
-			It("does not create HTTPRoute when no service is available", func() {
-				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects().Build(), serviceClusterIP: ""}
+			It("should update instance status with Pod IP when Service is headless and Pod exists (Container)", func() {
+				// Mock pod for container environment
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-xxxxx", serviceName.Name),
+						Namespace: serviceName.Namespace,
+						Labels:    forge.EnvironmentSelectorLabels(&instance, &environment),
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.244.50.60",
+					},
+				}
+				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(pod).Build(), serviceClusterIP: "None"}
 
 				err := reconciler.EnforceInstanceExposition(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+				Expect(instance.Status.Environments[index].IP).To(Equal("10.244.50.60"))
 			})
 
-			It("if HTTPRouted is created but not yet accepted and Ingress is present, leaves both present but ExpositionAccepted to false", func() {
-				ingress := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
-				httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
-				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&ingress, &httpRoute).Build(), serviceClusterIP: clusterIP}
+			It("should update instance status with Pod IP when Service is headless and VM pod exists", func() {
+				// Mock environment as VM
+				vmEnv := clv1alpha2.Environment{Name: "vm-env", EnvironmentType: clv1alpha2.ClassVM}
+				vmInstance := instance
+				vmInstance.Status.Environments = []clv1alpha2.InstanceStatusEnv{{}}
+				vmServiceName := forge.NamespacedNameWithSuffix(&vmInstance, vmEnv.Name)
 
-				err := reconciler.EnforceInstanceExposition(ctx)
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("virt-launcher-%s-xxxxx", vmServiceName.Name),
+						Namespace: vmServiceName.Namespace,
+						Labels:    forge.EnvironmentSelectorLabels(&vmInstance, &vmEnv),
+					},
+					Status: corev1.PodStatus{
+						PodIP: "10.244.100.200",
+					},
+				}
+				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(pod).Build(), serviceClusterIP: "None"}
+
+				vmCtx := ctrl.LoggerInto(context.Background(), logr.Discard())
+				vmCtx, _ = clctx.InstanceInto(vmCtx, &vmInstance)
+				vmCtx, _ = clctx.EnvironmentInto(vmCtx, &vmEnv)
+				vmCtx, _ = clctx.TemplateInto(vmCtx, &template)
+				vmCtx = clctx.EnvironmentIndexInto(vmCtx, 0)
+
+				err := reconciler.EnforceInstanceExposition(vmCtx)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
-				Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
-			})
-
-			It("if HTTPRoute is accepted, ensures Ingress is absent and sets ExpositionAccepted to true", func() {
-				httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
-				httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{{ControllerName: "gateway.networking.k8s.io/gateway-controller", ParentRef: gatewayv1.ParentReference{Name: "fake-gw", Namespace: ptr.To(gatewayv1.Namespace("fake-gw-ns"))}, Conditions: []metav1.Condition{{Type: string(gatewayv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}}}
-				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&httpRoute).Build(), serviceClusterIP: clusterIP}
-
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
-				Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeTrue())
-			})
-
-			It("skips creating HTTPRoute for GUI-less ClassVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassVM
-				environment.GuiEnabled = false
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
-
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
-			})
-
-			It("skips creating Ingress for GUI-less CloudVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassCloudVM
-				environment.GuiEnabled = false
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
-
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+				Expect(vmInstance.Status.Environments[0].IP).To(Equal("10.244.100.200"))
 			})
 		})
 
-		Context("Gateway API mode disabled", func() {
-			BeforeEach(func() { reconciler.ExpositionConfig.GatewayAPIMode = false })
+		Describe("HTTPRoute creation", func() {
+			Context("Gateway API mode enabled", func() {
+				BeforeEach(func() { reconciler.ExpositionConfig.GatewayAPIMode = true })
 
-			It("creates Ingress and Service", func() {
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+				It("should return without creating resources when the environment index is out of range", func() {
+					index = 10
+					ctx = clctx.EnvironmentIndexInto(ctx, index)
 
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(instance.Status.Environments[index].IP).To(Equal(clusterIP))
-				Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeTrue())
-			})
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-			It("deletes HTTPRoute if present and creates Ingress", func() {
-				httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
-				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&httpRoute).Build(), serviceClusterIP: clusterIP}
+					Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+				})
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+				It("should not create the HTTPRoute when no Service is available", func() {
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects().Build(), serviceClusterIP: ""}
 
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
-			})
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-			It("adds authentication annotations when enabled", func() {
-				reconciler.ExpositionConfig.EnableAuthentication = true
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+				})
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+				It("should create the HTTPRoute for VMs with a GUI", func() {
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				ing := netv1.Ingress{}
-				Expect(reconciler.Client.Get(ctx, ingressName, &ing)).To(Succeed())
-				Expect(ing.Annotations).To(HaveKey("nginx.ingress.kubernetes.io/auth-url"))
-				Expect(ing.Annotations).To(HaveKey("nginx.ingress.kubernetes.io/auth-signin"))
-			})
+					Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+					Expect(instance.Status.Environments[index].IP).To(Equal(clusterIP))
+				})
 
-			It("skips creating Ingress for GUI-less ClassVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassVM
-				environment.GuiEnabled = false
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+				DescribeTable("should skip creating the HTTPRoute for GUI-less VMs and mark ExpositionAccepted false",
+					func(envType clv1alpha2.EnvironmentType) {
+						environment.EnvironmentType = envType
+						environment.GuiEnabled = false
+						ctx, _ = clctx.EnvironmentInto(ctx, &environment)
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+						err := reconciler.EnforceInstanceExposition(ctx)
+						Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
-			})
+						Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
+						Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+						Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
+					},
+					Entry("ClassVM", clv1alpha2.ClassVM),
+					Entry("ClassCloudVM", clv1alpha2.ClassCloudVM),
+					Entry("ClassLocalVM", clv1alpha2.ClassLocalVM),
+				)
 
-			It("skips creating Ingress for GUI-less CloudVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassCloudVM
-				environment.GuiEnabled = false
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+				It("should leave the HTTPRoute present and mark ExpositionAccepted false if it is not yet accepted", func() {
+					httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&httpRoute).Build(), serviceClusterIP: clusterIP}
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
-			})
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+					Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
+				})
 
-			It("does not create Ingress when no service is available", func() {
-				reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects().Build(), serviceClusterIP: ""}
+				It("should set ExpositionAccepted to true if the HTTPRoute is accepted", func() {
+					httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{{ControllerName: "gateway.networking.k8s.io/gateway-controller", ParentRef: gatewayv1.ParentReference{Name: "fake-gw", Namespace: ptr.To(gatewayv1.Namespace("fake-gw-ns"))}, Conditions: []metav1.Condition{{Type: string(gatewayv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}}}
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&httpRoute).Build(), serviceClusterIP: clusterIP}
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+					Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeTrue())
+				})
+
+				It("should leave any Ingress if present if the HTTPRoute is not yet accepted", func() {
+					ingress := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&ingress, &httpRoute).Build(), serviceClusterIP: clusterIP}
+
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
+					Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
+				})
+
+				It("should remove an Ingress if present if the HTTPRoute is accepted", func() {
+					ingress := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					httpRoute.Status.Parents = []gatewayv1.RouteParentStatus{{ControllerName: "gateway.networking.k8s.io/gateway-controller", ParentRef: gatewayv1.ParentReference{Name: "fake-gw", Namespace: ptr.To(gatewayv1.Namespace("fake-gw-ns"))}, Conditions: []metav1.Condition{{Type: string(gatewayv1.RouteConditionAccepted), Status: metav1.ConditionTrue}}}}
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&ingress, &httpRoute).Build(), serviceClusterIP: clusterIP}
+
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(Succeed())
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+					Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeTrue())
+				})
 			})
 		})
 
-		Context("the environment is GUI-less", func() {
-			BeforeEach(func() { environment.GuiEnabled = false })
+		Describe("Ingress creation", func() {
+			Context("Gateway API mode disabled", func() {
+				BeforeEach(func() { reconciler.ExpositionConfig.GatewayAPIMode = false })
 
-			It("skips creating HTTPRoute or Ingress for GUI-less ClassVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassVM
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+				It("should return without creating resources when the environment index is out of range", func() {
+					index = 10
+					ctx = clctx.EnvironmentIndexInto(ctx, index)
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
-			})
+					Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+				})
 
-			It("skips creating HTTPRoute or Ingress for GUI-less LocalVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassLocalVM
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+				It("should not create the Ingress when no Service is available", func() {
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects().Build(), serviceClusterIP: ""}
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
-			})
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+				})
 
-			It("skips creating HTTPRoute or Ingress for GUI-less CloudVMs", func() {
-				environment.EnvironmentType = clv1alpha2.ClassCloudVM
-				ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+				It("should create the Ingress for VMs with a GUI", func() {
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
 
-				err := reconciler.EnforceInstanceExposition(ctx)
-				Expect(err).ToNot(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
+					Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
+					Expect(instance.Status.Environments[index].IP).To(Equal(clusterIP))
+					Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeTrue())
+				})
 
-				Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
-				Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
-				Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+				DescribeTable("should skip creating the Ingress for GUI-less VMs and mark ExpositionAccepted false",
+					func(envType clv1alpha2.EnvironmentType) {
+						environment.EnvironmentType = envType
+						environment.GuiEnabled = false
+						ctx, _ = clctx.EnvironmentInto(ctx, &environment)
+
+						err := reconciler.EnforceInstanceExposition(ctx)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(reconciler.Client.Get(ctx, serviceName, &corev1.Service{})).To(Succeed())
+						Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(HaveOccurred())
+						Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
+					},
+					Entry("ClassVM", clv1alpha2.ClassVM),
+					Entry("ClassCloudVM", clv1alpha2.ClassCloudVM),
+					Entry("ClassLocalVM", clv1alpha2.ClassLocalVM),
+				)
+
+				It("should delete the HTTPRoute if present and create the Ingress", func() {
+					httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
+					reconciler.Client = FakeClientWrapped{Client: clientBuilder.WithObjects(&httpRoute).Build(), serviceClusterIP: clusterIP}
+
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(reconciler.Client.Get(ctx, httpRouteName, &gatewayv1.HTTPRoute{})).To(HaveOccurred())
+					Expect(reconciler.Client.Get(ctx, ingressName, &netv1.Ingress{})).To(Succeed())
+				})
+
+				It("should add authentication annotations when enabled", func() {
+					reconciler.ExpositionConfig.EnableAuthentication = true
+
+					err := reconciler.EnforceInstanceExposition(ctx)
+					Expect(err).ToNot(HaveOccurred())
+
+					ing := netv1.Ingress{}
+					Expect(reconciler.Client.Get(ctx, ingressName, &ing)).To(Succeed())
+					Expect(ing.Annotations).To(HaveKey("nginx.ingress.kubernetes.io/auth-url"))
+					Expect(ing.Annotations).To(HaveKey("nginx.ingress.kubernetes.io/auth-signin"))
+				})
 			})
 		})
 	})
 
-	Context("When instance is not running", func() {
+	When("instance is not running", func() {
 		BeforeEach(func() { instance.Spec.Running = false })
 
-		It("extends Status.Environments and clears IP when index is out of range", func() {
+		It("should extend Status.Environments and clear the IP when the index is out of range", func() {
 			index = 5
 			ctx = clctx.EnvironmentIndexInto(ctx, index)
 
@@ -382,7 +372,7 @@ var _ = Describe("Exposition helpers", func() {
 			Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
 		})
 
-		It("removes Service/Ingress/HTTPRoute if present and clears status", func() {
+		It("should remove the Service, Ingress and HTTPRoute if present and clear status", func() {
 			svc := corev1.Service{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
 			ingress := netv1.Ingress{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
 			httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
@@ -400,7 +390,7 @@ var _ = Describe("Exposition helpers", func() {
 	})
 
 	Context("Failure cases", func() {
-		It("does not error when no resources exist and leaves status untouched", func() {
+		It("should not error when no resources exist and leave status untouched", func() {
 			instance.Spec.Running = false
 
 			err := reconciler.EnforceInstanceExposition(ctx)
@@ -409,7 +399,7 @@ var _ = Describe("Exposition helpers", func() {
 			Expect(instance.Status.Environments[index].IP).To(Equal(""))
 		})
 
-		It("does not error when httpRoute exists but has no status", func() {
+		It("should not error when the HTTPRoute exists but has no status", func() {
 			reconciler.ExpositionConfig.GatewayAPIMode = true
 			instance.Spec.Running = true
 			httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}
@@ -421,7 +411,7 @@ var _ = Describe("Exposition helpers", func() {
 			Expect(instance.Status.Environments[index].ExpositionAccepted).To(BeFalse())
 		})
 
-		It("does not error when getHTTPRouteAcceptedStatus receives HTTPRoute with empty status", func() {
+		It("should not error when getHTTPRouteAcceptedStatus receives an HTTPRoute with empty status", func() {
 			reconciler.ExpositionConfig.GatewayAPIMode = true
 			instance.Spec.Running = true
 			httpRoute := gatewayv1.HTTPRoute{ObjectMeta: forge.ObjectMetaWithSuffix(&instance, environment.Name)}

--- a/qlkube/deploy/qlkube/templates/httproute.yaml
+++ b/qlkube/deploy/qlkube/templates/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "qlkube.fullname" . }}
   labels:
     {{- include "qlkube.labels" . | nindent 4 }}
+    crownlabs.polito.it/public-route: "true"
 spec:
   parentRefs:
     - group: gateway.networking.k8s.io


### PR DESCRIPTION
# Description

This PR migrates Gateway API authentication from legacy NGINX Ingress annotations (`auth-url` and `auth-signin`) to Envoy Gateway's native `SecurityPolicy` resource.

# Key Changes

- **Envoy Gateway support:** Added Envoy Gateway API types and a mock `SecurityPolicy` CRD for `kubebuilder` envtests.
- **Global configuration:** Added the `--gateway-api-auth-service` CLI flag to configure the default authentication endpoint.
- **Controller logic:** The controller parses the `crownlabs.polito.it/auth-service` annotation before creating the `HTTPRoute`. When the annotation is valid, it creates and attaches a `SecurityPolicy`; otherwise, reconciliation stops with an appropriate validation error.

Related to #1143 