### PR TITLE
feat: local-cluster support in qlkube/operators and related fixes

### DIFF
--- a/dev-local/base-k3s/README.md
+++ b/dev-local/base-k3s/README.md
@@ -1,0 +1,76 @@
+# Base k3s cluster
+
+The single-node k3s cluster everything else in `dev-local/` (Keycloak,
+operators) runs on top of. Do this first.
+
+## 1. Install k3s
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+```
+
+## 2. kubeconfig access
+
+k3s writes its kubeconfig to `/etc/rancher/k3s/k3s.yaml`, readable only by
+root. How you get access to it depends on whether this is the only cluster
+you work with on this machine.
+
+### If you don't already have a kubeconfig (or don't care about other clusters)
+
+```bash
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+chmod 600 ~/.kube/config
+export KUBECONFIG=~/.kube/config
+```
+
+### If you already have a kubeconfig with other clusters/contexts
+
+Don't overwrite `~/.kube/config` — merge k3s's kubeconfig into it instead.
+k3s always names its cluster, user and context `default`, which will very
+likely collide with an entry already in your kubeconfig (e.g. Docker
+Desktop, kind, minikube also default to `default`) — a plain merge would
+silently clobber whichever one is listed second. Rename them to something
+unique first, *then* merge:
+
+```bash
+sudo cp /etc/rancher/k3s/k3s.yaml /tmp/k3s.yaml
+sudo chown $(id -u):$(id -g) /tmp/k3s.yaml
+
+# k3s.yaml has exactly one cluster/user/context, all literally named "default" —
+# rename all of them to something unique before merging, anchored to their
+# specific YAML keys so nothing inside the embedded certificate data is touched.
+sed -i \
+  -e 's/^  name: default$/  name: k3s-local/' \
+  -e 's/^- name: default$/- name: k3s-local/' \
+  -e 's/^current-context: default$/current-context: k3s-local/' \
+  -e 's/^    cluster: default$/    cluster: k3s-local/' \
+  -e 's/^    user: default$/    user: k3s-local/' \
+  /tmp/k3s.yaml
+
+KUBECONFIG=~/.kube/config:/tmp/k3s.yaml kubectl config view --flatten > /tmp/merged-config
+mv /tmp/merged-config ~/.kube/config
+chmod 600 ~/.kube/config
+rm /tmp/k3s.yaml
+
+kubectl config use-context k3s-local   # switch to it now, or later with the same command
+export KUBECONFIG=~/.kube/config
+```
+
+Either way, add `export KUBECONFIG=~/.kube/config` to your `.bashrc`/`.zshrc`
+— every `kubectl` command in the rest of `dev-local/` assumes it's set.
+
+## Verify
+
+```bash
+kubectl get nodes
+# expected: your node, Ready
+kubectl config current-context
+# expected: k3s-local (if you merged) or default (if you copied directly)
+```
+
+## Next
+
+- [`../keycloak/README.md`](../keycloak/README.md) — Keycloak, HTTPS, and the k3s apiserver OIDC integration.
+- [`../operators/README.md`](../operators/README.md) — base RBAC and running the CrownLabs operator (needs Keycloak first).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,6 @@
 VITE_APP_CROWNLABS_OIDC_AUTHORITY=https://auth.crownlabs.polito.it/auth/realms/crownlabs
 VITE_APP_CROWNLABS_OIDC_CLIENT_ID=k8s
-VITE_APP_CROWNLABS_GRAPHQL_URL=https://graphql.preprod.crownlabs.polito.it
+VITE_APP_CROWNLABS_GRAPHQL_URL=https://preprod.ng.crownlabs.polito.it/graph
 VITE_APP_MYDRIVE_TEMPLATE_NAME=mydrive
 VITE_APP_MYDRIVE_WORKSPACE_NAME=utilities
 VITE_APP_CROWNLABS_GROUPS_CLAIM_PREFIX=kubernetes

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -1,7 +1,7 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const schemaUrl =
-  (process.env.GRAPHQL_URL || 'https://graphql.ng.crownlabs.polito.it') +
+  (process.env.GRAPHQL_URL || 'https://preprod.ng.crownlabs.polito.it/graph') +
   '/schema';
 
 const config: CodegenConfig = {

--- a/frontend/src/generated-types.tsx
+++ b/frontend/src/generated-types.tsx
@@ -152,7 +152,7 @@ export type EnvironmentListListItem = {
   disableControls?: Maybe<Scalars['Boolean']['output']>;
   /**
    * The type of environment to be instantiated, among VirtualMachine,
-   * Container, CloudVM and Standalone.
+   * Container, CloudVM, LocalVM and Standalone.
    */
   environmentType: EnvironmentType;
   /** Whether the environment is characterized by a graphical desktop or not. */
@@ -193,7 +193,7 @@ export type EnvironmentListListItemInput = {
   disableControls?: InputMaybe<Scalars['Boolean']['input']>;
   /**
    * The type of environment to be instantiated, among VirtualMachine,
-   * Container, CloudVM and Standalone.
+   * Container, CloudVM, LocalVM and Standalone.
    */
   environmentType: EnvironmentType;
   /** Whether the environment is characterized by a graphical desktop or not. */
@@ -258,6 +258,7 @@ export type EnvironmentRefInput = {
 export enum EnvironmentType {
   CloudVm = 'CloudVM',
   Container = 'Container',
+  LocalVm = 'LocalVM',
   Standalone = 'Standalone',
   VirtualMachine = 'VirtualMachine'
 }
@@ -3852,7 +3853,7 @@ export type CreateInstanceMutationVariables = Exact<{
 }>;
 
 
-export type CreateInstanceMutation = { __typename?: 'Mutation', createdInstance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null } | null, status?: { __typename?: 'Status3', ip?: string | null, phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, nodeSelector?: any | null, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null };
+export type CreateInstanceMutation = { __typename?: 'Mutation', createdInstance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null } | null, status?: { __typename?: 'Status3', phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, nodeSelector?: any | null, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null };
 
 export type CreateSharedVolumeMutationVariables = Exact<{
   workspaceNamespace: Scalars['String']['input'];
@@ -3955,14 +3956,14 @@ export type OwnedInstancesQueryVariables = Exact<{
 }>;
 
 
-export type OwnedInstancesQuery = { __typename?: 'Query', instanceList?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceList', instances: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', ip?: string | null, phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, targetPort: number, protocol?: Protocol | null } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType, resources: { __typename?: 'Resources', cpu: number, memory: any, disk?: any | null } } | null> } | null } | null } | null } } | null } | null> } | null };
+export type OwnedInstancesQuery = { __typename?: 'Query', instanceList?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceList', instances: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, targetPort: number, protocol?: Protocol | null } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType, resources: { __typename?: 'Resources', cpu: number, memory: any, disk?: any | null } } | null> } | null } | null } | null } } | null } | null> } | null };
 
 export type InstancesLabelSelectorQueryVariables = Exact<{
   labels?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type InstancesLabelSelectorQuery = { __typename?: 'Query', instanceList?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceList', instances: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', ip?: string | null, phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, targetPort: number, protocol?: Protocol | null } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null> } | null };
+export type InstancesLabelSelectorQuery = { __typename?: 'Query', instanceList?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceList', instances: Array<{ __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, targetPort: number, protocol?: Protocol | null } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null> } | null };
 
 export type NodesLabelsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4025,14 +4026,14 @@ export type UpdatedOwnedInstancesSubscriptionVariables = Exact<{
 }>;
 
 
-export type UpdatedOwnedInstancesSubscription = { __typename?: 'Subscription', updateInstance?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceUpdate', updateType?: UpdateType | null, instance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', ip?: string | null, phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> } | null, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType, resources: { __typename?: 'Resources', cpu: number, memory: any, disk?: any | null } } | null> } | null } | null } | null } } | null } | null } | null };
+export type UpdatedOwnedInstancesSubscription = { __typename?: 'Subscription', updateInstance?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceUpdate', updateType?: UpdateType | null, instance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, labels?: any | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType, resources: { __typename?: 'Resources', cpu: number, memory: any, disk?: any | null } } | null> } | null } | null } | null } } | null } | null } | null };
 
 export type UpdatedInstancesLabelSelectorSubscriptionVariables = Exact<{
   labels?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type UpdatedInstancesLabelSelectorSubscription = { __typename?: 'Subscription', updateInstanceLabelSelector?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceUpdate', updateType?: UpdateType | null, instance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', ip?: string | null, phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null } | null };
+export type UpdatedInstancesLabelSelectorSubscription = { __typename?: 'Subscription', updateInstanceLabelSelector?: { __typename?: 'ItPolitoCrownlabsV1alpha2InstanceUpdate', updateType?: UpdateType | null, instance?: { __typename?: 'ItPolitoCrownlabsV1alpha2Instance', metadata?: { __typename?: 'IoK8sApimachineryPkgApisMetaV1ObjectMeta', name?: string | null, namespace?: string | null, creationTimestamp?: string | null, annotations?: any | null } | null, status?: { __typename?: 'Status3', phase?: Phase2 | null, url?: string | null, nodeName?: string | null, nodeSelector?: any | null, publicExposure?: { __typename?: 'PublicExposure2', externalIP?: string | null, phase?: Phase3 | null, ports?: Array<{ __typename?: 'Ports2ListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> | null } | null, environments?: Array<{ __typename?: 'EnvironmentsListItem', name: string, phase?: Phase | null, ip?: string | null, initialReadyTime?: string | null } | null> | null } | null, spec?: { __typename?: 'Spec3', running?: boolean | null, prettyName?: string | null, publicExposure?: { __typename?: 'PublicExposure', ports: Array<{ __typename?: 'PortsListItem', name: string, port: number, protocol?: Protocol | null, targetPort: number } | null> } | null, tenantCrownlabsPolitoItTenantRef: { __typename?: 'TenantCrownlabsPolitoItTenantRef', name: string, tenantV1alpha2Wrapper?: { __typename?: 'TenantV1alpha2Wrapper', itPolitoCrownlabsV1alpha2Tenant?: { __typename?: 'ItPolitoCrownlabsV1alpha2Tenant', spec?: { __typename?: 'Spec7', firstName: string, lastName: string } | null } | null } | null }, templateCrownlabsPolitoItTemplateRef: { __typename?: 'TemplateCrownlabsPolitoItTemplateRef', name: string, namespace?: string | null, templateWrapper?: { __typename?: 'TemplateWrapper', itPolitoCrownlabsV1alpha2Template?: { __typename?: 'ItPolitoCrownlabsV1alpha2Template', spec?: { __typename?: 'Spec6', prettyName: string, description: string, allowPublicExposure?: boolean | null, cleanup?: { __typename?: 'Cleanup', deleteAfterCreation: string, stopAfterInactivity: string, deleteAfterInactivity: string } | null, environmentList: Array<{ __typename?: 'EnvironmentListListItem', name: string, guiEnabled?: boolean | null, persistent?: boolean | null, environmentType: EnvironmentType } | null> } | null } | null } | null } } | null } | null } | null };
 
 export type UpdatedWorkspaceTemplatesSubscriptionVariables = Exact<{
   workspaceNamespace: Scalars['String']['input'];
@@ -4468,7 +4469,6 @@ export const CreateInstanceDocument = gql`
       labels
     }
     status {
-      ip
       phase
       url
       nodeName
@@ -5039,7 +5039,6 @@ export const OwnedInstancesDocument = gql`
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName
@@ -5164,7 +5163,6 @@ export const InstancesLabelSelectorDocument = gql`
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName
@@ -5797,7 +5795,6 @@ export const UpdatedOwnedInstancesDocument = gql`
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName
@@ -5828,6 +5825,17 @@ export const UpdatedOwnedInstancesDocument = gql`
             port
             protocol
             targetPort
+          }
+        }
+        tenantCrownlabsPolitoItTenantRef {
+          name
+          tenantV1alpha2Wrapper {
+            itPolitoCrownlabsV1alpha2Tenant {
+              spec {
+                firstName
+                lastName
+              }
+            }
           }
         }
         templateCrownlabsPolitoItTemplateRef {
@@ -5902,7 +5910,6 @@ export const UpdatedInstancesLabelSelectorDocument = gql`
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName

--- a/frontend/src/graphql-components/mutation/createInstance.mutation.graphql
+++ b/frontend/src/graphql-components/mutation/createInstance.mutation.graphql
@@ -32,7 +32,6 @@ mutation createInstance(
       labels
     }
     status {
-      ip
       phase
       url
       nodeName

--- a/frontend/src/graphql-components/query/instances.query.graphql
+++ b/frontend/src/graphql-components/query/instances.query.graphql
@@ -12,7 +12,6 @@ query ownedInstances($tenantNamespace: String!) {
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName

--- a/frontend/src/graphql-components/query/instancesLabelSelector.query.graphql
+++ b/frontend/src/graphql-components/query/instancesLabelSelector.query.graphql
@@ -8,7 +8,6 @@ query instancesLabelSelector($labels: String) {
         annotations
       }
       status {
-        ip
         phase
         url
         nodeName

--- a/frontend/src/graphql-components/subscription/instances.subscription.ts
+++ b/frontend/src/graphql-components/subscription/instances.subscription.ts
@@ -19,7 +19,6 @@ export default gql`
           annotations
         }
         status {
-          ip
           phase
           url
           nodeName
@@ -50,6 +49,17 @@ export default gql`
               port
               protocol
               targetPort
+            }
+          }
+          tenantCrownlabsPolitoItTenantRef {
+            name
+            tenantV1alpha2Wrapper {
+              itPolitoCrownlabsV1alpha2Tenant {
+                spec {
+                  firstName
+                  lastName
+                }
+              }
             }
           }
           templateCrownlabsPolitoItTemplateRef {

--- a/frontend/src/graphql-components/subscription/instancesLabelSelector.subscription.ts
+++ b/frontend/src/graphql-components/subscription/instancesLabelSelector.subscription.ts
@@ -14,7 +14,6 @@ export default gql`
           annotations
         }
         status {
-          ip
           phase
           url
           nodeName

--- a/frontend/src/utilsLogic.tsx
+++ b/frontend/src/utilsLogic.tsx
@@ -117,7 +117,7 @@ export const makeGuiTemplate = (
       disk:
         aggregatedResources.diskSum > 0
           ? `${aggregatedResources.diskSum}G`
-          : '',
+          : '0G',
     },
     environmentList: environmentList.map(env => ({
       name: env?.name ?? '',
@@ -141,7 +141,7 @@ export const makeGuiTemplate = (
       resources: {
         cpu: env?.resources?.cpu ?? 0,
         memory: env?.resources?.memory ?? '',
-        disk: env?.resources?.disk ?? '',
+        disk: env?.resources?.disk ?? '0Gi',
         reservedCPUPercentage: env?.resources?.reservedCPUPercentage ?? 50,
       },
     })),
@@ -401,7 +401,7 @@ export const makeGuiInstance = (
     templateName: templateName,
     templateId: makeTemplateKey(templateName, workspaceName),
     environmentType: environmentType || EnvironmentType.CloudVm,
-    ip: primaryStatus?.ip ?? status?.ip ?? '',
+    ip: primaryStatus?.ip ?? '',
     status: safePhase2Conversion(primaryStatus?.phase ?? status?.phase),
     url: status?.url || '',
     timeStamp: metadata?.creationTimestamp || '',

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -13,6 +13,10 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 DOMAIN="crownlabs.polito.it"
+METRICS_ADDR ?= :18080
+HEALTH_PROBE_ADDR ?= :18081
+TENANT_WEBHOOK_PORT ?= :18082
+MYDRIVE_STORAGE_CLASS ?= rook-nfs
 
 .PHONY: all
 all: gen
@@ -122,6 +126,9 @@ run-instance-automation-local: install-local samples-res-local run-instance-auto
 run-operator: generate ## Run the main operator locally
 	go run cmd/operator/*.go\
 				--target-label=crownlabs.polito.it/operator-selector=local\
+				--metrics-addr=$(METRICS_ADDR)\
+				--health-probe-bind-address=$(HEALTH_PROBE_ADDR)\
+				--tenant-webhook-port=$(TENANT_WEBHOOK_PORT)\
 				--keycloak-url=$(KEYCLOAK_URL)\
 				--keycloak-realm=$(KEYCLOAK_REALM)\
 				--keycloak-client-id=$(KEYCLOAK_CLIENT_ID)\
@@ -131,10 +138,24 @@ run-operator: generate ## Run the main operator locally
 				--enable-workspace=true\
 				--enable-instance=true\
 				--enable-sharedvolume=true\
-				--enable-pmp=true\
+				--enable-pmp=false\
 				--enable-keycloak=true\
 				--enable-webhooks=false\
-				--enable-image-list=true
+				--enable-imagelist=true\
+				--mydrive-pvcs-storage-class-name=$(MYDRIVE_STORAGE_CLASS)
+
+# The double target below is used to set Keycloak/storage-class defaults for the
+# dev-local Keycloak setup (see ../dev-local/keycloak/README.md) without touching
+# run-operator's own defaults. KEYCLOAK_CLIENT_SECRET has no default: it is
+# per-realm-install and must still be passed explicitly, e.g.:
+#   make run-operator-local KEYCLOAK_CLIENT_SECRET="$SECRET"
+.PHONY: run-operator-local
+run-operator-local: KEYCLOAK_URL=https://keycloak.crownlabs.local
+run-operator-local: KEYCLOAK_REALM=crownlabs
+run-operator-local: KEYCLOAK_CLIENT_ID=operator-local
+run-operator-local: KEYCLOAK_TARGET_CLIENT=operator-local
+run-operator-local: MYDRIVE_STORAGE_CLASS=local-path
+run-operator-local: install-local samples-res-local run-operator ## Prepare, then run the main operator locally against the dev-local Keycloak (requires KEYCLOAK_CLIENT_SECRET).
 
 .PHONY: install-local
 install-local: manifests ## Install CrownLabs & support CRDs.

--- a/operators/pkg/forge/services.go
+++ b/operators/pkg/forge/services.go
@@ -51,6 +51,12 @@ func ServiceSpec(instance *clv1alpha2.Instance, environment *clv1alpha2.Environm
 		ports = append(ports, serviceSpecTCPPort(GUIPortName, GUIPortNumber))
 	}
 
+	// Kubernetes Services require at least one port. Fall back to the metrics
+	// port for environments (e.g. non-GUI containers) that would otherwise have none.
+	if len(ports) == 0 {
+		ports = append(ports, serviceSpecTCPPort(MetricsPortName, MetricsPortNumber))
+	}
+
 	spec := corev1.ServiceSpec{
 		Type:     corev1.ServiceTypeClusterIP,
 		Selector: EnvironmentSelectorLabels(instance, environment),

--- a/operators/pkg/forge/services_test.go
+++ b/operators/pkg/forge/services_test.go
@@ -124,6 +124,26 @@ var _ = Describe("Services forging", func() {
 					{Name: forge.GUIPortName, Protocol: corev1.ProtocolTCP, Port: forge.GUIPortNumber, TargetPort: intstr.FromInt(forge.GUIPortNumber)},
 				},
 			}),
+			Entry("When the Environment is of type Container, without GUI", ServiceSpecCase{
+				Mutator: func(env *clv1alpha2.Environment) *clv1alpha2.Environment {
+					env.EnvironmentType = clv1alpha2.ClassContainer
+					env.GuiEnabled = false
+					return env
+				},
+				Expected: []corev1.ServicePort{
+					{Name: forge.MetricsPortName, Protocol: corev1.ProtocolTCP, Port: forge.MetricsPortNumber, TargetPort: intstr.FromInt(forge.MetricsPortNumber)},
+				},
+			}),
+			Entry("When the Environment is of type Container, with GUI", ServiceSpecCase{
+				Mutator: func(env *clv1alpha2.Environment) *clv1alpha2.Environment {
+					env.EnvironmentType = clv1alpha2.ClassContainer
+					env.GuiEnabled = true
+					return env
+				},
+				Expected: []corev1.ServicePort{
+					{Name: forge.GUIPortName, Protocol: corev1.ProtocolTCP, Port: forge.GUIPortNumber, TargetPort: intstr.FromInt(forge.GUIPortNumber)},
+				},
+			}),
 		)
 	})
 })

--- a/operators/samples/templates.yaml
+++ b/operators/samples/templates.yaml
@@ -53,7 +53,7 @@ spec:
   prettyName: Dark coffee
   description: Too strong to keep it running for a long time
   environmentList:
-    - name: dark-coffee-1
+    - name: dark-coffee1
       environmentType: Container
       image: registry.crownlabs.example.com/coffee/dark:strongest
       guiEnabled: false
@@ -62,6 +62,7 @@ spec:
       resources:
         cpu: 4
         memory: 1G
+        disk: 1G
         reservedCPUPercentage: 50
   workspace.crownlabs.polito.it/WorkspaceRef:
     name: coffee
@@ -78,9 +79,8 @@ spec:
   prettyName: Visual Studio Code - Python (marketplace disabled)
   description: A template about vscode
   environmentList:
-    - name: vscode-environment
+    - name: vscode-env
       environmentType: Standalone
-      mode: Standard
       mountMyDriveVolume: false
       image: harbor.crownlabs.polito.it/crownlabs-standalone/vscode-python:1.0.5
       containerStartupOptions:
@@ -106,10 +106,9 @@ spec:
   prettyName: vscode c-cpp persistent
   description: A template about vscode
   environmentList:
-    - name: vscode-environment
+    - name: vscode-env
       mountMyDriveVolume: false
       environmentType: Standalone
-      mode: Standard
       image: harbor.crownlabs.polito.it/crownlabs-standalone/vscode-c-cpp:1.0.5
       containerStartupOptions:
         contentPath: /config/workspace
@@ -132,10 +131,9 @@ spec:
   prettyName: jupyterlab
   description: A template about vscode
   environmentList:
-    - name: jupyterlab-environment
+    - name: jupyter-env
       mountMyDriveVolume: false
       environmentType: Standalone
-      mode: Standard
       image: harbor.crownlabs.polito.it/crownlabs-standalone/jupyterlab:1.0.0
       containerStartupOptions:
         contentPath: /home/crownlabs

--- a/operators/samples/tenant.yml
+++ b/operators/samples/tenant.yml
@@ -13,6 +13,8 @@ spec:
       role: user
     - name: coffee
       role: manager
+    - name: standalone
+      role: manager
   publicKeys:
     - type1 key1 comment1
     - type2 key2 comment3

--- a/operators/samples/workspace.yml
+++ b/operators/samples/workspace.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   prettyName: A cup of tea from the queen
   quota:
-    cpu: 8
+    cpu: "8"
     memory: "15Gi"
     instances: 3
 ---
@@ -20,7 +20,7 @@ metadata:
 spec:
   prettyName: Just coffee
   quota:
-    cpu: 10
+    cpu: "10"
     memory: "25Gi"
     instances: 5
 ---
@@ -33,6 +33,19 @@ metadata:
 spec:
   prettyName: A bit spicy
   quota:
-    cpu: 6
+    cpu: "6"
     memory: "20Gi"
     instances: 4
+---
+apiVersion: crownlabs.polito.it/v1alpha1
+kind: Workspace
+metadata:
+  name: standalone
+  labels:
+    crownlabs.polito.it/operator-selector: local
+spec:
+  prettyName: Standalone environments
+  quota:
+    cpu: "8"
+    memory: "15Gi"
+    instances: 3

--- a/qlkube/package.json
+++ b/qlkube/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "IN_CLUSTER=false nodemon --inspect src/index.js",
+    "dev-local-cluster": "IN_CLUSTER=false USE_LOCAL_CLUSTER=true NODE_TLS_REJECT_UNAUTHORIZED=0 nodemon --inspect src/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "check-format-lint": "eslint src",
     "pre-commit": "lint-staged",

--- a/qlkube/src/index.js
+++ b/qlkube/src/index.js
@@ -24,17 +24,35 @@ dotenv.config();
 
 async function main() {
   const inCluster = process.env.IN_CLUSTER !== 'false';
-  logger.info({ inCluster }, 'cluster mode configured');
+  const useLocalCluster = process.env.USE_LOCAL_CLUSTER === 'true';
+  logger.info({ inCluster, useLocalCluster }, 'cluster mode configured');
 
-  const kubeApiUrl = inCluster
-    ? 'https://kubernetes.default.svc'
-    : 'http://localhost:8001';
-  const inClusterToken = inCluster
-    ? await fs.readFile(
+  // When targeting a local cluster directly, bypass `kubectl proxy` (which always
+  // authenticates with its own kubeconfig credentials and ignores the client's
+  // bearer token) and talk straight to the real apiserver, forwarding the token
+  // as-is so the apiserver's own OIDC authenticator can enforce per-user RBAC.
+  let kubeApiUrl;
+  if (inCluster) {
+    kubeApiUrl = 'https://kubernetes.default.svc';
+  } else if (useLocalCluster) {
+    kubeApiUrl = process.env.LOCAL_K8S_API_URL || 'https://localhost:6443';
+  } else {
+    kubeApiUrl = 'http://localhost:8001';
+  }
+
+  // Talking to the real apiserver (useLocalCluster) requires *some* credential even
+  // for the one-off OpenAPI schema discovery call below, unlike `kubectl proxy` which
+  // used its own kubeconfig regardless. This must be a dedicated, minimally-scoped
+  // token (see dev-local/keycloak/apiserver-oidc-integration.md), never the end user's own token.
+  let inClusterToken = '';
+  if (inCluster) {
+    inClusterToken = await fs.readFile(
       '/var/run/secrets/kubernetes.io/serviceaccount/token',
       'utf8',
-    )
-    : '';
+    );
+  } else if (useLocalCluster) {
+    inClusterToken = process.env.LOCAL_K8S_BOOTSTRAP_TOKEN || '';
+  }
   const registryUrl = inCluster ? 'http://cloudimg-registry' : 'http://localhost:8002';
 
   const oas = await getOpenApiSpec(kubeApiUrl, ['openapi/v2'], inClusterToken);

--- a/qlkube/src/subscriptions.js
+++ b/qlkube/src/subscriptions.js
@@ -2,7 +2,7 @@
 // When qlkube is deployed with Helm, it is overwritten by an equivalent
 // one automatically generated from the configuration therein specified.
 
-const subscriptions = [
+const subscriptionsRemote = [
   {
     api: 'apis',
     group: 'crownlabs.polito.it',
@@ -21,4 +21,52 @@ const subscriptions = [
   },
 ];
 
-module.exports = { subscriptions };
+const subscriptionsLocal = [
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha2',
+    resource: 'instances',
+    type: 'itPolitoCrownlabsV1alpha2Instance',
+    listMapping: 'itPolitoCrownlabsV1alpha2InstanceList',
+  },
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha2',
+    resource: 'instancesnapshots',
+    type: 'itPolitoCrownlabsV1alpha2InstanceSnapshot',
+  },
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha2',
+    resource: 'templates',
+    type: 'itPolitoCrownlabsV1alpha2Template',
+  },
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha2',
+    resource: 'tenants',
+    type: 'itPolitoCrownlabsV1alpha2Tenant',
+  },
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha1',
+    resource: 'workspaces',
+    type: 'itPolitoCrownlabsV1alpha1Workspace',
+  },
+  {
+    api: 'apis',
+    group: 'crownlabs.polito.it',
+    version: 'v1alpha1',
+    resource: 'imagelists',
+    type: 'itPolitoCrownlabsV1alpha1ImageList',
+  },
+];
+
+module.exports = {
+  subscriptions: process.env.USE_LOCAL_CLUSTER ? subscriptionsLocal : subscriptionsRemote,
+};

--- a/qlkube/src/wrappers.js
+++ b/qlkube/src/wrappers.js
@@ -2,7 +2,7 @@
 // When qlkube is deployed with Helm, it is overwritten by an equivalent
 // one automatically generated from the configuration therein specified.
 
-const wrappers = [
+const wrappersRemote = [
   {
     type: 'itPolitoCrownlabsV1alpha2Template',
     fieldWrapper: 'TemplateCrownlabsPolitoItTemplateRef',
@@ -12,4 +12,28 @@ const wrappers = [
   },
 ];
 
-module.exports = { wrappers };
+const wrappersLocal = [
+  {
+    type: 'itPolitoCrownlabsV1alpha2Template',
+    fieldWrapper: 'TemplateCrownlabsPolitoItTemplateRef',
+    nameWrapper: 'templateWrapper',
+    queryFieldsRequired: ['name', 'namespace'],
+    parents: ['itPolitoCrownlabsV1alpha2Instance'],
+  },
+  {
+    type: 'itPolitoCrownlabsV1alpha2Tenant',
+    fieldWrapper: 'TenantCrownlabsPolitoItTenantRef',
+    nameWrapper: 'tenantV1alpha2Wrapper',
+    queryFieldsRequired: ['name'],
+    parents: ['itPolitoCrownlabsV1alpha2Instance'],
+  },
+  {
+    type: 'itPolitoCrownlabsV1alpha1Workspace',
+    fieldWrapper: 'WorkspacesListItem',
+    nameWrapper: 'workspaceWrapperTenantV1alpha2',
+    queryFieldsRequired: ['name'],
+    parents: ['itPolitoCrownlabsV1alpha2Tenant'],
+  },
+];
+
+module.exports = { wrappers: process.env.USE_LOCAL_CLUSTER ? wrappersLocal : wrappersRemote };


### PR DESCRIPTION
Squashed from fix-keycloak, everything outside dev-local/ (plus dev-local/base-k3s/, kept here rather than in dev-local-envoy-gateway): qlkube's direct-apiserver USE_LOCAL_CLUSTER mode and wrapper/subscription fixes, operators/Makefile run-operator-local/run-instance-local targets, a guiEnabled Service fix in operators/pkg/forge, and related sample/frontend adjustments needed to exercise all of that locally.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B
