### PR TITLE
feat: local Keycloak + Envoy Gateway dev-local setup

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,7 +1,10 @@
 ignorePatterns:
   - pattern: "^https://.*\\.example\\.com/.*$"
-  # This link often returns http code 429 ("too many requests") when executed from github  
+  # This link often returns http code 429 ("too many requests") when executed from github
   - pattern: "^https://developer.hashicorp.com/packer$"
+  # mailpit.axllent.org returns http code 403 to the linkspector crawler when executed from
+  # github actions (likely bot protection); the site itself is reachable from a real browser
+  - pattern: "^https://mailpit\\.axllent\\.org.*$"
   # ignore https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/README.md because of 503 error in github actions
 # This link has never created troubles; let me try once more before adding to the "ignore" list (Fulvio, Dec 3rd, 2025)
 #  - pattern: "^https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/README.md$"

--- a/dev-local/README.md
+++ b/dev-local/README.md
@@ -1,8 +1,7 @@
 # Local deployment support files
 
-General place for support files/manifests needed to run pieces of CrownLabs'
-infrastructure locally, so they don't get scattered across ad-hoc locations
-or left undocumented in someone's shell history.
+This folder holds the support files and manifests you need to run pieces of the CrownLabs infrastructure locally.
+The goal is to keep everything in one place, instead of scattered across ad-hoc locations or lost in someone's shell history.
 
 ## Structure
 
@@ -11,37 +10,26 @@ dev-local/<system>/manifests/<yaml-files>
 dev-local/<system>/README.md
 ```
 
-Each `<system>` is a self-contained piece of local infrastructure (e.g.
-`keycloak`). Its `README.md` documents prerequisites and how/where/what to
-deploy; its `manifests/` folder holds the plain Kubernetes YAML to
-`kubectl apply`.
+Each `<system>` is a self-contained piece of local infrastructure, for example `keycloak`.
+Its `README.md` file lists the prerequisites and explains how, where, and what to deploy.
+Its `manifests/` folder holds the plain Kubernetes YAML files you apply with `kubectl apply`.
 
-Manifests in here are meant to be applied as-is with `kubectl apply -f`. If
-a resource is already templated in the main `deploy/` Helm chart, prefer
-rendering it on demand from that chart (`helm template -s ...`) instead of
-keeping a hand-maintained, de-templated copy here that can drift from the
-original — see `operators/README.md` step 1 for an example.
+You can apply the manifests in this folder as-is, with `kubectl apply -f`.
+If a resource is already templated in the main `deploy/` Helm chart, render it from that chart instead (`helm template -s ...`).
+Do not keep a hand-maintained, de-templated copy here: it can drift from the original.
+See step 1 in `operators/README.md` for an example.
 
 ## Systems
 
-Set up in this order — each one is a prerequisite of the next:
+Set these up in order. Each one is a prerequisite for the next.
 
-- [`base-k3s/`](base-k3s/README.md) — installing k3s itself and getting
-  `kubectl` access (including how to merge its kubeconfig into one that
-  already has other clusters).
-- [`envoy/`](envoy/README.md) — the single Envoy Gateway (Kubernetes Gateway
-  API) every locally-exposed service is reachable through, at
-  `https://<service>.crownlabs.local`. Do this before `keycloak/`.
-- [`keycloak/`](keycloak/README.md) — local Keycloak (realm import) and the
-  Kubernetes apiserver OIDC integration, exposed via an `HTTPRoute` through
-  `envoy/`.
-- [`operators/`](operators/README.md) — base RBAC and running the CrownLabs
-  operator against the local realm.
-- [`mailpit/`](mailpit/README.md) — fake SMTP + web UI for local email testing,
-  exposed via an `HTTPRoute` through `envoy/` like Keycloak.
+- [`base-k3s/`](base-k3s/README.md): install k3s and get `kubectl` access. This also explains how to merge k3s's kubeconfig into one that already has other clusters.
+- [`envoy/`](envoy/README.md): the single Envoy Gateway (Kubernetes Gateway API) that every locally-exposed service goes through, at `https://<service>.crownlabs.local`. Do this before `keycloak/`.
+- [`keycloak/`](keycloak/README.md): the local Keycloak setup (realm import) and the Kubernetes API server OIDC integration. Keycloak is exposed through an `HTTPRoute` on the Gateway from `envoy/`.
+- [`operators/`](operators/README.md): the base RBAC setup and how to run the CrownLabs operator against the local realm.
+- [`mailpit/`](mailpit/README.md): a fake SMTP server with a web UI, for local email testing. Like Keycloak, it is exposed through an `HTTPRoute` on the Gateway from `envoy/`.
 
 ## Running the full stack
 
-- [`local-development.md`](local-development.md) — end-to-end guide to bring
-  up Keycloak, qlkube, the frontend and the operators locally, once the
-  cluster itself exists.
+See [`local-development.md`](local-development.md) for the end-to-end guide.
+It shows how to bring up Keycloak, qlkube, the frontend, and the operators locally, once the cluster itself exists.

--- a/dev-local/README.md
+++ b/dev-local/README.md
@@ -1,0 +1,47 @@
+# Local deployment support files
+
+General place for support files/manifests needed to run pieces of CrownLabs'
+infrastructure locally, so they don't get scattered across ad-hoc locations
+or left undocumented in someone's shell history.
+
+## Structure
+
+```
+dev-local/<system>/manifests/<yaml-files>
+dev-local/<system>/README.md
+```
+
+Each `<system>` is a self-contained piece of local infrastructure (e.g.
+`keycloak`). Its `README.md` documents prerequisites and how/where/what to
+deploy; its `manifests/` folder holds the plain Kubernetes YAML to
+`kubectl apply`.
+
+Manifests in here are meant to be applied as-is with `kubectl apply -f`. If
+a resource is already templated in the main `deploy/` Helm chart, prefer
+rendering it on demand from that chart (`helm template -s ...`) instead of
+keeping a hand-maintained, de-templated copy here that can drift from the
+original — see `operators/README.md` step 1 for an example.
+
+## Systems
+
+Set up in this order — each one is a prerequisite of the next:
+
+- [`base-k3s/`](base-k3s/README.md) — installing k3s itself and getting
+  `kubectl` access (including how to merge its kubeconfig into one that
+  already has other clusters).
+- [`envoy/`](envoy/README.md) — the single Envoy Gateway (Kubernetes Gateway
+  API) every locally-exposed service is reachable through, at
+  `https://<service>.crownlabs.local`. Do this before `keycloak/`.
+- [`keycloak/`](keycloak/README.md) — local Keycloak (realm import) and the
+  Kubernetes apiserver OIDC integration, exposed via an `HTTPRoute` through
+  `envoy/`.
+- [`operators/`](operators/README.md) — base RBAC and running the CrownLabs
+  operator against the local realm.
+- [`mailpit/`](mailpit/README.md) — fake SMTP + web UI for local email testing,
+  exposed via an `HTTPRoute` through `envoy/` like Keycloak.
+
+## Running the full stack
+
+- [`local-development.md`](local-development.md) — end-to-end guide to bring
+  up Keycloak, qlkube, the frontend and the operators locally, once the
+  cluster itself exists.

--- a/dev-local/envoy/README.md
+++ b/dev-local/envoy/README.md
@@ -1,21 +1,24 @@
 # Envoy Gateway — single ingress point for dev-local
 
-A single [Envoy Gateway](https://gateway.envoyproxy.io/) (Kubernetes Gateway API)
-fronting every locally-exposed dev-local service under one local domain
-(`*.crownlabs.local`), replacing the old per-service `NodePort` pattern (used by
-Keycloak until now). Do this **before** [`../keycloak/README.md`](../keycloak/README.md)
-— Keycloak's manifest now includes an `HTTPRoute` that depends on the `Gateway`
-created here.
+This guide sets up a single [Envoy Gateway](https://gateway.envoyproxy.io/) (Kubernetes Gateway API) in front of every locally-exposed dev-local service.
+Every service becomes reachable under one local domain, `*.crownlabs.local`.
+This replaces the old `NodePort` pattern, which needed a separate port for each service.
 
-TLS terminates here, at the Gateway edge, with one self-signed wildcard
-certificate. Every backend behind it (Keycloak, [Mailpit](../mailpit/README.md))
-is reached over plain HTTP internally — nothing else needs its own
-certificate or HTTPS listener.
+Set up the Gateway before you set up Keycloak.
+See [`../keycloak/README.md`](../keycloak/README.md) for the Keycloak setup.
+Keycloak's manifest defines an `HTTPRoute` object.
+That `HTTPRoute` needs the `Gateway` you create in this guide, so the Gateway must exist first.
+
+TLS terminates at the Gateway, using one self-signed wildcard certificate.
+Every backend behind the Gateway, such as Keycloak and [Mailpit](../mailpit/README.md), is reached over plain HTTP internally.
+No other component needs its own certificate or HTTPS listener.
 
 ## 0. Prerequisites
 
-- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
-- cert-manager, for the wildcard certificate below:
+To run the Envoy Gateway, you need the following components:
+
+- The base k3s cluster. See [`../base-k3s/README.md`](../base-k3s/README.md).
+- cert-manager, which issues the wildcard certificate used below:
   ```bash
   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
   kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
@@ -23,17 +26,15 @@ certificate or HTTPS listener.
 
 ## 1. Disable k3s's bundled Traefik
 
-k3s ships Traefik as its default ingress controller, with its own `LoadBalancer`
-`Service` bound to the node's 80/443 via k3s's `ServiceLB` (`svclb-traefik`). Envoy
-Gateway's own `Service` needs those same ports, so Traefik has to go first — this repo
-uses Envoy Gateway instead of Traefik's own (more limited) Gateway API support.
+Traefik is k3s's default ingress controller.
+It runs its own `LoadBalancer` `Service`, bound to the node's ports 80 and 443 through k3s's `ServiceLB` (the `svclb-traefik` pod).
+The Envoy Gateway's own `Service` needs those same ports, so you must remove Traefik first.
+This project uses Envoy Gateway instead of Traefik's built-in Gateway API support, because Envoy Gateway supports more features.
 
-Add a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/` (requires
-root) — k3s merges every `*.yaml` there into its config automatically, in
-alphabetical order, so this doesn't touch whatever
-[`../base-k3s/README.md`](../base-k3s/README.md) or
-[`../keycloak/apiserver-oidc-integration.md`](../keycloak/apiserver-oidc-integration.md)
-already put there, and vice versa — no shared file to merge into by hand:
+To disable Traefik, add a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/` (this requires root access).
+k3s automatically merges every `*.yaml` file in that folder into its configuration, in alphabetical order.
+This means your new file will not touch anything that [`../base-k3s/README.md`](../base-k3s/README.md) or [`../keycloak/apiserver-oidc-integration.md`](../keycloak/apiserver-oidc-integration.md) already added there, and vice versa.
+There is no single shared file to edit by hand.
 
 ```bash
 sudo mkdir -p /etc/rancher/k3s/config.yaml.d
@@ -45,57 +46,52 @@ EOF
 
 ```bash
 sudo systemctl restart k3s
-journalctl -u k3s -f   # confirm no errors, then Ctrl+C
-kubectl get nodes      # expected: Ready
+journalctl -u k3s -f   # Confirm there are no errors, then press Ctrl+C.
+kubectl get nodes      # Expected: the node is Ready.
 ```
 
-**This restarts the whole control plane** — same caveat as the apiserver OIDC step:
-briefly unreachable, and any open `kubectl proxy`/`port-forward`/operator connection
-needs restarting afterwards.
+Restarting k3s restarts the whole control plane.
+This is the same caveat as the API server OIDC step: the cluster is briefly unreachable, and you need to restart any open `kubectl proxy`, `port-forward`, or operator connection afterwards.
 
 Confirm Traefik is gone:
 
 ```bash
 kubectl get pods -n kube-system | grep -i traefik
-# expected: no traefik/svclb-traefik pods (only the completed helm-install-traefik*
-# jobs may still be listed — harmless, they're one-shot Jobs, not live components)
+# Expected: no traefik or svclb-traefik pods.
+# The completed helm-install-traefik* jobs may still be listed: this is harmless, since they are one-shot Jobs, not live components.
 ```
 
-If disabling `traefik` on an already-running cluster doesn't clean up the leftover
-`traefik`/`svclb-traefik` Deployment/DaemonSet on your k3s version, remove them
-directly (this does **not** touch the Gateway API CRDs — those come from the separate
-`traefik-crd` HelmChart, which `--disable=traefik` does not affect, and which Envoy
-Gateway's own CRDs coexist with/upgrade in step 2 below):
+If disabling `traefik` on an already-running cluster does not clean up the leftover `traefik` or `svclb-traefik` Deployment/DaemonSet on your k3s version, remove them directly:
 
 ```bash
 kubectl delete deployment traefik -n kube-system
 kubectl delete svc traefik -n kube-system
 ```
 
-## 2. Install the Gateway API CRDs + Envoy Gateway controller
+This does **not** touch the Gateway API CRDs.
+Those CRDs come from a separate `traefik-crd` Helm chart, which `--disable=traefik` does not affect.
+Envoy Gateway's own CRDs coexist with, and upgrade, that chart's CRDs in step 2 below.
 
-Pin an explicit release (not `latest`) — the `latest` *tag* for the install manifest and
-the `latest` *image* tag can drift out of sync with each other (tested: this produced a
-controller crash — `no matches for kind "ListenerSet" in version
-"gateway.networking.k8s.io/v1"` — because the CRD bundle was older than what the
-controller image expected):
+## 2. Install the Gateway API CRDs and the Envoy Gateway controller
+
+Always pin an explicit release, and never use `latest`.
+The `latest` *tag* for the install manifest and the `latest` *image* tag can drift out of sync with each other.
+We tested this: it produced a controller crash, with the error `no matches for kind "ListenerSet" in version "gateway.networking.k8s.io/v1"`, because the CRD bundle was older than what the controller image expected.
 
 ```bash
 kubectl apply --server-side --force-conflicts -f https://github.com/envoyproxy/gateway/releases/download/v1.8.2/install.yaml
 kubectl wait --timeout=120s -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
 ```
 
-`--force-conflicts` is required here: k3s's bundled `traefik-crd` chart already installs
-the core Gateway API CRDs (`GatewayClass`/`Gateway`/`HTTPRoute`/...) at an older schema
-version, field-managed by `helm`; this takes over that field ownership so Envoy Gateway
-can upgrade them. Safe to do even before Traefik itself is disabled — Helm never deletes
-CRDs on chart uninstall, so this doesn't put those CRDs at risk once `traefik-crd`'s
-release (if ever) goes away.
+The `--force-conflicts` flag is required here.
+k3s's bundled `traefik-crd` chart already installs the core Gateway API CRDs (`GatewayClass`, `Gateway`, `HTTPRoute`, and others) at an older schema version, managed by `helm`.
+This flag lets Envoy Gateway take over that field ownership, so it can upgrade the CRDs.
+It is safe to run this command even before you disable Traefik itself, because Helm never deletes CRDs when you uninstall a chart.
+This means the CRDs stay safe even after the `traefik-crd` release eventually goes away.
 
-> If you hit `The CustomResourceDefinition "backendtlspolicies.gateway.networking.k8s.io"
-> is invalid: status.storedVersions[0]: ... must remain in spec.versions` — confirm no
-> `BackendTLSPolicy` objects exist yet (`kubectl get backendtlspolicies -A`, expected:
-> none on a fresh install) and delete just that CRD before re-running the command above:
+> If you hit the error `The CustomResourceDefinition "backendtlspolicies.gateway.networking.k8s.io" is invalid: status.storedVersions[0]: ... must remain in spec.versions`, please do the following:
+> 1) Confirm no `BackendTLSPolicy` objects exist yet (`kubectl get backendtlspolicies -A`, expected: none on a fresh install);
+> 2) Delete just that CRD before re-running the command above:
 > `kubectl delete crd backendtlspolicies.gateway.networking.k8s.io`.
 
 ## 3. Apply the shared Gateway
@@ -106,35 +102,31 @@ kubectl wait --for=condition=Ready certificate/crownlabs-tls -n default --timeou
 ```
 
 This applies:
-- `ClusterIssuer selfsigned` + `Certificate crownlabs-tls` — the wildcard cert
-  (`*.crownlabs.local`), cert-manager-issued, in the `crownlabs-tls` Secret.
-- `GatewayClass envoy-gateway` and `Gateway crownlabs` (namespace `default`) — one HTTPS
-  listener (443, terminates TLS with the cert above) and one HTTP listener (80, redirect
-  only).
-- `HTTPRoute http-to-https-redirect` — any plain-HTTP request to `*.crownlabs.local`
-  gets a 301 to HTTPS.
+- `ClusterIssuer selfsigned` and `Certificate crownlabs-tls`: the wildcard certificate (`*.crownlabs.local`), issued by cert-manager and stored in the `crownlabs-tls` Secret.
+- `GatewayClass envoy-gateway` and `Gateway crownlabs` (in the `default` namespace): one HTTPS listener on port 443, which terminates TLS with the certificate above, and one HTTP listener on port 80, used only for redirects.
+- `HTTPRoute http-to-https-redirect`: any plain HTTP request to `*.crownlabs.local` gets a 301 redirect to HTTPS.
 
-Envoy Gateway auto-creates the actual `LoadBalancer` `Service` backing this `Gateway`,
-under `envoy-gateway-system`, with an auto-generated name. Find it:
+Envoy Gateway automatically creates the actual `LoadBalancer` `Service` that backs this `Gateway`, under the `envoy-gateway-system` namespace, with an auto-generated name.
+To find it:
 
 ```bash
 kubectl get svc -n envoy-gateway-system
-# look for the LoadBalancer-type Service, e.g. envoy-default-crownlabs-<hash>
+# Look for the LoadBalancer-type Service, for example envoy-default-crownlabs-<hash>.
 ```
 
-Once Traefik is disabled (step 1) and its DaemonSet has released 80/443, k3s's
-`ServiceLB` assigns those same ports to this Service — confirm:
+Once Traefik is disabled (step 1) and its DaemonSet has released ports 80 and 443, k3s's `ServiceLB` assigns those same ports to this Service.
+You can verify with the following command:
 
 ```bash
 kubectl get gateway crownlabs -n default
-# expected: PROGRAMMED = True (it's False / "AddressNotAssigned" until Traefik is
-# actually gone and 80/443 are free)
+# Expected: PROGRAMMED = True.
+# It stays False, with reason "AddressNotAssigned", until Traefik is actually gone and ports 80/443 are free.
 ```
 
 ## 4. `/etc/hosts`
 
-One line per hostname routed through the Gateway, pointing at `127.0.0.1` (this is a
-single-node cluster, so the node *is* `127.0.0.1`):
+Add one line per hostname routed through the Gateway, pointing at `127.0.0.1`.
+This is a single-node cluster, so the node itself *is* `127.0.0.1`.
 
 ```bash
 echo "127.0.0.1 keycloak.crownlabs.local" | sudo tee -a /etc/hosts
@@ -144,61 +136,57 @@ echo "127.0.0.1 keycloak.crownlabs.local" | sudo tee -a /etc/hosts
 echo "127.0.0.1 mail.crownlabs.local" | sudo tee -a /etc/hosts
 ```
 
-> **On WSL2, this alone is not enough for the browser.** The command above only
-> edits the *Linux/WSL2-side* `/etc/hosts` — it's what lets processes running
-> inside WSL2 itself (the apiserver, `curl`, the operator) resolve the hostname.
-> The browser runs on **Windows**, which resolves hostnames using its own,
-> separate hosts file — tested and confirmed: without this, the browser fails
-> with `DNS_PROBE_FINISHED_NXDOMAIN`, not a certificate warning, since it never
-> even gets far enough to open a connection. Add the same line there too, from
-> an **elevated** PowerShell (plain Notepad-as-administrator can silently fail
-> here — Windows' File/Registry Virtualization redirects the save to a
-> per-user shadow copy with no error if the elevation didn't actually take,
-> so the edit looks successful but the real file is untouched):
+Please note that the changes to the local `/etc/hosts` file only take effect when you connect to the cluster from the same host.
+If a second machine also connects to the k3s cluster, you need to update the `/etc/hosts` file on that machine too, replacing `127.0.0.1` with the actual IP address of the k3s host.
+
+> **On WSL2, editing `/etc/hosts` alone is not enough for the browser.**
+> The command above only edits the *Linux/WSL2-side* `/etc/hosts` file.
+> This lets processes running inside WSL2 itself (the API server, `curl`, the operator) resolve the hostname.
+> The browser, however, runs on **Windows**, and Windows resolves hostnames using its own, separate hosts file.
+> We tested this: without updating the Windows hosts file, the browser fails with `DNS_PROBE_FINISHED_NXDOMAIN`, not a certificate warning, because the connection never even opens.
+> Add the same line to the Windows hosts file too, from an **elevated** PowerShell window.
+> Plain Notepad-as-administrator can silently fail here: if the elevation did not actually take effect, Windows' File/Registry Virtualization redirects the save to a per-user shadow copy, with no error message. The edit then looks successful, but the real file stays untouched.
 > ```powershell
 > Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 keycloak.crownlabs.local"
 > ```
-> Verify it actually landed (`Get-Content C:\Windows\System32\drivers\etc\hosts
-> | Select-String crownlabs`), then `ipconfig /flushdns` and `ping
-> keycloak.crownlabs.local` (expect a reply from `127.0.0.1`) before retrying
-> the browser.
+> Verify the change actually landed:
+> ```powershell
+> Get-Content C:\Windows\System32\drivers\etc\hosts | Select-String crownlabs
+> ```
+> Then run `ipconfig /flushdns` and `ping keycloak.crownlabs.local` (expect a reply from `127.0.0.1`) before you retry the browser.
 
 ## 5. On WSL2: bridge the Gateway
 
-Same underlying limitation already documented for Keycloak's old NodePort (tested and
-confirmed on both `networkingMode`s): a `LoadBalancer` Service backed by k3s's
-`ServiceLB` has no *real* listening socket on 80/443 — it's iptables DNAT — so Windows'
-`localhostForwarding` has nothing to relay, and the browser gets
-`ERR_CONNECTION_REFUSED`. The fix is the same pattern as before, but now there's only
-**one** bridge to keep open, covering every hostname behind the Gateway instead of one
-per service:
+On WSL2, the browser on Windows cannot reach the Gateway's ports directly, for the same reason described earlier for Keycloak's old NodePort setup.
+A `LoadBalancer` Service backed by k3s's `ServiceLB` does not open a real listening socket on ports 80 and 443.
+Instead, it uses `iptables` rules to redirect traffic (DNAT).
+Windows' `localhostForwarding` feature only relays real listening sockets, so it has nothing to forward here, and the browser fails with `ERR_CONNECTION_REFUSED`.
+
+The fix follows the same pattern used before, but now you only need **one** bridge, covering every hostname behind the Gateway instead of one bridge per service:
 
 ```bash
 kubectl port-forward -n envoy-gateway-system svc/<gateway-service-name> 8443:443
 ```
 
-(substitute the Service name found in step 3). From here on, **every hostname in this
-guide needs `:8443` appended on WSL2** (`https://keycloak.crownlabs.local:8443`, etc.) —
-same reasoning as the old `:18543` bridge: reusing port 443 itself gets hijacked by
-kube-proxy's own iptables rules for that port and times out.
+Replace `<gateway-service-name>` with the Service name you found in step 3.
+From here on, **append `:8443` to every hostname in this guide when you use WSL2** (for example, `https://keycloak.crownlabs.local:8443`).
+This is the same reasoning as the old `:18543` bridge: if you try to reuse port 443 itself, kube-proxy's own `iptables` rules for that port hijack the connection, and it times out.
 
 ## Final checks
 
 ```bash
 curl -sk -o /dev/null -w "%{http_code}\n" https://keycloak.crownlabs.local/realms/crownlabs
-# WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
-# expected: 200, once ../keycloak/README.md's manifests are applied
+# On WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
+# Expected: 200, once you apply the manifests from ../keycloak/README.md.
 ```
 
 Expected end state:
-- ✅ Traefik disabled, Gateway API CRDs upgraded, Envoy Gateway controller running.
-- ✅ `Gateway crownlabs` `PROGRAMMED = True`.
+- ✅ Traefik is disabled, the Gateway API CRDs are upgraded, and the Envoy Gateway controller is running.
+- ✅ `Gateway crownlabs` shows `PROGRAMMED = True`.
 - ✅ `/etc/hosts` has an entry for every hostname you use.
-- ✅ (WSL2 only) one `kubectl port-forward` bridge open.
+- ✅ (WSL2 only) one `kubectl port-forward` bridge is open.
 
 ## Next
 
-- [`../keycloak/README.md`](../keycloak/README.md) — Keycloak, now reachable at
-  `https://keycloak.crownlabs.local` via the `HTTPRoute` in its own manifest.
-- [`../mailpit/README.md`](../mailpit/README.md) — fake SMTP + web UI, reachable at
-  `https://mail.crownlabs.local` the same way.
+- [`../keycloak/README.md`](../keycloak/README.md): set up Keycloak, now reachable at `https://keycloak.crownlabs.local` through the `HTTPRoute` in its own manifest.
+- [`../mailpit/README.md`](../mailpit/README.md): set up the fake SMTP server and web UI, reachable at `https://mail.crownlabs.local` the same way.

--- a/dev-local/envoy/README.md
+++ b/dev-local/envoy/README.md
@@ -28,7 +28,7 @@ To run the Envoy Gateway, you need the following components:
 
 Traefik is k3s's default ingress controller.
 It runs its own `LoadBalancer` `Service`, bound to the node's ports 80 and 443 through k3s's `ServiceLB` (the `svclb-traefik` pod).
-The Envoy Gateway's own `Service` needs those same ports, so you must remove Traefik first.
+The Envoy Gateway's own `Service` needs the same ports, so Traefik has to be removed.
 This project uses Envoy Gateway instead of Traefik's built-in Gateway API support, because Envoy Gateway supports more features.
 
 To disable Traefik, add a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/` (this requires root access).

--- a/dev-local/envoy/README.md
+++ b/dev-local/envoy/README.md
@@ -1,0 +1,204 @@
+# Envoy Gateway — single ingress point for dev-local
+
+A single [Envoy Gateway](https://gateway.envoyproxy.io/) (Kubernetes Gateway API)
+fronting every locally-exposed dev-local service under one local domain
+(`*.crownlabs.local`), replacing the old per-service `NodePort` pattern (used by
+Keycloak until now). Do this **before** [`../keycloak/README.md`](../keycloak/README.md)
+— Keycloak's manifest now includes an `HTTPRoute` that depends on the `Gateway`
+created here.
+
+TLS terminates here, at the Gateway edge, with one self-signed wildcard
+certificate. Every backend behind it (Keycloak, [Mailpit](../mailpit/README.md))
+is reached over plain HTTP internally — nothing else needs its own
+certificate or HTTPS listener.
+
+## 0. Prerequisites
+
+- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
+- cert-manager, for the wildcard certificate below:
+  ```bash
+  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
+  kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
+  ```
+
+## 1. Disable k3s's bundled Traefik
+
+k3s ships Traefik as its default ingress controller, with its own `LoadBalancer`
+`Service` bound to the node's 80/443 via k3s's `ServiceLB` (`svclb-traefik`). Envoy
+Gateway's own `Service` needs those same ports, so Traefik has to go first — this repo
+uses Envoy Gateway instead of Traefik's own (more limited) Gateway API support.
+
+Add a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/` (requires
+root) — k3s merges every `*.yaml` there into its config automatically, in
+alphabetical order, so this doesn't touch whatever
+[`../base-k3s/README.md`](../base-k3s/README.md) or
+[`../keycloak/apiserver-oidc-integration.md`](../keycloak/apiserver-oidc-integration.md)
+already put there, and vice versa — no shared file to merge into by hand:
+
+```bash
+sudo mkdir -p /etc/rancher/k3s/config.yaml.d
+sudo tee /etc/rancher/k3s/config.yaml.d/20-disable-traefik.yaml > /dev/null <<'EOF'
+disable:
+  - traefik
+EOF
+```
+
+```bash
+sudo systemctl restart k3s
+journalctl -u k3s -f   # confirm no errors, then Ctrl+C
+kubectl get nodes      # expected: Ready
+```
+
+**This restarts the whole control plane** — same caveat as the apiserver OIDC step:
+briefly unreachable, and any open `kubectl proxy`/`port-forward`/operator connection
+needs restarting afterwards.
+
+Confirm Traefik is gone:
+
+```bash
+kubectl get pods -n kube-system | grep -i traefik
+# expected: no traefik/svclb-traefik pods (only the completed helm-install-traefik*
+# jobs may still be listed — harmless, they're one-shot Jobs, not live components)
+```
+
+If disabling `traefik` on an already-running cluster doesn't clean up the leftover
+`traefik`/`svclb-traefik` Deployment/DaemonSet on your k3s version, remove them
+directly (this does **not** touch the Gateway API CRDs — those come from the separate
+`traefik-crd` HelmChart, which `--disable=traefik` does not affect, and which Envoy
+Gateway's own CRDs coexist with/upgrade in step 2 below):
+
+```bash
+kubectl delete deployment traefik -n kube-system
+kubectl delete svc traefik -n kube-system
+```
+
+## 2. Install the Gateway API CRDs + Envoy Gateway controller
+
+Pin an explicit release (not `latest`) — the `latest` *tag* for the install manifest and
+the `latest` *image* tag can drift out of sync with each other (tested: this produced a
+controller crash — `no matches for kind "ListenerSet" in version
+"gateway.networking.k8s.io/v1"` — because the CRD bundle was older than what the
+controller image expected):
+
+```bash
+kubectl apply --server-side --force-conflicts -f https://github.com/envoyproxy/gateway/releases/download/v1.8.2/install.yaml
+kubectl wait --timeout=120s -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+```
+
+`--force-conflicts` is required here: k3s's bundled `traefik-crd` chart already installs
+the core Gateway API CRDs (`GatewayClass`/`Gateway`/`HTTPRoute`/...) at an older schema
+version, field-managed by `helm`; this takes over that field ownership so Envoy Gateway
+can upgrade them. Safe to do even before Traefik itself is disabled — Helm never deletes
+CRDs on chart uninstall, so this doesn't put those CRDs at risk once `traefik-crd`'s
+release (if ever) goes away.
+
+> If you hit `The CustomResourceDefinition "backendtlspolicies.gateway.networking.k8s.io"
+> is invalid: status.storedVersions[0]: ... must remain in spec.versions` — confirm no
+> `BackendTLSPolicy` objects exist yet (`kubectl get backendtlspolicies -A`, expected:
+> none on a fresh install) and delete just that CRD before re-running the command above:
+> `kubectl delete crd backendtlspolicies.gateway.networking.k8s.io`.
+
+## 3. Apply the shared Gateway
+
+```bash
+kubectl apply -f dev-local/envoy/manifests
+kubectl wait --for=condition=Ready certificate/crownlabs-tls -n default --timeout=30s
+```
+
+This applies:
+- `ClusterIssuer selfsigned` + `Certificate crownlabs-tls` — the wildcard cert
+  (`*.crownlabs.local`), cert-manager-issued, in the `crownlabs-tls` Secret.
+- `GatewayClass envoy-gateway` and `Gateway crownlabs` (namespace `default`) — one HTTPS
+  listener (443, terminates TLS with the cert above) and one HTTP listener (80, redirect
+  only).
+- `HTTPRoute http-to-https-redirect` — any plain-HTTP request to `*.crownlabs.local`
+  gets a 301 to HTTPS.
+
+Envoy Gateway auto-creates the actual `LoadBalancer` `Service` backing this `Gateway`,
+under `envoy-gateway-system`, with an auto-generated name. Find it:
+
+```bash
+kubectl get svc -n envoy-gateway-system
+# look for the LoadBalancer-type Service, e.g. envoy-default-crownlabs-<hash>
+```
+
+Once Traefik is disabled (step 1) and its DaemonSet has released 80/443, k3s's
+`ServiceLB` assigns those same ports to this Service — confirm:
+
+```bash
+kubectl get gateway crownlabs -n default
+# expected: PROGRAMMED = True (it's False / "AddressNotAssigned" until Traefik is
+# actually gone and 80/443 are free)
+```
+
+## 4. `/etc/hosts`
+
+One line per hostname routed through the Gateway, pointing at `127.0.0.1` (this is a
+single-node cluster, so the node *is* `127.0.0.1`):
+
+```bash
+echo "127.0.0.1 keycloak.crownlabs.local" | sudo tee -a /etc/hosts
+```
+
+```bash
+echo "127.0.0.1 mail.crownlabs.local" | sudo tee -a /etc/hosts
+```
+
+> **On WSL2, this alone is not enough for the browser.** The command above only
+> edits the *Linux/WSL2-side* `/etc/hosts` — it's what lets processes running
+> inside WSL2 itself (the apiserver, `curl`, the operator) resolve the hostname.
+> The browser runs on **Windows**, which resolves hostnames using its own,
+> separate hosts file — tested and confirmed: without this, the browser fails
+> with `DNS_PROBE_FINISHED_NXDOMAIN`, not a certificate warning, since it never
+> even gets far enough to open a connection. Add the same line there too, from
+> an **elevated** PowerShell (plain Notepad-as-administrator can silently fail
+> here — Windows' File/Registry Virtualization redirects the save to a
+> per-user shadow copy with no error if the elevation didn't actually take,
+> so the edit looks successful but the real file is untouched):
+> ```powershell
+> Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 keycloak.crownlabs.local"
+> ```
+> Verify it actually landed (`Get-Content C:\Windows\System32\drivers\etc\hosts
+> | Select-String crownlabs`), then `ipconfig /flushdns` and `ping
+> keycloak.crownlabs.local` (expect a reply from `127.0.0.1`) before retrying
+> the browser.
+
+## 5. On WSL2: bridge the Gateway
+
+Same underlying limitation already documented for Keycloak's old NodePort (tested and
+confirmed on both `networkingMode`s): a `LoadBalancer` Service backed by k3s's
+`ServiceLB` has no *real* listening socket on 80/443 — it's iptables DNAT — so Windows'
+`localhostForwarding` has nothing to relay, and the browser gets
+`ERR_CONNECTION_REFUSED`. The fix is the same pattern as before, but now there's only
+**one** bridge to keep open, covering every hostname behind the Gateway instead of one
+per service:
+
+```bash
+kubectl port-forward -n envoy-gateway-system svc/<gateway-service-name> 8443:443
+```
+
+(substitute the Service name found in step 3). From here on, **every hostname in this
+guide needs `:8443` appended on WSL2** (`https://keycloak.crownlabs.local:8443`, etc.) —
+same reasoning as the old `:18543` bridge: reusing port 443 itself gets hijacked by
+kube-proxy's own iptables rules for that port and times out.
+
+## Final checks
+
+```bash
+curl -sk -o /dev/null -w "%{http_code}\n" https://keycloak.crownlabs.local/realms/crownlabs
+# WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
+# expected: 200, once ../keycloak/README.md's manifests are applied
+```
+
+Expected end state:
+- ✅ Traefik disabled, Gateway API CRDs upgraded, Envoy Gateway controller running.
+- ✅ `Gateway crownlabs` `PROGRAMMED = True`.
+- ✅ `/etc/hosts` has an entry for every hostname you use.
+- ✅ (WSL2 only) one `kubectl port-forward` bridge open.
+
+## Next
+
+- [`../keycloak/README.md`](../keycloak/README.md) — Keycloak, now reachable at
+  `https://keycloak.crownlabs.local` via the `HTTPRoute` in its own manifest.
+- [`../mailpit/README.md`](../mailpit/README.md) — fake SMTP + web UI, reachable at
+  `https://mail.crownlabs.local` the same way.

--- a/dev-local/envoy/manifests/gateway.yaml
+++ b/dev-local/envoy/manifests/gateway.yaml
@@ -1,0 +1,96 @@
+# Single ingress point for every locally-exposed dev-local service (Keycloak now,
+# Mailpit later — see ../../mailpit/README.md), replacing the old per-service
+# NodePort pattern with one Envoy Gateway fronting everything under one local
+# domain (*.crownlabs.local).
+#
+# Requires:
+# - cert-manager installed (see ../README.md step 0) — provides the wildcard
+#   certificate below.
+# - The Gateway API CRDs + Envoy Gateway controller installed first (../README.md
+#   steps 1-2) — this file only contains the GatewayClass/Gateway/Certificate/
+#   redirect, not the controller itself.
+#
+# TLS terminates here, at the Gateway edge — backends (Keycloak, later Mailpit)
+# are plain HTTP behind it. This is what let Keycloak's own manifest drop its
+# self-managed HTTPS certificate/probes entirely (see ../../keycloak/manifests/keycloak.yaml).
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: crownlabs-tls
+  namespace: default
+  labels:
+    app: envoy-gateway
+spec:
+  secretName: crownlabs-tls
+  commonName: "*.crownlabs.local"
+  dnsNames:
+    - "*.crownlabs.local"
+    - "crownlabs.local"
+  # Local dev only: a long duration avoids the local copies of the CA (k3s
+  # --oidc-ca-file, the operator's SSL_CERT_FILE) going stale on renewal —
+  # see ../../keycloak/apiserver-oidc-integration.md.
+  duration: 87600h0m0s
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-gateway
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: crownlabs
+  namespace: default
+spec:
+  gatewayClassName: envoy-gateway
+  listeners:
+    # Plain HTTP exists only to serve the redirect below — every real route is HTTPS.
+    - name: http
+      protocol: HTTP
+      port: 80
+      hostname: "*.crownlabs.local"
+      allowedRoutes:
+        namespaces:
+          from: Same
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.crownlabs.local"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: crownlabs-tls
+      allowedRoutes:
+        namespaces:
+          from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-to-https-redirect
+  namespace: default
+spec:
+  parentRefs:
+    - name: crownlabs
+      sectionName: http
+  hostnames:
+    - "*.crownlabs.local"
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/dev-local/keycloak/README.md
+++ b/dev-local/keycloak/README.md
@@ -1,0 +1,190 @@
+# Local Keycloak + OIDC — end-to-end setup
+
+Everything needed to bring up Keycloak (realm, clients, scopes, base users) and the
+Kubernetes apiserver validating Keycloak-issued tokens (instead of every local request
+silently running as cluster-admin under `kubectl proxy`), on top of an already-existing
+k3s cluster with [Envoy Gateway](../envoy/README.md) set up.
+
+- [`manifests/`](manifests/) — applied with a single
+  `kubectl apply -f dev-local/keycloak/manifests`: Keycloak + Postgres, its `HTTPRoute`,
+  the realm import, and the `mydrive-pvcs` namespace.
+- [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) — the
+  rationale, verification steps and troubleshooting table behind the OIDC
+  setup below. Read it if something in this guide doesn't behave as
+  expected; this README only has the commands.
+
+## 0. Prerequisites
+
+- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md) set up (Gateway API CRDs, the controller, the
+  shared `crownlabs` Gateway, the `*.crownlabs.local` wildcard cert) — Keycloak's own
+  manifest has no HTTPS/NodePort of its own anymore, it's exposed entirely through the
+  `HTTPRoute` in `manifests/keycloak.yaml`, which needs that `Gateway` to already exist.
+
+```bash
+kubectl get nodes
+# expected: your node, Ready
+kubectl get gateway crownlabs -n default
+# expected: PROGRAMMED = True
+```
+
+## 1. Keycloak and the `mydrive-pvcs` namespace
+
+```bash
+kubectl apply -f dev-local/keycloak/manifests
+kubectl rollout status statefulset/keycloak
+```
+
+This single apply covers:
+- Keycloak + Postgres (`manifests/keycloak.yaml`), with `--import-realm` enabled and the
+  realm ConfigMap mounted. Keycloak itself only ever speaks plain HTTP — TLS terminates
+  at the Gateway (see [`../envoy/README.md`](../envoy/README.md)), not here, so there's
+  no certificate/HTTPS config on Keycloak's own side at all.
+- An `HTTPRoute` (same file) routing `keycloak.crownlabs.local` to that Service through
+  the shared `crownlabs` Gateway.
+- The realm import itself (`manifests/crownlabs-realm-configmap.yaml`) — the
+  `crownlabs` realm export (clients `k8s`/`operator-local`, scopes
+  `groups`/`k8s-audience`, base users), wrapped in a `ConfigMap` so it's
+  applied declaratively instead of via an easy-to-forget imperative
+  `kubectl create configmap` step.
+- The `mydrive-pvcs` namespace (`manifests/mydrive-pvcs-namespace.yaml`),
+  used by the operator for tenants' personal-drive PVCs.
+
+Keycloak is now reachable at `https://keycloak.crownlabs.local` — no `kubectl
+port-forward` needed on native Linux (see [`../envoy/README.md`](../envoy/README.md) for
+how that's wired: one shared Gateway, `ServiceLB`-backed on 80/443, instead of a
+per-service `NodePort`).
+
+> **On WSL2**: same underlying limitation as everything else behind the Gateway — see
+> [`../envoy/README.md`](../envoy/README.md) step 5 for the one bridge you need
+> (`kubectl port-forward ... 8443:443`). **Every hostname in this guide and in
+> `apiserver-oidc-integration.md` needs `:8443` appended on WSL2**
+> (`https://keycloak.crownlabs.local:8443`) — this must exactly match whatever URL the
+> browser actually reaches Keycloak through, since that's what ends up in the token's
+> `iss` claim.
+>
+> **Also on WSL2**: Keycloak (`KC_HOSTNAME_STRICT=false`) infers its own issuer from the
+> request it receives, but — tested and confirmed — it reports the issuer **without**
+> a port regardless of which port the request actually arrived on (Envoy Gateway
+> doesn't forward a `X-Forwarded-Port`). On native Linux that's fine (port 443 is the
+> default, no bridge involved). On WSL2 it's not: the issuer needs to say `:8443`
+> explicitly, or it won't byte-for-byte match the `oidc-issuer-url` the apiserver is
+> configured with in step 2 below, and every token gets rejected with an issuer
+> mismatch. Pin it explicitly after applying the manifests:
+> ```bash
+> kubectl set env statefulset/keycloak KC_HOSTNAME=https://keycloak.crownlabs.local:8443
+> kubectl rollout status statefulset/keycloak
+> ```
+> This is a live patch, not part of `manifests/keycloak.yaml` (which stays
+> environment-agnostic) — re-run it if you ever re-`kubectl apply` the base manifest on
+> WSL2, same gotcha as the `Tenant`/`Workspace` patches in `../operators/README.md`.
+
+The self-signed wildcard certificate (issued at the Gateway, see
+[`../envoy/README.md`](../envoy/README.md)) triggers a browser warning
+(`ERR_CERT_AUTHORITY_INVALID`) the first time you visit
+`https://keycloak.crownlabs.local/...` — expected for local dev; click through it once
+("Advanced" → "Proceed") and the browser trusts it for the rest of the session.
+
+On first startup, Keycloak imports the realm from the mounted ConfigMap
+automatically (log: `KC-SERVICES0032: Import JSON RealmRepresentation from
+file .../crownlabs-realm.json`). **If the realm already exists in the
+database, the import is silently skipped** — standard `--import-realm`
+behavior, meant to avoid losing state across restarts. To re-import from
+scratch, delete the realm first (Admin Console, or `DELETE
+/admin/realms/crownlabs`), or wipe the Postgres database.
+
+Credentials included in the export:
+
+| Who | Credentials |
+|---|---|
+| Keycloak admin (`master` realm) | `admin` / `admin` (set via env var, not part of the export) |
+| Test user (`crownlabs` realm) | `john.doe` / `johndoe123`, email verified |
+| `operator-local` client (service account for the operator) | client secret: `operator-local-dev-secret` |
+| `k8s` client (frontend, public) | no secret, redirect URI already set to `http://localhost:3000/*` |
+
+> These are **known values, deliberately documented for local development**,
+> exactly like `admin`/`admin` in the manifest — not meant for real
+> environments.
+
+## 2. Configure the k3s apiserver for OIDC
+
+This is the one step that genuinely requires root and a k3s restart, so it
+can't be folded into the manifests above. See
+[`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) for the
+full rationale (why each flag, the `groups`/`aud` claim mappers, etc.) —
+here's just the commands:
+
+```bash
+mkdir -p ~/certs
+kubectl get secret crownlabs-tls -n default -o jsonpath='{.data.ca\.crt}' | base64 -d > ~/certs/crownlabs-ca.crt
+sudo cp ~/certs/crownlabs-ca.crt /etc/rancher/k3s/crownlabs-ca.crt
+```
+
+Write a dedicated drop-in file (requires root) instead of editing the shared
+`/etc/rancher/k3s/config.yaml` — k3s merges every `*.yaml` under
+`/etc/rancher/k3s/config.yaml.d/` automatically, so this can't clobber
+whatever [`../base-k3s/README.md`](../base-k3s/README.md) or
+[`../envoy/README.md`](../envoy/README.md) already put there:
+
+```bash
+sudo mkdir -p /etc/rancher/k3s/config.yaml.d
+sudo tee /etc/rancher/k3s/config.yaml.d/30-keycloak-oidc.yaml > /dev/null <<'EOF'
+kube-apiserver-arg:
+  - "oidc-issuer-url=https://keycloak.crownlabs.local/realms/crownlabs"
+  - "oidc-client-id=k8s"
+  - "oidc-username-claim=preferred_username"
+  - "oidc-username-prefix=-"
+  - "oidc-groups-claim=groups"
+  - "oidc-groups-prefix=kubernetes:"
+  - "oidc-ca-file=/etc/rancher/k3s/crownlabs-ca.crt"
+EOF
+```
+
+> **On WSL2**: use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs`
+> instead (the Gateway bridge port from [`../envoy/README.md`](../envoy/README.md) step
+> 5) — this must exactly match whatever URL the browser actually reaches Keycloak
+> through, since that's what ends up in the token's `iss` claim.
+
+```bash
+sudo systemctl restart k3s
+journalctl -u k3s -f   # confirm no "invalid authentication configuration" error, then Ctrl+C
+```
+
+**This restarts the whole control plane** — the apiserver is briefly
+unreachable, and any process with an open watch/proxy connection to it
+(`kubectl proxy`, `kubectl port-forward`, the operators) needs restarting
+afterwards. Confirm `kubectl get nodes` reports `Ready` before moving on.
+
+## Final checks
+
+```bash
+kubectl get pods -A
+# keycloak-0, postgres, cert-manager, envoy-gateway-system pods all Running, no CrashLoopBackOff
+
+curl -sk -o /dev/null -w "%{http_code}\n" https://keycloak.crownlabs.local/realms/crownlabs
+# WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
+# expected: 200
+
+kubectl get nodes
+# expected: Ready — confirms the apiserver came back up after Step 2's restart
+```
+
+Expected end state:
+- ✅ Keycloak up, reachable through the Gateway.
+- ✅ Realm `crownlabs` imported; `k8s`/`operator-local` clients configured.
+- ✅ `mydrive-pvcs` namespace present.
+- ✅ Kubernetes apiserver authenticating via OIDC.
+
+## Next
+
+- [`../operators/README.md`](../operators/README.md) — base RBAC and running
+  the CrownLabs operator (needs everything above).
+- For qlkube (talking directly to the real apiserver instead of through
+  `kubectl proxy`) and the frontend's OIDC configuration, see
+  [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) Steps 4–6.
+
+## Regenerating the realm export
+
+If you manually change something in the local realm (new client, new
+scope, new user, etc.) and want to freeze it for future installs, see
+[`regenerating-the-realm-export.md`](regenerating-the-realm-export.md).

--- a/dev-local/keycloak/README.md
+++ b/dev-local/keycloak/README.md
@@ -1,31 +1,25 @@
 # Local Keycloak + OIDC — end-to-end setup
 
-Everything needed to bring up Keycloak (realm, clients, scopes, base users) and the
-Kubernetes apiserver validating Keycloak-issued tokens (instead of every local request
-silently running as cluster-admin under `kubectl proxy`), on top of an already-existing
-k3s cluster with [Envoy Gateway](../envoy/README.md) set up.
+This section presents the steps needed to bring up Keycloak locally: the realm, the clients, the scopes, and the base users.
+It also configures the Kubernetes API server to validate the tokens Keycloak issues.
+Without this, every local request through `kubectl proxy` runs silently as cluster-admin, with no real authentication.
+You need an already-existing k3s cluster with [Envoy Gateway](../envoy/README.md) set up before you start.
 
-- [`manifests/`](manifests/) — applied with a single
-  `kubectl apply -f dev-local/keycloak/manifests`: Keycloak + Postgres, its `HTTPRoute`,
-  the realm import, and the `mydrive-pvcs` namespace.
-- [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) — the
-  rationale, verification steps and troubleshooting table behind the OIDC
-  setup below. Read it if something in this guide doesn't behave as
-  expected; this README only has the commands.
+- [`manifests/`](manifests/): apply everything with a single command, `kubectl apply -f dev-local/keycloak/manifests`. This includes Keycloak, Postgres, its `HTTPRoute`, the realm import, and the `mydrive-pvcs` namespace.
+- [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md): the rationale, verification steps, and troubleshooting table behind the OIDC setup below. Read it if something in this guide does not behave as expected. This README only lists the commands.
 
 ## 0. Prerequisites
 
-- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
-- [Envoy Gateway](../envoy/README.md) set up (Gateway API CRDs, the controller, the
-  shared `crownlabs` Gateway, the `*.crownlabs.local` wildcard cert) — Keycloak's own
-  manifest has no HTTPS/NodePort of its own anymore, it's exposed entirely through the
-  `HTTPRoute` in `manifests/keycloak.yaml`, which needs that `Gateway` to already exist.
+- The base k3s cluster. See [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md) set up: the Gateway API CRDs, the controller, the shared `crownlabs` Gateway, and the `*.crownlabs.local` wildcard certificate.
+  Keycloak's own manifest no longer has its own HTTPS listener or NodePort.
+  It is exposed entirely through the `HTTPRoute` in `manifests/keycloak.yaml`, which needs that `Gateway` to already exist.
 
 ```bash
 kubectl get nodes
-# expected: your node, Ready
+# Expected: your node (the machine running k3s) is Ready.
 kubectl get gateway crownlabs -n default
-# expected: PROGRAMMED = True
+# Expected: PROGRAMMED = True.
 ```
 
 ## 1. Keycloak and the `mydrive-pvcs` namespace
@@ -36,83 +30,61 @@ kubectl rollout status statefulset/keycloak
 ```
 
 This single apply covers:
-- Keycloak + Postgres (`manifests/keycloak.yaml`), with `--import-realm` enabled and the
-  realm ConfigMap mounted. Keycloak itself only ever speaks plain HTTP — TLS terminates
-  at the Gateway (see [`../envoy/README.md`](../envoy/README.md)), not here, so there's
-  no certificate/HTTPS config on Keycloak's own side at all.
-- An `HTTPRoute` (same file) routing `keycloak.crownlabs.local` to that Service through
-  the shared `crownlabs` Gateway.
-- The realm import itself (`manifests/crownlabs-realm-configmap.yaml`) — the
-  `crownlabs` realm export (clients `k8s`/`operator-local`, scopes
-  `groups`/`k8s-audience`, base users), wrapped in a `ConfigMap` so it's
-  applied declaratively instead of via an easy-to-forget imperative
-  `kubectl create configmap` step.
-- The `mydrive-pvcs` namespace (`manifests/mydrive-pvcs-namespace.yaml`),
-  used by the operator for tenants' personal-drive PVCs.
+- Keycloak and Postgres (`manifests/keycloak.yaml`), with `--import-realm` enabled and the
+  realm ConfigMap mounted. Keycloak itself only speaks plain HTTP (in fact, TLS terminates
+  at the Gateway, as described in [`../envoy/README.md`](../envoy/README.md)), so there's
+  no certificate or HTTPS configuration on Keycloak's own side at all.
+- An `HTTPRoute` (in the same file) that routes `keycloak.crownlabs.local` to that Service, through the shared `crownlabs` Gateway.
+- The realm import itself (`manifests/crownlabs-realm-configmap.yaml`): the `crownlabs` realm export, with the `k8s` and `operator-local` clients, the `groups` and `k8s-audience` scopes, and the base users. It is wrapped in a `ConfigMap`, so you apply it declaratively instead of running an easy-to-forget, manual `kubectl create configmap` command.
+- The `mydrive-pvcs` namespace (`manifests/mydrive-pvcs-namespace.yaml`), used by the operator for tenants' personal-drive PVCs.
 
-Keycloak is now reachable at `https://keycloak.crownlabs.local` — no `kubectl
-port-forward` needed on native Linux (see [`../envoy/README.md`](../envoy/README.md) for
-how that's wired: one shared Gateway, `ServiceLB`-backed on 80/443, instead of a
-per-service `NodePort`).
+Keycloak is now reachable at `https://keycloak.crownlabs.local`.
+You do not need `kubectl port-forward` on native Linux.
+See [`../envoy/README.md`](../envoy/README.md) for how this works: one shared Gateway, backed by `ServiceLB` on ports 80 and 443, instead of a separate `NodePort` per service.
 
-> **On WSL2**: same underlying limitation as everything else behind the Gateway — see
-> [`../envoy/README.md`](../envoy/README.md) step 5 for the one bridge you need
-> (`kubectl port-forward ... 8443:443`). **Every hostname in this guide and in
-> `apiserver-oidc-integration.md` needs `:8443` appended on WSL2**
-> (`https://keycloak.crownlabs.local:8443`) — this must exactly match whatever URL the
-> browser actually reaches Keycloak through, since that's what ends up in the token's
-> `iss` claim.
+> **On WSL2**: this has the same underlying limitation as everything else behind the Gateway.
+> See [`../envoy/README.md`](../envoy/README.md) step 5 for the one bridge you need (`kubectl port-forward ... 8443:443`).
+> **Append `:8443` to every hostname in this guide and in `apiserver-oidc-integration.md` when you use WSL2** (for example, `https://keycloak.crownlabs.local:8443`).
+> This must exactly match the URL the browser actually uses to reach Keycloak, because that URL ends up in the token's `iss` (issuer) claim.
 >
-> **Also on WSL2**: Keycloak (`KC_HOSTNAME_STRICT=false`) infers its own issuer from the
-> request it receives, but — tested and confirmed — it reports the issuer **without**
-> a port regardless of which port the request actually arrived on (Envoy Gateway
-> doesn't forward a `X-Forwarded-Port`). On native Linux that's fine (port 443 is the
-> default, no bridge involved). On WSL2 it's not: the issuer needs to say `:8443`
-> explicitly, or it won't byte-for-byte match the `oidc-issuer-url` the apiserver is
-> configured with in step 2 below, and every token gets rejected with an issuer
-> mismatch. Pin it explicitly after applying the manifests:
+> **Also on WSL2**: Keycloak (with `KC_HOSTNAME_STRICT=false`) infers its own issuer from the request it receives.
+> We tested this: Keycloak always reports the issuer **without** a port, no matter which port the request actually arrived on, because Envoy Gateway does not forward an `X-Forwarded-Port` header.
+> On native Linux, this is fine, since port 443 is the default and there is no bridge involved.
+> On WSL2, it is not fine: the issuer needs to say `:8443` explicitly, or it will not match, byte-for-byte, the `oidc-issuer-url` you configure for the API server in step 2 below. If it does not match, every token gets rejected with an issuer mismatch error.
+> Pin the hostname explicitly after you apply the manifests:
 > ```bash
 > kubectl set env statefulset/keycloak KC_HOSTNAME=https://keycloak.crownlabs.local:8443
 > kubectl rollout status statefulset/keycloak
 > ```
-> This is a live patch, not part of `manifests/keycloak.yaml` (which stays
-> environment-agnostic) — re-run it if you ever re-`kubectl apply` the base manifest on
-> WSL2, same gotcha as the `Tenant`/`Workspace` patches in `../operators/README.md`.
+> This is a live patch. It is not part of `manifests/keycloak.yaml`, which stays environment-agnostic.
+> Re-run this patch if you ever re-apply the base manifest on WSL2. This is the same gotcha as the `Tenant`/`Workspace` patches described in `../operators/README.md`.
 
-The self-signed wildcard certificate (issued at the Gateway, see
-[`../envoy/README.md`](../envoy/README.md)) triggers a browser warning
-(`ERR_CERT_AUTHORITY_INVALID`) the first time you visit
-`https://keycloak.crownlabs.local/...` — expected for local dev; click through it once
-("Advanced" → "Proceed") and the browser trusts it for the rest of the session.
+The self-signed wildcard certificate (issued at the Gateway, see [`../envoy/README.md`](../envoy/README.md)) triggers a browser warning (`ERR_CERT_AUTHORITY_INVALID`) the first time you visit `https://keycloak.crownlabs.local/...`.
+This warning is expected for local development.
+Click through it once ("Advanced" → "Proceed"), and the browser trusts the certificate for the rest of the session.
 
-On first startup, Keycloak imports the realm from the mounted ConfigMap
-automatically (log: `KC-SERVICES0032: Import JSON RealmRepresentation from
-file .../crownlabs-realm.json`). **If the realm already exists in the
-database, the import is silently skipped** — standard `--import-realm`
-behavior, meant to avoid losing state across restarts. To re-import from
-scratch, delete the realm first (Admin Console, or `DELETE
-/admin/realms/crownlabs`), or wipe the Postgres database.
+On first startup, Keycloak automatically imports the realm from the mounted ConfigMap.
+You will see this in the logs: `KC-SERVICES0032: Import JSON RealmRepresentation from file .../crownlabs-realm.json`.
+**If the realm already exists in the database, Keycloak silently skips the import.**
+This is the standard `--import-realm` behavior, meant to avoid losing state across restarts.
+To re-import from scratch, first delete the realm (through the Admin Console, or with `DELETE /admin/realms/crownlabs`), or wipe the Postgres database.
 
 Credentials included in the export:
 
 | Who | Credentials |
 |---|---|
-| Keycloak admin (`master` realm) | `admin` / `admin` (set via env var, not part of the export) |
+| Keycloak admin (`master` realm) | `admin` / `admin` (set through an environment variable, not part of the export) |
 | Test user (`crownlabs` realm) | `john.doe` / `johndoe123`, email verified |
 | `operator-local` client (service account for the operator) | client secret: `operator-local-dev-secret` |
-| `k8s` client (frontend, public) | no secret, redirect URI already set to `http://localhost:3000/*` |
+| `k8s` client (frontend, public) | no secret; redirect URI already set to `http://localhost:3000/*` |
 
-> These are **known values, deliberately documented for local development**,
-> exactly like `admin`/`admin` in the manifest — not meant for real
-> environments.
+> These are **known values, deliberately documented for local development**, exactly like `admin`/`admin` in the manifest. Do not reuse them in real environments.
 
-## 2. Configure the k3s apiserver for OIDC
+## 2. Configure the k3s API server for OIDC
 
-This is the one step that genuinely requires root and a k3s restart, so it
-can't be folded into the manifests above. See
-[`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) for the
-full rationale (why each flag, the `groups`/`aud` claim mappers, etc.) —
-here's just the commands:
+This step requires root privileges and a k3s restart, so it cannot be folded into the manifests above.
+See [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) for the full rationale: why each flag is needed, the `groups`/`aud` claim mappers, and so on.
+Here are just the commands:
 
 ```bash
 mkdir -p ~/certs
@@ -120,11 +92,8 @@ kubectl get secret crownlabs-tls -n default -o jsonpath='{.data.ca\.crt}' | base
 sudo cp ~/certs/crownlabs-ca.crt /etc/rancher/k3s/crownlabs-ca.crt
 ```
 
-Write a dedicated drop-in file (requires root) instead of editing the shared
-`/etc/rancher/k3s/config.yaml` — k3s merges every `*.yaml` under
-`/etc/rancher/k3s/config.yaml.d/` automatically, so this can't clobber
-whatever [`../base-k3s/README.md`](../base-k3s/README.md) or
-[`../envoy/README.md`](../envoy/README.md) already put there:
+Write a dedicated drop-in file (this requires root) instead of editing the shared `/etc/rancher/k3s/config.yaml` file directly.
+k3s automatically merges every `*.yaml` file under `/etc/rancher/k3s/config.yaml.d/`, so this new file cannot clobber anything that [`../base-k3s/README.md`](../base-k3s/README.md) or [`../envoy/README.md`](../envoy/README.md) already added there:
 
 ```bash
 sudo mkdir -p /etc/rancher/k3s/config.yaml.d
@@ -140,51 +109,43 @@ kube-apiserver-arg:
 EOF
 ```
 
-> **On WSL2**: use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs`
-> instead (the Gateway bridge port from [`../envoy/README.md`](../envoy/README.md) step
-> 5) — this must exactly match whatever URL the browser actually reaches Keycloak
-> through, since that's what ends up in the token's `iss` claim.
+> **On WSL2**: use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs` instead (the Gateway bridge port from [`../envoy/README.md`](../envoy/README.md) step 5).
+> This must exactly match the URL the browser actually uses to reach Keycloak, because that URL ends up in the token's `iss` (issuer) claim.
 
 ```bash
 sudo systemctl restart k3s
-journalctl -u k3s -f   # confirm no "invalid authentication configuration" error, then Ctrl+C
+journalctl -u k3s -f   # Confirm there is no "invalid authentication configuration" error, then press Ctrl+C.
 ```
 
-**This restarts the whole control plane** — the apiserver is briefly
-unreachable, and any process with an open watch/proxy connection to it
-(`kubectl proxy`, `kubectl port-forward`, the operators) needs restarting
-afterwards. Confirm `kubectl get nodes` reports `Ready` before moving on.
+Restarting k3s restarts the whole control plane.
+The API server is briefly unreachable, and you need to restart any process with an open watch or proxy connection to it (`kubectl proxy`, `kubectl port-forward`, the operators) afterwards.
+Confirm `kubectl get nodes` reports `Ready` before you move on.
 
 ## Final checks
 
 ```bash
 kubectl get pods -A
-# keycloak-0, postgres, cert-manager, envoy-gateway-system pods all Running, no CrashLoopBackOff
+# Expected: keycloak-0, postgres, cert-manager, and envoy-gateway-system pods are all Running, with no CrashLoopBackOff.
 
 curl -sk -o /dev/null -w "%{http_code}\n" https://keycloak.crownlabs.local/realms/crownlabs
-# WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
-# expected: 200
+# On WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs
+# Expected: 200.
 
 kubectl get nodes
-# expected: Ready — confirms the apiserver came back up after Step 2's restart
+# Expected: Ready. This confirms the API server came back up after the restart in step 2.
 ```
 
 Expected end state:
-- ✅ Keycloak up, reachable through the Gateway.
-- ✅ Realm `crownlabs` imported; `k8s`/`operator-local` clients configured.
-- ✅ `mydrive-pvcs` namespace present.
-- ✅ Kubernetes apiserver authenticating via OIDC.
+- ✅ Keycloak is up, and reachable through the Gateway.
+- ✅ The `crownlabs` realm is imported, and the `k8s`/`operator-local` clients are configured.
+- ✅ The `mydrive-pvcs` namespace exists.
+- ✅ The Kubernetes API server authenticates through OIDC.
 
 ## Next
 
-- [`../operators/README.md`](../operators/README.md) — base RBAC and running
-  the CrownLabs operator (needs everything above).
-- For qlkube (talking directly to the real apiserver instead of through
-  `kubectl proxy`) and the frontend's OIDC configuration, see
-  [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md) Steps 4–6.
+- [`../operators/README.md`](../operators/README.md): set up base RBAC and run the CrownLabs operator. This needs everything above.
+- For qlkube (which talks directly to the real API server instead of through `kubectl proxy`) and for the frontend's OIDC configuration, see steps 4 to 6 in [`apiserver-oidc-integration.md`](apiserver-oidc-integration.md).
 
 ## Regenerating the realm export
 
-If you manually change something in the local realm (new client, new
-scope, new user, etc.) and want to freeze it for future installs, see
-[`regenerating-the-realm-export.md`](regenerating-the-realm-export.md).
+If you manually change something in the local realm (a new client, a new scope, a new user, and so on) and you want to freeze it for future installs, see [`regenerating-the-realm-export.md`](regenerating-the-realm-export.md).

--- a/dev-local/keycloak/apiserver-oidc-integration.md
+++ b/dev-local/keycloak/apiserver-oidc-integration.md
@@ -1,0 +1,290 @@
+# Authenticating the local Kubernetes apiserver with Keycloak (OIDC)
+
+This document describes how to make the **local k3s apiserver itself** trust Keycloak-issued tokens and enforce per-user RBAC, mirroring how a real CrownLabs cluster authenticates users — instead of every local request silently running as cluster-admin.
+
+This is a separate, optional layer on top of the basic local setup described in `dev-local/local-development.md` and [`README.md`](README.md). Read those first; this document assumes [Envoy Gateway](../envoy/README.md), Keycloak, qlkube, the frontend and the operators are already working locally with `kubectl proxy`/admin credentials.
+
+## Why this is needed
+
+In the basic local setup, qlkube (in `IN_CLUSTER=false` mode) talks to the apiserver through `kubectl proxy` (`http://localhost:8001`). **`kubectl proxy` always authenticates using its own kubeconfig credentials and completely ignores whatever `Authorization` header the client sends** — confirmed by sending a garbage bearer token through it and observing a successful, fully-authorized response. This means every request qlkube makes runs as cluster-admin regardless of which user is logged into the frontend, and any RBAC configured by the operator has no real effect locally.
+
+To actually exercise per-user RBAC locally (and catch RBAC bugs before they reach a real cluster), the apiserver needs to validate the user's own OIDC token directly, and qlkube needs to forward that token to the apiserver instead of routing through `kubectl proxy`.
+
+## Overview of what changes
+
+1. Two extra Keycloak protocol mappers are added: one to expose the user's client roles as a `groups` claim, one to make sure the `k8s` client is present in its own token's `aud` claim.
+2. qlkube gets a new mode (`USE_LOCAL_CLUSTER=true`) that talks to the real apiserver directly instead of through `kubectl proxy`.
+3. k3s's apiserver gets `--oidc-*` flags pointing at Keycloak's `HTTPRoute` hostname (`keycloak.crownlabs.local`, behind the shared Gateway — TLS is required for k3s to accept the issuer at all, and it's the Gateway that terminates it, not Keycloak itself).
+4. The base CrownLabs `ClusterRole`/`ClusterRoleBinding` resources (normally installed by the Helm chart, never applied when running the operators directly via `go run`) get applied so RBAC actually has something to grant.
+
+> **If you installed Keycloak from this folder's `manifests/`** (see [`README.md`](README.md)), Step 1 below is already baked in — the `groups`/`k8s-audience` client scopes are part of the imported realm. Step 4 (base RBAC) lives in [`../operators/README.md`](../operators/README.md) Step 1 instead, since it's really a prerequisite of running the operator, not of Keycloak itself. Skip ahead to Step 3 for the rest. Steps 1 and 4 are kept here in full for reference and rationale.
+
+## Step 1 — Keycloak realm configuration
+
+### 1.1 `groups` claim from client roles
+
+CrownLabs' operator binds `ClusterRoleBinding`/`RoleBinding` `Subject`s of `Kind: Group` with names like `kubernetes:workspace-tea:manager` (see `operators/pkg/forge/rbac.go`, `rolebinding.go`). For the apiserver to resolve a user into these groups, the token must carry a `groups` claim listing the user's raw Keycloak client roles (the `kubernetes:` prefix is added by the apiserver itself via `--oidc-groups-prefix`, not by Keycloak).
+
+```bash
+TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/master/protocol/openid-connect/token \
+  -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"groups","protocol":"openid-connect","attributes":{"include.in.token.scope":"true","display.on.consent.screen":"false"}}'
+
+GROUPS_SCOPE_ID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print([s['id'] for s in json.load(sys.stdin) if s['name']=='groups'][0])")
+
+# NOTE: 'usermodel.clientRoleMapping.clientId' must be the client that ACTUALLY holds the
+# workspace-*:role client roles — this is whatever you passed as --keycloak-roles-client-id
+# to the operator (operator-local in this local setup).
+curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes/$GROUPS_SCOPE_ID/protocol-mappers/models" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "operator-local-client-roles-to-groups",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-usermodel-client-role-mapper",
+    "config": {
+      "usermodel.clientRoleMapping.clientId": "operator-local",
+      "claim.name": "groups",
+      "jsonType.label": "String",
+      "multivalued": "true",
+      "id.token.claim": "true",
+      "access.token.claim": "true",
+      "userinfo.token.claim": "true"
+    }
+  }'
+
+K8S_UUID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients?clientId=k8s" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['id'])")
+
+curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID/default-client-scopes/$GROUPS_SCOPE_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### 1.2 `aud` (audience) fix
+
+By default, Keycloak does **not** include a client's own `clientId` in the `aud` claim of the tokens it issues to that client — only clients that have a role-mapping pointing at them (like `operator-local`, added implicitly by the mapper above) or the built-in `account` client end up in `aud`. Kubernetes' OIDC authenticator requires `--oidc-client-id` to be present in the token's `aud`, so without this fix every request would fail with an audience mismatch, even though the token is otherwise perfectly valid.
+
+```bash
+curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"name":"k8s-audience","protocol":"openid-connect","attributes":{"include.in.token.scope":"true","display.on.consent.screen":"false"}}'
+
+AUD_SCOPE_ID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print([s['id'] for s in json.load(sys.stdin) if s['name']=='k8s-audience'][0])")
+
+curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes/$AUD_SCOPE_ID/protocol-mappers/models" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{
+    "name": "k8s-self-audience",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-audience-mapper",
+    "config": {"included.client.audience": "k8s", "id.token.claim": "false", "access.token.claim": "true"}
+  }'
+
+curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID/default-client-scopes/$AUD_SCOPE_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### 1.3 Verify the token shape
+
+Temporarily enable direct access grants on `k8s` to pull a password-grant test token (remember to disable it again afterwards — it's off by default for a reason):
+
+```bash
+curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"directAccessGrantsEnabled": true}'
+
+JD_TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/crownlabs/protocol/openid-connect/token \
+  -d "client_id=k8s" -d "username=john.doe" -d "password=johndoe123" -d "grant_type=password" -d "scope=openid profile email api groups" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+echo "$JD_TOKEN" | cut -d. -f2 | python3 -c "
+import sys, base64, json
+s = sys.stdin.read().strip(); s += '=' * (-len(s) % 4)
+p = json.loads(base64.urlsafe_b64decode(s))
+print('iss:', p.get('iss')); print('aud:', p.get('aud'))
+print('preferred_username:', p.get('preferred_username')); print('groups:', p.get('groups'))
+"
+# expected: iss matches https://keycloak.crownlabs.local/realms/crownlabs exactly
+# (WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs),
+# aud contains "k8s", preferred_username is the plain username, groups lists workspace-*:role entries
+
+curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"directAccessGrantsEnabled": false}'
+```
+
+## Step 2 — Base CrownLabs RBAC resources (rationale)
+
+The top-level Helm chart (`deploy/crownlabs/templates/clusterroles.yaml` and `clusterrolebindings.yaml`) defines the base `ClusterRole`s the operator's per-tenant/per-workspace bindings reference (`crownlabs-manage-tenants`, `crownlabs-manage-instances`, `crownlabs-view-workspaces`, ...), plus a couple of `ClusterRoleBinding`s to the built-in `system:authenticated` group (any logged-in user can *view* workspaces and image lists, needed for the enrollment/discovery UI). **None of this exists if you only ran the operators locally via `go run`** — the gap is invisible under `kubectl proxy` (which never checks RBAC) and only surfaces once the apiserver starts doing real authorization.
+
+Rather than hand-maintaining a de-templated copy of those two files (which can silently drift from the real chart), [`../operators/README.md`](../operators/README.md) Step 1 renders them straight from `deploy/crownlabs` with `helm template -s templates/clusterroles.yaml -s templates/clusterrolebindings.yaml` and pipes the result into `kubectl apply`. Nothing to run here beyond that; this section only exists to explain why that step is there. These are purely additive RBAC definitions — creating a `ClusterRole` grants nothing by itself until something is bound to it, so applying them is always safe.
+
+## Step 3 — Configure the k3s apiserver
+
+Write a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/`
+(requires root) instead of editing the shared `/etc/rancher/k3s/config.yaml`
+— k3s merges every `*.yaml` there automatically, so this can't clobber
+whatever [`../base-k3s/README.md`](../base-k3s/README.md) (kubeconfig
+access) or [`../envoy/README.md`](../envoy/README.md) (disabling Traefik)
+already put there:
+
+```bash
+sudo mkdir -p /etc/rancher/k3s/config.yaml.d
+sudo tee /etc/rancher/k3s/config.yaml.d/30-keycloak-oidc.yaml > /dev/null <<'EOF'
+kube-apiserver-arg:
+  - "oidc-issuer-url=https://keycloak.crownlabs.local/realms/crownlabs"
+  - "oidc-client-id=k8s"
+  - "oidc-username-claim=preferred_username"
+  - "oidc-username-prefix=-"
+  - "oidc-groups-claim=groups"
+  - "oidc-groups-prefix=kubernetes:"
+  - "oidc-ca-file=/etc/rancher/k3s/crownlabs-ca.crt"
+EOF
+```
+
+On WSL2, use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs` instead (the Gateway bridge port, see [`../envoy/README.md`](../envoy/README.md) step 5 / `README.md` step 2).
+
+Notes on each flag:
+- `oidc-issuer-url` must match the token's `iss` claim **exactly** (scheme, host, port, path) — it reflects whatever URL the browser/frontend uses to reach Keycloak, not an arbitrary internal address.
+- `oidc-username-prefix=-` is required explicitly: without it, some k8s versions prefix the username with the issuer URL (`https://...#john.doe`), which won't match the plain `john.doe` used in the operator's `RoleBinding`/`ClusterRoleBinding` subjects.
+- `oidc-ca-file` is required because the apiserver's own HTTP client won't trust a self-signed certificate by default — it needs an explicit copy of the certificate to fetch the OIDC discovery document and JWKS. This is the Gateway's wildcard cert now (`crownlabs-tls`), not a Keycloak-specific one — see [`../envoy/README.md`](../envoy/README.md).
+
+Extract the CA certificate from the `crownlabs-tls` Secret (cert-manager populates `ca.crt` there — see [`../envoy/README.md`](../envoy/README.md)) into a user-owned copy, reused below for the operator's `SSL_CERT_FILE` too, then copy it where the (root-owned) apiserver config expects it and restart:
+
+```bash
+mkdir -p ~/certs
+kubectl get secret crownlabs-tls -n default -o jsonpath='{.data.ca\.crt}' | base64 -d > ~/certs/crownlabs-ca.crt
+
+sudo cp ~/certs/crownlabs-ca.crt /etc/rancher/k3s/crownlabs-ca.crt
+sudo systemctl restart k3s
+journalctl -u k3s -f   # confirm no "invalid authentication configuration" error, Ctrl+C once it's up
+```
+
+**This restarts the whole control plane** (running pods survive, but the apiserver is briefly unreachable, and any process with an open watch/proxy connection to it — `kubectl proxy`, `kubectl port-forward`, the operators — will need to be restarted afterwards). Get everything (`kubectl get nodes`) confirmed healthy before moving on.
+
+### If you need to roll this back
+
+```bash
+sudo rm /etc/rancher/k3s/config.yaml.d/30-keycloak-oidc.yaml
+sudo systemctl restart k3s
+```
+
+## Step 4 — qlkube: talk to the real apiserver
+
+`qlkube/src/index.js` now has a `USE_LOCAL_CLUSTER=true` mode that bypasses `kubectl proxy` and connects directly to `https://localhost:6443` (or `LOCAL_K8S_API_URL` if set), forwarding whatever bearer token it receives as-is instead of it being silently discarded. This talks to the apiserver's own port directly (unrelated to the Gateway/Keycloak hostname above).
+
+Two things this needs that `kubectl proxy` didn't:
+
+**A trusted-but-self-signed TLS connection.** Set `NODE_TLS_REJECT_UNAUTHORIZED=0` when starting qlkube this way (already wired into the `dev-local-cluster` npm script). This is acceptable for local dev only — it disables certificate verification for the whole Node process.
+
+**A credential for the one-off OpenAPI schema discovery call at startup**, which happens before any user request exists. `kubectl proxy` used its own kubeconfig for this regardless of what you sent it; talking to the real apiserver means this call is genuinely unauthenticated unless you provide something. k3s's default kubeconfig uses **client-certificate auth (mTLS)**, not a bearer token, so it can't be reused directly here — create a small dedicated `ServiceAccount` instead, scoped to exactly what discovery needs (nothing more):
+
+```bash
+kubectl create serviceaccount qlkube-local -n default
+kubectl create clusterrolebinding qlkube-local-discovery --clusterrole=system:discovery --serviceaccount=default:qlkube-local
+```
+
+Generate a long-lived token for it and export it before starting qlkube (never commit this token anywhere):
+
+```bash
+export LOCAL_K8S_BOOTSTRAP_TOKEN=$(kubectl create token qlkube-local -n default --duration=87600h)
+cd qlkube
+CROWNLABS_QLKUBE_PORT=8085 npm run dev-local-cluster
+```
+
+Verify:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8085/graph/schema
+# expected: 200, and the qlkube log should show "OpenApi retrieved" with baseUrl https://localhost:6443
+```
+
+## Step 5 — Frontend configuration
+
+```bash
+VITE_APP_CROWNLABS_OIDC_AUTHORITY=https://keycloak.crownlabs.local/realms/crownlabs
+VITE_APP_CROWNLABS_OIDC_CLIENT_ID=k8s
+VITE_APP_CROWNLABS_GRAPHQL_URL=http://localhost:8085/graph
+```
+
+On WSL2, use `https://keycloak.crownlabs.local:8443/realms/crownlabs` for `VITE_APP_CROWNLABS_OIDC_AUTHORITY` instead.
+
+Restart the frontend dev server after changing `.env` (Vite does not hot-reload environment variables).
+
+### Trusting the self-signed certificate in the browser
+
+The frontend's OIDC library makes background `fetch()` calls (discovery document, token exchange, silent renew) directly to `https://keycloak.crownlabs.local`. A browser will silently fail these with `ERR_CERT_AUTHORITY_INVALID` for an untrusted self-signed certificate — this manifests as an **infinite login redirect loop with no visible error**, because the app can't tell "the network call to refresh my session failed" apart from "the session is genuinely gone", and reacts to both by forcing a fresh Keycloak login (`AuthContextProvider.tsx`'s `execLogin` logic — see `dev-local/local-development.md` troubleshooting table).
+
+Fix: visit `https://keycloak.crownlabs.local/realms/crownlabs/.well-known/openid-configuration` (WSL2: `https://keycloak.crownlabs.local:8443/...`) directly in the same browser once, click through the "not private" warning ("Advanced" → "Proceed"), then reload the app. The browser now trusts that origin for the rest of the session.
+
+## Step 6 — Make sure every namespace tenants touch is a real, enrolled Workspace
+
+Any namespace used for sample `Instance`/`Template` resources needs a matching `Workspace` custom resource with the tenant actually enrolled in it — otherwise the operator never creates the Keycloak `workspace-<name>:*` roles or the `RoleBinding`s that grant access, and any real per-user RBAC check on that namespace's `templates`/`instances` fails with `403 Forbidden`. This is invisible under `kubectl proxy` (admin can read anything) and only shows up once RBAC is actually enforced. If you have ad-hoc namespaces (e.g. a `workspace-standalone` created by hand for miscellaneous sample templates, with no corresponding `Workspace` CR), create the missing `Workspace` and enroll the tenant:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: crownlabs.polito.it/v1alpha1
+kind: Workspace
+metadata:
+  name: standalone
+  labels:
+    crownlabs.polito.it/operator-selector: local
+spec:
+  prettyName: Standalone environments
+  quota: {cpu: "8", memory: "15Gi", instances: 3}
+EOF
+
+kubectl patch tenant john.doe --type='json' \
+  -p='[{"op": "add", "path": "/spec/workspaces/-", "value": {"name": "standalone", "role": "manager"}}]'
+```
+
+The operator (if running) picks this up automatically and creates the corresponding Keycloak roles within a few seconds — verify with:
+
+```bash
+TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/master/protocol/openid-connect/token \
+  -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+OP_UUID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients?clientId=operator-local" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['id'])")
+curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$OP_UUID/roles" -H "Authorization: Bearer $TOKEN" \
+  | python3 -c "import json,sys; print([r['name'] for r in json.load(sys.stdin) if 'standalone' in r['name']])"
+```
+
+**The frontend's already-issued token won't reflect the new role until it refreshes** — log out and back in (or wait for the ~5 minute silent-refresh cycle) after enrolling a tenant in a new workspace.
+
+## Restarting the operator against Keycloak
+
+The operator's Keycloak client (`gocloak`, a plain Go `http.Client` under the hood) also needs to trust the self-signed certificate presented at the Gateway. Go's `crypto/x509` respects the `SSL_CERT_FILE` environment variable on Linux for loading extra trusted roots — point it at the same `~/certs/crownlabs-ca.crt` extracted in Step 3, then use the `run-operator-local` Makefile target (see [`../operators/README.md`](../operators/README.md) Step 2):
+
+```bash
+export SSL_CERT_FILE=~/certs/crownlabs-ca.crt
+cd operators
+make run-operator-local KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret
+```
+
+On WSL2, also override `KEYCLOAK_URL` to the bridge port: `make run-operator-local KEYCLOAK_URL=https://keycloak.crownlabs.local:8443 KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| k3s fails to start: `jwt[0].issuer.url: ... URL scheme must be https` | k3s 1.34+ hard-rejects non-HTTPS OIDC issuers | Confirm the Gateway's HTTPS listener is up ([`../envoy/README.md`](../envoy/README.md)) — TLS lives there now, not on Keycloak itself |
+| `403 Forbidden` from apiserver even after `--oidc-*` flags are set | Base CrownLabs `ClusterRole`s not installed (never applied outside Helm) | Render and apply them via `helm template` — [`../operators/README.md`](../operators/README.md) Step 1 (rationale: Step 2 of this doc) |
+| Token rejected / audience mismatch | `k8s` client's own `clientId` missing from its token's `aud` (Keycloak doesn't add it by default) | Add the audience mapper (Step 1.2) |
+| Token rejected / issuer mismatch (WSL2 only) | Keycloak (`KC_HOSTNAME_STRICT=false`) reports its issuer **without** a port regardless of which port the request came in on — tested and confirmed, Envoy Gateway doesn't forward `X-Forwarded-Port` — so it doesn't byte-for-byte match an `oidc-issuer-url` ending in `:8443` | Pin `KC_HOSTNAME=https://keycloak.crownlabs.local:8443` explicitly, see [`README.md`](README.md) step 1 |
+| Apiserver can't validate the OIDC discovery document | Self-signed cert not trusted by the apiserver's HTTP client | Add `--oidc-ca-file` pointing at the Gateway's wildcard CA (Step 3) |
+| Frontend stuck in an infinite login redirect loop, no visible error | Browser doesn't trust the self-signed cert; background OIDC fetches fail silently, app treats it as a stale session and forces re-login | Visit the Keycloak URL directly once and accept the browser warning (Step 5) |
+| qlkube: `connect ECONNREFUSED` on the OpenAPI discovery call | Direct-apiserver mode with no bootstrap credential (unlike `kubectl proxy`, which never needed one) | Set `LOCAL_K8S_BOOTSTRAP_TOKEN` (Step 4) |
+| qlkube: `SELF_SIGNED_CERT_IN_CHAIN` talking to `localhost:6443` | Node's default TLS verification rejects the apiserver's cert | `NODE_TLS_REJECT_UNAUTHORIZED=0` (already in `dev-local-cluster` script) |
+| Operator can't reach Keycloak (`x509: certificate signed by unknown authority`) | Go's HTTP client doesn't trust the self-signed cert either | `export SSL_CERT_FILE=<path-to-cert>` before starting the operator |
+| `403 Forbidden` reading `templates`/`instances` in a specific `workspace-*` namespace | The tenant was never actually enrolled in a matching `Workspace` CR (ad-hoc namespace, no membership) | Create the `Workspace` and enroll the tenant (Step 6); log out/in afterwards to get a fresh token |
+| `403 Forbidden` on a namespace/role that worked before, after running `make run-operator-local`/`run-instance-local` again | `operators/samples/` got re-applied as a target prerequisite; `kubectl apply`'s 3-way merge silently reverted a `kubectl patch`-only change (e.g. a `Workspace` enrollment added per Step 6) that was never reflected in the checked-in sample file | Re-apply the `kubectl patch`; log out/in for a fresh token. See the "Gotcha" note in `../operators/README.md` Step 2 |
+| `bind: address already in use` restarting the operator or qlkube | The actual compiled Go/Node binary survived independently of the `go run`/`npm run` wrapper process that appeared to exit (e.g. across a k3s restart) | Find the real PID via `ss -tlnp \| grep <port>` (the process name is the compiled binary, e.g. `imagelist`, not `go run`) and `kill -9` it directly |
+| A `kubectl port-forward`/operator/qlkube process dies right after `systemctl restart k3s` | Expected — restarting k3s restarts the whole control plane, dropping any open connection to it | Restart the affected process once `kubectl get nodes` reports `Ready` again |
+| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket; WSL2's `localhostForwarding` only relays real sockets | Bridge with `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` and append `:8443` everywhere — see [`../envoy/README.md`](../envoy/README.md) step 5 |
+| Operator: `dial tcp 127.0.0.1:XXXXX: i/o timeout` reaching Keycloak (WSL2 only) | The port-forward bridge reused the *same* port number as the Gateway's own 80/443 — kube-proxy's own iptables rules for those ports hijack local loopback traffic to them before it reaches the port-forward's listener | Use a bridge port different from 80/443 (`:8443`, not `:443`) |

--- a/dev-local/keycloak/apiserver-oidc-integration.md
+++ b/dev-local/keycloak/apiserver-oidc-integration.md
@@ -1,29 +1,43 @@
-# Authenticating the local Kubernetes apiserver with Keycloak (OIDC)
+# Authenticating the local Kubernetes API server with Keycloak (OIDC)
 
-This document describes how to make the **local k3s apiserver itself** trust Keycloak-issued tokens and enforce per-user RBAC, mirroring how a real CrownLabs cluster authenticates users — instead of every local request silently running as cluster-admin.
+This document explains how to make the **local k3s API server itself** trust Keycloak-issued tokens, and enforce per-user RBAC.
+This mirrors how a real CrownLabs cluster authenticates users.
+Without this setup, every local request runs silently as cluster-admin.
 
-This is a separate, optional layer on top of the basic local setup described in `dev-local/local-development.md` and [`README.md`](README.md). Read those first; this document assumes [Envoy Gateway](../envoy/README.md), Keycloak, qlkube, the frontend and the operators are already working locally with `kubectl proxy`/admin credentials.
+This is a separate, optional layer on top of the basic local setup described in `dev-local/local-development.md` and [`README.md`](README.md).
+Read those first.
+This document assumes [Envoy Gateway](../envoy/README.md), Keycloak, qlkube, the frontend, and the operators are already working locally with `kubectl proxy` and admin credentials.
 
 ## Why this is needed
 
-In the basic local setup, qlkube (in `IN_CLUSTER=false` mode) talks to the apiserver through `kubectl proxy` (`http://localhost:8001`). **`kubectl proxy` always authenticates using its own kubeconfig credentials and completely ignores whatever `Authorization` header the client sends** — confirmed by sending a garbage bearer token through it and observing a successful, fully-authorized response. This means every request qlkube makes runs as cluster-admin regardless of which user is logged into the frontend, and any RBAC configured by the operator has no real effect locally.
+In the basic local setup, qlkube (in `IN_CLUSTER=false` mode) talks to the API server through `kubectl proxy` (`http://localhost:8001`).
+**`kubectl proxy` always authenticates using its own kubeconfig credentials, and completely ignores whatever `Authorization` header the client sends.**
+We confirmed this by sending a garbage bearer token through it, and getting back a successful, fully-authorized response anyway.
+This means every request qlkube makes runs as cluster-admin, no matter which user is logged into the frontend.
+Any RBAC rule configured by the operator has no real effect locally.
 
-To actually exercise per-user RBAC locally (and catch RBAC bugs before they reach a real cluster), the apiserver needs to validate the user's own OIDC token directly, and qlkube needs to forward that token to the apiserver instead of routing through `kubectl proxy`.
+To actually exercise per-user RBAC locally, and catch RBAC bugs before they reach a real cluster, the API server needs to validate the user's own OIDC token directly.
+qlkube also needs to forward that token to the API server, instead of routing through `kubectl proxy`.
 
 ## Overview of what changes
 
-1. Two extra Keycloak protocol mappers are added: one to expose the user's client roles as a `groups` claim, one to make sure the `k8s` client is present in its own token's `aud` claim.
-2. qlkube gets a new mode (`USE_LOCAL_CLUSTER=true`) that talks to the real apiserver directly instead of through `kubectl proxy`.
-3. k3s's apiserver gets `--oidc-*` flags pointing at Keycloak's `HTTPRoute` hostname (`keycloak.crownlabs.local`, behind the shared Gateway — TLS is required for k3s to accept the issuer at all, and it's the Gateway that terminates it, not Keycloak itself).
-4. The base CrownLabs `ClusterRole`/`ClusterRoleBinding` resources (normally installed by the Helm chart, never applied when running the operators directly via `go run`) get applied so RBAC actually has something to grant.
+1. Two extra Keycloak protocol mappers are added: one exposes the user's client roles as a `groups` claim, and the other makes sure the `k8s` client is present in its own token's `aud` claim.
+2. qlkube gets a new mode (`USE_LOCAL_CLUSTER=true`) that talks to the real API server directly, instead of going through `kubectl proxy`.
+3. k3s's API server gets `--oidc-*` flags pointing at Keycloak's `HTTPRoute` hostname (`keycloak.crownlabs.local`, behind the shared Gateway). TLS is required for k3s to accept the issuer at all, and the Gateway terminates that TLS, not Keycloak itself.
+4. The base CrownLabs `ClusterRole` and `ClusterRoleBinding` resources get applied, so RBAC actually has something to grant. The Helm chart normally installs these, but they are never applied when you run the operators directly with `go run`.
 
-> **If you installed Keycloak from this folder's `manifests/`** (see [`README.md`](README.md)), Step 1 below is already baked in — the `groups`/`k8s-audience` client scopes are part of the imported realm. Step 4 (base RBAC) lives in [`../operators/README.md`](../operators/README.md) Step 1 instead, since it's really a prerequisite of running the operator, not of Keycloak itself. Skip ahead to Step 3 for the rest. Steps 1 and 4 are kept here in full for reference and rationale.
+> **If you installed Keycloak from this folder's `manifests/`** (see [`README.md`](README.md)), step 1 below is already done: the `groups` and `k8s-audience` client scopes are part of the imported realm.
+> Step 4 (base RBAC) lives in [`../operators/README.md`](../operators/README.md), step 1, instead, because it is really a prerequisite for running the operator, not for Keycloak itself.
+> You can skip ahead to step 3.
+> Steps 1 and 4 stay here in full, for reference and rationale.
 
 ## Step 1 — Keycloak realm configuration
 
 ### 1.1 `groups` claim from client roles
 
-CrownLabs' operator binds `ClusterRoleBinding`/`RoleBinding` `Subject`s of `Kind: Group` with names like `kubernetes:workspace-tea:manager` (see `operators/pkg/forge/rbac.go`, `rolebinding.go`). For the apiserver to resolve a user into these groups, the token must carry a `groups` claim listing the user's raw Keycloak client roles (the `kubernetes:` prefix is added by the apiserver itself via `--oidc-groups-prefix`, not by Keycloak).
+The CrownLabs operator binds `ClusterRoleBinding` and `RoleBinding` subjects of `Kind: Group`, with names like `kubernetes:workspace-tea:manager` (see `operators/pkg/forge/rbac.go` and `rolebinding.go`).
+For the API server to resolve a user into these groups, the token must carry a `groups` claim that lists the user's raw Keycloak client roles.
+The API server itself adds the `kubernetes:` prefix, through the `--oidc-groups-prefix` flag. Keycloak does not add it.
 
 ```bash
 TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/master/protocol/openid-connect/token \
@@ -37,9 +51,9 @@ curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client
 GROUPS_SCOPE_ID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
   -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print([s['id'] for s in json.load(sys.stdin) if s['name']=='groups'][0])")
 
-# NOTE: 'usermodel.clientRoleMapping.clientId' must be the client that ACTUALLY holds the
-# workspace-*:role client roles — this is whatever you passed as --keycloak-roles-client-id
-# to the operator (operator-local in this local setup).
+# Note: "usermodel.clientRoleMapping.clientId" must be the client that actually holds the
+# workspace-*:role client roles. This is whatever you passed as --keycloak-roles-client-id
+# to the operator ("operator-local" in this local setup).
 curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes/$GROUPS_SCOPE_ID/protocol-mappers/models" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{
@@ -66,7 +80,10 @@ curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients
 
 ### 1.2 `aud` (audience) fix
 
-By default, Keycloak does **not** include a client's own `clientId` in the `aud` claim of the tokens it issues to that client — only clients that have a role-mapping pointing at them (like `operator-local`, added implicitly by the mapper above) or the built-in `account` client end up in `aud`. Kubernetes' OIDC authenticator requires `--oidc-client-id` to be present in the token's `aud`, so without this fix every request would fail with an audience mismatch, even though the token is otherwise perfectly valid.
+By default, Keycloak does **not** include a client's own `clientId` in the `aud` claim of the tokens it issues to that client.
+Only clients that have a role-mapping pointing at them (like `operator-local`, added implicitly by the mapper above), or the built-in `account` client, end up in `aud`.
+Kubernetes' OIDC authenticator requires `--oidc-client-id` to be present in the token's `aud`.
+Without this fix, every request would fail with an audience mismatch, even though the token is otherwise perfectly valid.
 
 ```bash
 curl -sk -X POST "https://keycloak.crownlabs.local/admin/realms/crownlabs/client-scopes" \
@@ -91,7 +108,8 @@ curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients
 
 ### 1.3 Verify the token shape
 
-Temporarily enable direct access grants on `k8s` to pull a password-grant test token (remember to disable it again afterwards — it's off by default for a reason):
+Temporarily enable direct access grants on the `k8s` client, so you can pull a password-grant test token.
+Remember to disable this again afterwards: it is off by default for a reason.
 
 ```bash
 curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID" \
@@ -109,9 +127,9 @@ p = json.loads(base64.urlsafe_b64decode(s))
 print('iss:', p.get('iss')); print('aud:', p.get('aud'))
 print('preferred_username:', p.get('preferred_username')); print('groups:', p.get('groups'))
 "
-# expected: iss matches https://keycloak.crownlabs.local/realms/crownlabs exactly
-# (WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs),
-# aud contains "k8s", preferred_username is the plain username, groups lists workspace-*:role entries
+# Expected: "iss" matches https://keycloak.crownlabs.local/realms/crownlabs exactly.
+# On WSL2: https://keycloak.crownlabs.local:8443/realms/crownlabs.
+# "aud" contains "k8s". "preferred_username" is the plain username. "groups" lists workspace-*:role entries.
 
 curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$K8S_UUID" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -120,18 +138,19 @@ curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients
 
 ## Step 2 — Base CrownLabs RBAC resources (rationale)
 
-The top-level Helm chart (`deploy/crownlabs/templates/clusterroles.yaml` and `clusterrolebindings.yaml`) defines the base `ClusterRole`s the operator's per-tenant/per-workspace bindings reference (`crownlabs-manage-tenants`, `crownlabs-manage-instances`, `crownlabs-view-workspaces`, ...), plus a couple of `ClusterRoleBinding`s to the built-in `system:authenticated` group (any logged-in user can *view* workspaces and image lists, needed for the enrollment/discovery UI). **None of this exists if you only ran the operators locally via `go run`** — the gap is invisible under `kubectl proxy` (which never checks RBAC) and only surfaces once the apiserver starts doing real authorization.
+The top-level Helm chart (`deploy/crownlabs/templates/clusterroles.yaml` and `clusterrolebindings.yaml`) defines the base `ClusterRole`s that the operator's per-tenant and per-workspace bindings reference (`crownlabs-manage-tenants`, `crownlabs-manage-instances`, `crownlabs-view-workspaces`, and others).
+It also defines a couple of `ClusterRoleBinding`s to the built-in `system:authenticated` group, so any logged-in user can *view* workspaces and image lists. The enrollment and discovery UI needs this.
+**None of this exists if you only ran the operators locally with `go run`.**
+This gap stays invisible under `kubectl proxy`, which never checks RBAC, and only shows up once the API server starts doing real authorization.
 
-Rather than hand-maintaining a de-templated copy of those two files (which can silently drift from the real chart), [`../operators/README.md`](../operators/README.md) Step 1 renders them straight from `deploy/crownlabs` with `helm template -s templates/clusterroles.yaml -s templates/clusterrolebindings.yaml` and pipes the result into `kubectl apply`. Nothing to run here beyond that; this section only exists to explain why that step is there. These are purely additive RBAC definitions — creating a `ClusterRole` grants nothing by itself until something is bound to it, so applying them is always safe.
+Rather than hand-maintaining a de-templated copy of those two files, which can silently drift from the real chart, [`../operators/README.md`](../operators/README.md), step 1, renders them straight from `deploy/crownlabs` with `helm template -s templates/clusterroles.yaml -s templates/clusterrolebindings.yaml`, and pipes the result into `kubectl apply`.
+There is nothing to run here beyond that: this section only explains why that step exists.
+These RBAC definitions are purely additive: creating a `ClusterRole` grants nothing by itself, until something is bound to it. So applying them is always safe.
 
-## Step 3 — Configure the k3s apiserver
+## Step 3 — Configure the k3s API server
 
-Write a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/`
-(requires root) instead of editing the shared `/etc/rancher/k3s/config.yaml`
-— k3s merges every `*.yaml` there automatically, so this can't clobber
-whatever [`../base-k3s/README.md`](../base-k3s/README.md) (kubeconfig
-access) or [`../envoy/README.md`](../envoy/README.md) (disabling Traefik)
-already put there:
+Write a dedicated drop-in file under `/etc/rancher/k3s/config.yaml.d/` (this requires root), instead of editing the shared `/etc/rancher/k3s/config.yaml` file directly.
+k3s automatically merges every `*.yaml` file there, so this cannot clobber anything that [`../base-k3s/README.md`](../base-k3s/README.md) (kubeconfig access) or [`../envoy/README.md`](../envoy/README.md) (disabling Traefik) already put there:
 
 ```bash
 sudo mkdir -p /etc/rancher/k3s/config.yaml.d
@@ -147,14 +166,16 @@ kube-apiserver-arg:
 EOF
 ```
 
-On WSL2, use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs` instead (the Gateway bridge port, see [`../envoy/README.md`](../envoy/README.md) step 5 / `README.md` step 2).
+On WSL2, use `oidc-issuer-url=https://keycloak.crownlabs.local:8443/realms/crownlabs` instead (the Gateway bridge port, see [`../envoy/README.md`](../envoy/README.md) step 5, or `README.md` step 2).
 
 Notes on each flag:
-- `oidc-issuer-url` must match the token's `iss` claim **exactly** (scheme, host, port, path) — it reflects whatever URL the browser/frontend uses to reach Keycloak, not an arbitrary internal address.
-- `oidc-username-prefix=-` is required explicitly: without it, some k8s versions prefix the username with the issuer URL (`https://...#john.doe`), which won't match the plain `john.doe` used in the operator's `RoleBinding`/`ClusterRoleBinding` subjects.
-- `oidc-ca-file` is required because the apiserver's own HTTP client won't trust a self-signed certificate by default — it needs an explicit copy of the certificate to fetch the OIDC discovery document and JWKS. This is the Gateway's wildcard cert now (`crownlabs-tls`), not a Keycloak-specific one — see [`../envoy/README.md`](../envoy/README.md).
+- `oidc-issuer-url` must match the token's `iss` claim **exactly** (scheme, host, port, path). It reflects whatever URL the browser or frontend uses to reach Keycloak, not an arbitrary internal address.
+- `oidc-username-prefix=-` is required explicitly. Without it, some Kubernetes versions prefix the username with the issuer URL (`https://...#john.doe`), which will not match the plain `john.doe` used in the operator's `RoleBinding` and `ClusterRoleBinding` subjects.
+- `oidc-ca-file` is required because the API server's own HTTP client does not trust a self-signed certificate by default. It needs an explicit copy of the certificate to fetch the OIDC discovery document and the JWKS. This is the Gateway's wildcard certificate (`crownlabs-tls`) now, not a Keycloak-specific one. See [`../envoy/README.md`](../envoy/README.md).
 
-Extract the CA certificate from the `crownlabs-tls` Secret (cert-manager populates `ca.crt` there — see [`../envoy/README.md`](../envoy/README.md)) into a user-owned copy, reused below for the operator's `SSL_CERT_FILE` too, then copy it where the (root-owned) apiserver config expects it and restart:
+Extract the CA certificate from the `crownlabs-tls` Secret into a user-owned copy (cert-manager stores it under `ca.crt` there, see [`../envoy/README.md`](../envoy/README.md)).
+You reuse this same copy below, for the operator's `SSL_CERT_FILE` too.
+Then copy it where the root-owned API server configuration expects it, and restart:
 
 ```bash
 mkdir -p ~/certs
@@ -162,10 +183,12 @@ kubectl get secret crownlabs-tls -n default -o jsonpath='{.data.ca\.crt}' | base
 
 sudo cp ~/certs/crownlabs-ca.crt /etc/rancher/k3s/crownlabs-ca.crt
 sudo systemctl restart k3s
-journalctl -u k3s -f   # confirm no "invalid authentication configuration" error, Ctrl+C once it's up
+journalctl -u k3s -f   # Confirm there is no "invalid authentication configuration" error, then press Ctrl+C.
 ```
 
-**This restarts the whole control plane** (running pods survive, but the apiserver is briefly unreachable, and any process with an open watch/proxy connection to it — `kubectl proxy`, `kubectl port-forward`, the operators — will need to be restarted afterwards). Get everything (`kubectl get nodes`) confirmed healthy before moving on.
+**This restarts the whole control plane.**
+Running pods survive, but the API server is briefly unreachable, and any process with an open watch or proxy connection to it (`kubectl proxy`, `kubectl port-forward`, the operators) needs restarting afterwards.
+Confirm everything is healthy (`kubectl get nodes`) before you move on.
 
 ### If you need to roll this back
 
@@ -174,22 +197,28 @@ sudo rm /etc/rancher/k3s/config.yaml.d/30-keycloak-oidc.yaml
 sudo systemctl restart k3s
 ```
 
-## Step 4 — qlkube: talk to the real apiserver
+## Step 4 — qlkube: talk to the real API server
 
-`qlkube/src/index.js` now has a `USE_LOCAL_CLUSTER=true` mode that bypasses `kubectl proxy` and connects directly to `https://localhost:6443` (or `LOCAL_K8S_API_URL` if set), forwarding whatever bearer token it receives as-is instead of it being silently discarded. This talks to the apiserver's own port directly (unrelated to the Gateway/Keycloak hostname above).
+`qlkube/src/index.js` now has a `USE_LOCAL_CLUSTER=true` mode that bypasses `kubectl proxy`, and connects directly to `https://localhost:6443` (or to `LOCAL_K8S_API_URL`, if you set it).
+This mode forwards whatever bearer token it receives as-is, instead of silently discarding it.
+It talks to the API server's own port directly, which is unrelated to the Gateway/Keycloak hostname used above.
 
-Two things this needs that `kubectl proxy` didn't:
+This mode needs two things that `kubectl proxy` did not need:
 
-**A trusted-but-self-signed TLS connection.** Set `NODE_TLS_REJECT_UNAUTHORIZED=0` when starting qlkube this way (already wired into the `dev-local-cluster` npm script). This is acceptable for local dev only — it disables certificate verification for the whole Node process.
+**A trusted-but-self-signed TLS connection.** Set `NODE_TLS_REJECT_UNAUTHORIZED=0` when you start qlkube this way (this is already wired into the `dev-local-cluster` npm script). This is acceptable for local development only: it disables certificate verification for the whole Node process.
 
-**A credential for the one-off OpenAPI schema discovery call at startup**, which happens before any user request exists. `kubectl proxy` used its own kubeconfig for this regardless of what you sent it; talking to the real apiserver means this call is genuinely unauthenticated unless you provide something. k3s's default kubeconfig uses **client-certificate auth (mTLS)**, not a bearer token, so it can't be reused directly here — create a small dedicated `ServiceAccount` instead, scoped to exactly what discovery needs (nothing more):
+**A credential for the one-off OpenAPI schema discovery call at startup**, which happens before any user request exists.
+`kubectl proxy` used its own kubeconfig for this, regardless of what you sent it.
+Talking to the real API server means this call is genuinely unauthenticated, unless you provide something.
+k3s's default kubeconfig uses **client-certificate authentication (mTLS)**, not a bearer token, so you cannot reuse it directly here.
+Instead, create a small, dedicated `ServiceAccount`, scoped to exactly what discovery needs, and nothing more:
 
 ```bash
 kubectl create serviceaccount qlkube-local -n default
 kubectl create clusterrolebinding qlkube-local-discovery --clusterrole=system:discovery --serviceaccount=default:qlkube-local
 ```
 
-Generate a long-lived token for it and export it before starting qlkube (never commit this token anywhere):
+Generate a long-lived token for it, and export it before starting qlkube. Never commit this token anywhere:
 
 ```bash
 export LOCAL_K8S_BOOTSTRAP_TOKEN=$(kubectl create token qlkube-local -n default --duration=87600h)
@@ -201,7 +230,7 @@ Verify:
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8085/graph/schema
-# expected: 200, and the qlkube log should show "OpenApi retrieved" with baseUrl https://localhost:6443
+# Expected: 200. The qlkube log should also show "OpenApi retrieved", with baseUrl https://localhost:6443.
 ```
 
 ## Step 5 — Frontend configuration
@@ -214,17 +243,27 @@ VITE_APP_CROWNLABS_GRAPHQL_URL=http://localhost:8085/graph
 
 On WSL2, use `https://keycloak.crownlabs.local:8443/realms/crownlabs` for `VITE_APP_CROWNLABS_OIDC_AUTHORITY` instead.
 
-Restart the frontend dev server after changing `.env` (Vite does not hot-reload environment variables).
+Restart the frontend dev server after changing `.env`. Vite does not hot-reload environment variables.
 
 ### Trusting the self-signed certificate in the browser
 
-The frontend's OIDC library makes background `fetch()` calls (discovery document, token exchange, silent renew) directly to `https://keycloak.crownlabs.local`. A browser will silently fail these with `ERR_CERT_AUTHORITY_INVALID` for an untrusted self-signed certificate — this manifests as an **infinite login redirect loop with no visible error**, because the app can't tell "the network call to refresh my session failed" apart from "the session is genuinely gone", and reacts to both by forcing a fresh Keycloak login (`AuthContextProvider.tsx`'s `execLogin` logic — see `dev-local/local-development.md` troubleshooting table).
+The frontend's OIDC library makes background `fetch()` calls (the discovery document, token exchange, silent renew) directly to `https://keycloak.crownlabs.local`.
+A browser silently fails these calls with `ERR_CERT_AUTHORITY_INVALID`, for an untrusted self-signed certificate.
+This shows up as an **infinite login redirect loop, with no visible error**, because the app cannot tell "the network call to refresh my session failed" apart from "the session is genuinely gone".
+It reacts to both cases the same way, by forcing a fresh Keycloak login (see `AuthContextProvider.tsx`'s `execLogin` logic, and the troubleshooting table in `dev-local/local-development.md`).
 
-Fix: visit `https://keycloak.crownlabs.local/realms/crownlabs/.well-known/openid-configuration` (WSL2: `https://keycloak.crownlabs.local:8443/...`) directly in the same browser once, click through the "not private" warning ("Advanced" → "Proceed"), then reload the app. The browser now trusts that origin for the rest of the session.
+Fix: visit `https://keycloak.crownlabs.local/realms/crownlabs/.well-known/openid-configuration` (on WSL2: `https://keycloak.crownlabs.local:8443/...`) directly, once, in the same browser.
+Click through the "not private" warning ("Advanced" → "Proceed"), then reload the app.
+The browser now trusts that origin for the rest of the session.
 
 ## Step 6 — Make sure every namespace tenants touch is a real, enrolled Workspace
 
-Any namespace used for sample `Instance`/`Template` resources needs a matching `Workspace` custom resource with the tenant actually enrolled in it — otherwise the operator never creates the Keycloak `workspace-<name>:*` roles or the `RoleBinding`s that grant access, and any real per-user RBAC check on that namespace's `templates`/`instances` fails with `403 Forbidden`. This is invisible under `kubectl proxy` (admin can read anything) and only shows up once RBAC is actually enforced. If you have ad-hoc namespaces (e.g. a `workspace-standalone` created by hand for miscellaneous sample templates, with no corresponding `Workspace` CR), create the missing `Workspace` and enroll the tenant:
+Any namespace used for sample `Instance` or `Template` resources needs a matching `Workspace` custom resource, with the tenant actually enrolled in it.
+Otherwise, the operator never creates the Keycloak `workspace-<name>:*` roles, or the `RoleBinding`s that grant access.
+Any real per-user RBAC check on that namespace's `templates` or `instances` then fails with `403 Forbidden`.
+This stays invisible under `kubectl proxy`, since the admin user can read anything, and only shows up once RBAC is actually enforced.
+
+If you have ad-hoc namespaces (for example, a `workspace-standalone` namespace, created by hand for miscellaneous sample templates, with no corresponding `Workspace` CR), create the missing `Workspace` and enroll the tenant:
 
 ```bash
 kubectl apply -f - <<'EOF'
@@ -243,7 +282,7 @@ kubectl patch tenant john.doe --type='json' \
   -p='[{"op": "add", "path": "/spec/workspaces/-", "value": {"name": "standalone", "role": "manager"}}]'
 ```
 
-The operator (if running) picks this up automatically and creates the corresponding Keycloak roles within a few seconds — verify with:
+If the operator is running, it picks this up automatically, and creates the corresponding Keycloak roles within a few seconds. Verify with:
 
 ```bash
 TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/master/protocol/openid-connect/token \
@@ -255,11 +294,14 @@ curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$OP_UU
   | python3 -c "import json,sys; print([r['name'] for r in json.load(sys.stdin) if 'standalone' in r['name']])"
 ```
 
-**The frontend's already-issued token won't reflect the new role until it refreshes** — log out and back in (or wait for the ~5 minute silent-refresh cycle) after enrolling a tenant in a new workspace.
+**The frontend's already-issued token will not reflect the new role until it refreshes.**
+Log out and back in (or wait for the roughly 5-minute silent-refresh cycle) after you enroll a tenant in a new workspace.
 
 ## Restarting the operator against Keycloak
 
-The operator's Keycloak client (`gocloak`, a plain Go `http.Client` under the hood) also needs to trust the self-signed certificate presented at the Gateway. Go's `crypto/x509` respects the `SSL_CERT_FILE` environment variable on Linux for loading extra trusted roots — point it at the same `~/certs/crownlabs-ca.crt` extracted in Step 3, then use the `run-operator-local` Makefile target (see [`../operators/README.md`](../operators/README.md) Step 2):
+The operator's Keycloak client (`gocloak`, a plain Go `http.Client` under the hood) also needs to trust the self-signed certificate presented at the Gateway.
+Go's `crypto/x509` respects the `SSL_CERT_FILE` environment variable on Linux, for loading extra trusted roots.
+Point it at the same `~/certs/crownlabs-ca.crt` file you extracted in step 3, then use the `run-operator-local` Makefile target (see [`../operators/README.md`](../operators/README.md), step 2):
 
 ```bash
 export SSL_CERT_FILE=~/certs/crownlabs-ca.crt
@@ -273,18 +315,18 @@ On WSL2, also override `KEYCLOAK_URL` to the bridge port: `make run-operator-loc
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| k3s fails to start: `jwt[0].issuer.url: ... URL scheme must be https` | k3s 1.34+ hard-rejects non-HTTPS OIDC issuers | Confirm the Gateway's HTTPS listener is up ([`../envoy/README.md`](../envoy/README.md)) — TLS lives there now, not on Keycloak itself |
-| `403 Forbidden` from apiserver even after `--oidc-*` flags are set | Base CrownLabs `ClusterRole`s not installed (never applied outside Helm) | Render and apply them via `helm template` — [`../operators/README.md`](../operators/README.md) Step 1 (rationale: Step 2 of this doc) |
-| Token rejected / audience mismatch | `k8s` client's own `clientId` missing from its token's `aud` (Keycloak doesn't add it by default) | Add the audience mapper (Step 1.2) |
-| Token rejected / issuer mismatch (WSL2 only) | Keycloak (`KC_HOSTNAME_STRICT=false`) reports its issuer **without** a port regardless of which port the request came in on — tested and confirmed, Envoy Gateway doesn't forward `X-Forwarded-Port` — so it doesn't byte-for-byte match an `oidc-issuer-url` ending in `:8443` | Pin `KC_HOSTNAME=https://keycloak.crownlabs.local:8443` explicitly, see [`README.md`](README.md) step 1 |
-| Apiserver can't validate the OIDC discovery document | Self-signed cert not trusted by the apiserver's HTTP client | Add `--oidc-ca-file` pointing at the Gateway's wildcard CA (Step 3) |
-| Frontend stuck in an infinite login redirect loop, no visible error | Browser doesn't trust the self-signed cert; background OIDC fetches fail silently, app treats it as a stale session and forces re-login | Visit the Keycloak URL directly once and accept the browser warning (Step 5) |
-| qlkube: `connect ECONNREFUSED` on the OpenAPI discovery call | Direct-apiserver mode with no bootstrap credential (unlike `kubectl proxy`, which never needed one) | Set `LOCAL_K8S_BOOTSTRAP_TOKEN` (Step 4) |
-| qlkube: `SELF_SIGNED_CERT_IN_CHAIN` talking to `localhost:6443` | Node's default TLS verification rejects the apiserver's cert | `NODE_TLS_REJECT_UNAUTHORIZED=0` (already in `dev-local-cluster` script) |
-| Operator can't reach Keycloak (`x509: certificate signed by unknown authority`) | Go's HTTP client doesn't trust the self-signed cert either | `export SSL_CERT_FILE=<path-to-cert>` before starting the operator |
-| `403 Forbidden` reading `templates`/`instances` in a specific `workspace-*` namespace | The tenant was never actually enrolled in a matching `Workspace` CR (ad-hoc namespace, no membership) | Create the `Workspace` and enroll the tenant (Step 6); log out/in afterwards to get a fresh token |
-| `403 Forbidden` on a namespace/role that worked before, after running `make run-operator-local`/`run-instance-local` again | `operators/samples/` got re-applied as a target prerequisite; `kubectl apply`'s 3-way merge silently reverted a `kubectl patch`-only change (e.g. a `Workspace` enrollment added per Step 6) that was never reflected in the checked-in sample file | Re-apply the `kubectl patch`; log out/in for a fresh token. See the "Gotcha" note in `../operators/README.md` Step 2 |
-| `bind: address already in use` restarting the operator or qlkube | The actual compiled Go/Node binary survived independently of the `go run`/`npm run` wrapper process that appeared to exit (e.g. across a k3s restart) | Find the real PID via `ss -tlnp \| grep <port>` (the process name is the compiled binary, e.g. `imagelist`, not `go run`) and `kill -9` it directly |
-| A `kubectl port-forward`/operator/qlkube process dies right after `systemctl restart k3s` | Expected — restarting k3s restarts the whole control plane, dropping any open connection to it | Restart the affected process once `kubectl get nodes` reports `Ready` again |
-| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket; WSL2's `localhostForwarding` only relays real sockets | Bridge with `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` and append `:8443` everywhere — see [`../envoy/README.md`](../envoy/README.md) step 5 |
-| Operator: `dial tcp 127.0.0.1:XXXXX: i/o timeout` reaching Keycloak (WSL2 only) | The port-forward bridge reused the *same* port number as the Gateway's own 80/443 — kube-proxy's own iptables rules for those ports hijack local loopback traffic to them before it reaches the port-forward's listener | Use a bridge port different from 80/443 (`:8443`, not `:443`) |
+| k3s fails to start: `jwt[0].issuer.url: ... URL scheme must be https` | k3s 1.34+ hard-rejects non-HTTPS OIDC issuers | Confirm the Gateway's HTTPS listener is up ([`../envoy/README.md`](../envoy/README.md)). TLS lives there now, not on Keycloak itself |
+| `403 Forbidden` from the API server, even after `--oidc-*` flags are set | Base CrownLabs `ClusterRole`s not installed (never applied outside Helm) | Render and apply them with `helm template` — [`../operators/README.md`](../operators/README.md) step 1 (rationale in step 2 of this doc) |
+| Token rejected, audience mismatch | The `k8s` client's own `clientId` is missing from its token's `aud` (Keycloak does not add it by default) | Add the audience mapper (step 1.2) |
+| Token rejected, issuer mismatch (WSL2 only) | Keycloak (`KC_HOSTNAME_STRICT=false`) reports its issuer **without** a port, no matter which port the request came in on. Envoy Gateway does not forward `X-Forwarded-Port`, so this does not byte-for-byte match an `oidc-issuer-url` ending in `:8443` | Pin `KC_HOSTNAME=https://keycloak.crownlabs.local:8443` explicitly, see [`README.md`](README.md) step 1 |
+| API server cannot validate the OIDC discovery document | Self-signed certificate not trusted by the API server's HTTP client | Add `--oidc-ca-file`, pointing at the Gateway's wildcard CA (step 3) |
+| Frontend stuck in an infinite login redirect loop, no visible error | Browser does not trust the self-signed certificate. Background OIDC calls fail silently, and the app treats this as a stale session, forcing a re-login | Visit the Keycloak URL directly once, and accept the browser warning (step 5) |
+| qlkube: `connect ECONNREFUSED` on the OpenAPI discovery call | Direct-API-server mode has no bootstrap credential (unlike `kubectl proxy`, which never needed one) | Set `LOCAL_K8S_BOOTSTRAP_TOKEN` (step 4) |
+| qlkube: `SELF_SIGNED_CERT_IN_CHAIN` talking to `localhost:6443` | Node's default TLS verification rejects the API server's certificate | Set `NODE_TLS_REJECT_UNAUTHORIZED=0` (already in the `dev-local-cluster` script) |
+| Operator cannot reach Keycloak (`x509: certificate signed by unknown authority`) | Go's HTTP client does not trust the self-signed certificate either | `export SSL_CERT_FILE=<path-to-certificate>` before starting the operator |
+| `403 Forbidden` reading `templates` or `instances` in a specific `workspace-*` namespace | The tenant was never actually enrolled in a matching `Workspace` CR (ad-hoc namespace, no membership) | Create the `Workspace` and enroll the tenant (step 6); log out and back in afterwards, for a fresh token |
+| `403 Forbidden` on a namespace or role that worked before, after running `make run-operator-local` or `run-instance-local` again | `operators/samples/` got re-applied as a target prerequisite. `kubectl apply`'s 3-way merge silently reverted a `kubectl patch`-only change (for example, a `Workspace` enrollment added per step 6) that was never reflected in the checked-in sample file | Re-apply the `kubectl patch`; log out and back in, for a fresh token. See the "Gotcha" note in `../operators/README.md`, step 2 |
+| `bind: address already in use` restarting the operator or qlkube | The actual compiled Go or Node binary survived independently of the `go run` or `npm run` wrapper process that appeared to exit (for example, across a k3s restart) | Find the real PID with `ss -tlnp \| grep <port>` (the process name is the compiled binary, for example `imagelist`, not `go run`), then `kill -9` it directly |
+| A `kubectl port-forward`, operator, or qlkube process dies right after `systemctl restart k3s` | Expected: restarting k3s restarts the whole control plane, dropping any open connection to it | Restart the affected process once `kubectl get nodes` reports `Ready` again |
+| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket. WSL2's `localhostForwarding` only relays real sockets | Bridge with `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443`, and append `:8443` everywhere. See [`../envoy/README.md`](../envoy/README.md) step 5 |
+| Operator: `dial tcp 127.0.0.1:XXXXX: i/o timeout` reaching Keycloak (WSL2 only) | The port-forward bridge reused the *same* port number as the Gateway's own 80/443. kube-proxy's own `iptables` rules for those ports hijack local loopback traffic before it reaches the port-forward's listener | Use a bridge port different from 80/443 (`:8443`, not `:443`) |

--- a/dev-local/keycloak/manifests/crownlabs-realm-configmap.yaml
+++ b/dev-local/keycloak/manifests/crownlabs-realm-configmap.yaml
@@ -1,0 +1,2377 @@
+# Generated from a `kc.sh export` of the crownlabs realm — do not hand-edit.
+# See ../README.md, "Regenerating the export", to refresh this file.
+apiVersion: v1
+data:
+  crownlabs-realm.json: |-
+    {
+      "id" : "3fb20f65-5a04-41f6-9f27-dd2d8a53f460",
+      "realm" : "crownlabs",
+      "notBefore" : 0,
+      "defaultSignatureAlgorithm" : "RS256",
+      "revokeRefreshToken" : false,
+      "refreshTokenMaxReuse" : 0,
+      "accessTokenLifespan" : 300,
+      "accessTokenLifespanForImplicitFlow" : 900,
+      "ssoSessionIdleTimeout" : 1800,
+      "ssoSessionMaxLifespan" : 36000,
+      "ssoSessionIdleTimeoutRememberMe" : 0,
+      "ssoSessionMaxLifespanRememberMe" : 0,
+      "offlineSessionIdleTimeout" : 2592000,
+      "offlineSessionMaxLifespanEnabled" : false,
+      "offlineSessionMaxLifespan" : 5184000,
+      "clientSessionIdleTimeout" : 0,
+      "clientSessionMaxLifespan" : 0,
+      "clientOfflineSessionIdleTimeout" : 0,
+      "clientOfflineSessionMaxLifespan" : 0,
+      "accessCodeLifespan" : 60,
+      "accessCodeLifespanUserAction" : 300,
+      "accessCodeLifespanLogin" : 1800,
+      "actionTokenGeneratedByAdminLifespan" : 43200,
+      "actionTokenGeneratedByUserLifespan" : 300,
+      "oauth2DeviceCodeLifespan" : 600,
+      "oauth2DevicePollingInterval" : 5,
+      "enabled" : true,
+      "sslRequired" : "external",
+      "registrationAllowed" : false,
+      "registrationEmailAsUsername" : false,
+      "rememberMe" : false,
+      "verifyEmail" : false,
+      "loginWithEmailAllowed" : true,
+      "duplicateEmailsAllowed" : false,
+      "resetPasswordAllowed" : false,
+      "editUsernameAllowed" : false,
+      "bruteForceProtected" : false,
+      "permanentLockout" : false,
+      "maxTemporaryLockouts" : 0,
+      "bruteForceStrategy" : "MULTIPLE",
+      "maxFailureWaitSeconds" : 900,
+      "minimumQuickLoginWaitSeconds" : 60,
+      "waitIncrementSeconds" : 60,
+      "quickLoginCheckMilliSeconds" : 1000,
+      "maxDeltaTimeSeconds" : 43200,
+      "failureFactor" : 30,
+      "roles" : {
+        "realm" : [ {
+          "id" : "a8d8beea-57c7-4f41-ab27-13494b336c59",
+          "name" : "offline_access",
+          "description" : "${role_offline-access}",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "3fb20f65-5a04-41f6-9f27-dd2d8a53f460",
+          "attributes" : { }
+        }, {
+          "id" : "4f19670b-5822-42db-b413-63a0e085793b",
+          "name" : "uma_authorization",
+          "description" : "${role_uma_authorization}",
+          "composite" : false,
+          "clientRole" : false,
+          "containerId" : "3fb20f65-5a04-41f6-9f27-dd2d8a53f460",
+          "attributes" : { }
+        }, {
+          "id" : "c9504c6f-2c20-4983-8091-f005ac5a24a9",
+          "name" : "default-roles-crownlabs",
+          "description" : "${role_default-roles}",
+          "composite" : true,
+          "composites" : {
+            "realm" : [ "offline_access", "uma_authorization" ],
+            "client" : {
+              "account" : [ "manage-account", "view-profile" ]
+            }
+          },
+          "clientRole" : false,
+          "containerId" : "3fb20f65-5a04-41f6-9f27-dd2d8a53f460",
+          "attributes" : { }
+        } ],
+        "client" : {
+          "realm-management" : [ {
+            "id" : "c91eda17-ed60-4e39-8ba1-959e5fba32d2",
+            "name" : "realm-admin",
+            "description" : "${role_realm-admin}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "query-clients", "query-users", "view-clients", "create-client", "manage-events", "manage-realm", "manage-authorization", "view-users", "view-authorization", "view-events", "manage-users", "view-identity-providers", "query-groups", "impersonation", "view-realm", "query-realms", "manage-identity-providers", "manage-clients" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "623dd9f5-fa77-4f5e-aaae-a8b35e1349dc",
+            "name" : "query-clients",
+            "description" : "${role_query-clients}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "1337d042-7fd6-4122-9412-8a5b0623f4b8",
+            "name" : "query-users",
+            "description" : "${role_query-users}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "48215948-1ec1-4892-aae4-3ecbafd61501",
+            "name" : "view-clients",
+            "description" : "${role_view-clients}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "query-clients" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "494c86ea-4875-4967-b552-c5aa355f42ce",
+            "name" : "create-client",
+            "description" : "${role_create-client}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "3906f4d4-7057-4f1c-b3a5-a55005987fd8",
+            "name" : "manage-events",
+            "description" : "${role_manage-events}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "e90f0fae-04b2-4aae-b13a-c636960bd736",
+            "name" : "manage-authorization",
+            "description" : "${role_manage-authorization}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "9a81e878-6707-4389-b994-fa121e9138d2",
+            "name" : "manage-realm",
+            "description" : "${role_manage-realm}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "2a32b3fa-799b-44b6-a62a-3478720d1286",
+            "name" : "view-users",
+            "description" : "${role_view-users}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "realm-management" : [ "query-users", "query-groups" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "2130339a-97cf-4afe-a6fb-5c1ad36c90ab",
+            "name" : "view-authorization",
+            "description" : "${role_view-authorization}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "17f034c1-e080-4f4f-bf58-a0f74890b4a0",
+            "name" : "view-events",
+            "description" : "${role_view-events}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "bcae6ff4-57a4-4d14-a95c-33f4babaabed",
+            "name" : "manage-users",
+            "description" : "${role_manage-users}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "b67e1b65-233c-4a70-800f-9fce57113974",
+            "name" : "query-groups",
+            "description" : "${role_query-groups}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "9d0d8147-4ec2-4239-93f9-5a98a8c805b4",
+            "name" : "view-identity-providers",
+            "description" : "${role_view-identity-providers}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "a07fc3cb-1353-41cd-b2ce-c10c2ad18f67",
+            "name" : "impersonation",
+            "description" : "${role_impersonation}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "8fddd476-707e-4d34-99dc-dff3ae5ef198",
+            "name" : "query-realms",
+            "description" : "${role_query-realms}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "60b3007b-248e-4d94-bdea-617098d44c5d",
+            "name" : "view-realm",
+            "description" : "${role_view-realm}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "fa2385d8-9410-4349-ad27-c249674f5606",
+            "name" : "manage-identity-providers",
+            "description" : "${role_manage-identity-providers}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          }, {
+            "id" : "fe8ed0a8-b220-4be0-90dd-bada067e068d",
+            "name" : "manage-clients",
+            "description" : "${role_manage-clients}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "de5debc9-500a-4540-97ae-6283298a6774",
+            "attributes" : { }
+          } ],
+          "security-admin-console" : [ ],
+          "k8s" : [ {
+            "id" : "473b9934-64f3-4603-abad-0255432742dc",
+            "name" : "workspace-coffee:user",
+            "description" : "Just coffee User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          }, {
+            "id" : "65372e2a-ca09-4ace-90cc-64a0799eff51",
+            "name" : "workspace-chill-pepper:user",
+            "description" : "A bit spicy User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          }, {
+            "id" : "3eb94b99-4690-4d2f-b5f7-43002e68697b",
+            "name" : "workspace-tea:manager",
+            "description" : "A cup of tea from the queen Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          }, {
+            "id" : "c86dde56-3c46-486d-abbb-54a8629a8bce",
+            "name" : "workspace-chill-pepper:manager",
+            "description" : "A bit spicy Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          }, {
+            "id" : "27b31488-131c-4a75-ac4f-0fd218ce8d68",
+            "name" : "workspace-coffee:manager",
+            "description" : "Just coffee Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          }, {
+            "id" : "6d89122c-6997-4303-8198-aedfef7ed712",
+            "name" : "workspace-tea:user",
+            "description" : "A cup of tea from the queen User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+            "attributes" : { }
+          } ],
+          "operator-local" : [ {
+            "id" : "dce592a2-347e-4f69-939a-9f985cb95667",
+            "name" : "workspace-coffee:manager",
+            "description" : "Just coffee Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          }, {
+            "id" : "d26ca5d9-bf19-432f-bfcf-1338570c3cf4",
+            "name" : "workspace-tea:manager",
+            "description" : "A cup of tea from the queen Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          }, {
+            "id" : "c9245b68-9d40-4e95-bb40-b041ed5508bc",
+            "name" : "workspace-coffee:user",
+            "description" : "Just coffee User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          }, {
+            "id" : "b2116c7d-2b1e-4083-ad66-559a116aaab6",
+            "name" : "workspace-tea:user",
+            "description" : "A cup of tea from the queen User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          }, {
+            "id" : "b3fcd69d-5ca3-4ee5-8049-49511b88e8de",
+            "name" : "workspace-chill-pepper:manager",
+            "description" : "A bit spicy Manager Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          }, {
+            "id" : "89287d64-8951-480e-8aac-8649eb270043",
+            "name" : "workspace-chill-pepper:user",
+            "description" : "A bit spicy User Role",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+            "attributes" : { }
+          } ],
+          "admin-cli" : [ ],
+          "account-console" : [ ],
+          "broker" : [ {
+            "id" : "fa3188b1-d342-48ca-b5ff-a711d5a3bdbb",
+            "name" : "read-token",
+            "description" : "${role_read-token}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "bcb3b116-990e-41a4-a1e1-71c30a0fb11e",
+            "attributes" : { }
+          } ],
+          "account" : [ {
+            "id" : "47cc36e9-080b-4d0c-a171-e7f9fc8cfe2e",
+            "name" : "manage-consent",
+            "description" : "${role_manage-consent}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "account" : [ "view-consent" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "4a83c355-ac18-4925-8440-10820f5f96f2",
+            "name" : "view-consent",
+            "description" : "${role_view-consent}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "310cc2da-228c-42da-9f32-66cac2160b33",
+            "name" : "manage-account",
+            "description" : "${role_manage-account}",
+            "composite" : true,
+            "composites" : {
+              "client" : {
+                "account" : [ "manage-account-links" ]
+              }
+            },
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "d51f8a00-ac87-48e5-bfb0-d4962baae248",
+            "name" : "view-profile",
+            "description" : "${role_view-profile}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "797adbb4-3a2d-4377-be93-96a81fb1bf82",
+            "name" : "manage-account-links",
+            "description" : "${role_manage-account-links}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "5eecd78a-4498-40e3-9d76-53e875886519",
+            "name" : "view-groups",
+            "description" : "${role_view-groups}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "f0a45c35-f6cd-4cd1-a1d1-f3cdabe387fc",
+            "name" : "delete-account",
+            "description" : "${role_delete-account}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          }, {
+            "id" : "92bc1bb5-827b-4e84-8710-1b0161ffa6cc",
+            "name" : "view-applications",
+            "description" : "${role_view-applications}",
+            "composite" : false,
+            "clientRole" : true,
+            "containerId" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+            "attributes" : { }
+          } ]
+        }
+      },
+      "groups" : [ ],
+      "defaultRole" : {
+        "id" : "c9504c6f-2c20-4983-8091-f005ac5a24a9",
+        "name" : "default-roles-crownlabs",
+        "description" : "${role_default-roles}",
+        "composite" : true,
+        "clientRole" : false,
+        "containerId" : "3fb20f65-5a04-41f6-9f27-dd2d8a53f460"
+      },
+      "requiredCredentials" : [ "password" ],
+      "otpPolicyType" : "totp",
+      "otpPolicyAlgorithm" : "HmacSHA1",
+      "otpPolicyInitialCounter" : 0,
+      "otpPolicyDigits" : 6,
+      "otpPolicyLookAheadWindow" : 1,
+      "otpPolicyPeriod" : 30,
+      "otpPolicyCodeReusable" : false,
+      "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+      "localizationTexts" : { },
+      "webAuthnPolicyRpEntityName" : "keycloak",
+      "webAuthnPolicySignatureAlgorithms" : [ "ES256", "RS256" ],
+      "webAuthnPolicyRpId" : "",
+      "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+      "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+      "webAuthnPolicyRequireResidentKey" : "not specified",
+      "webAuthnPolicyUserVerificationRequirement" : "not specified",
+      "webAuthnPolicyCreateTimeout" : 0,
+      "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+      "webAuthnPolicyAcceptableAaguids" : [ ],
+      "webAuthnPolicyExtraOrigins" : [ ],
+      "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+      "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256", "RS256" ],
+      "webAuthnPolicyPasswordlessRpId" : "",
+      "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+      "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+      "webAuthnPolicyPasswordlessRequireResidentKey" : "Yes",
+      "webAuthnPolicyPasswordlessUserVerificationRequirement" : "required",
+      "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+      "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+      "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+      "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+      "users" : [ {
+        "id" : "a34101d3-7c98-4226-bb5c-41b783a8a9b1",
+        "username" : "john.doe",
+        "firstName" : "John",
+        "lastName" : "Doe",
+        "email" : "jonh.doe@email.com",
+        "emailVerified" : true,
+        "enabled" : true,
+        "createdTimestamp" : 1774007497397,
+        "totp" : false,
+        "credentials" : [ {
+          "id" : "c3645a97-47e3-47e6-a70d-ff207e2c7314",
+          "type" : "password",
+          "createdDate" : 1783329319966,
+          "secretData" : "{\"value\":\"iB6huiiwqHBQykaONudeC9U519cdyyTeRO2r22FfIIw=\",\"salt\":\"a265LCeSNKkCfUFHSC9r8Q==\",\"additionalParameters\":{}}",
+          "credentialData" : "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+        } ],
+        "disableableCredentialTypes" : [ ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "default-roles-crownlabs" ],
+        "clientRoles" : {
+          "k8s" : [ "workspace-tea:user", "workspace-coffee:manager" ],
+          "operator-local" : [ "workspace-coffee:manager", "workspace-tea:user" ]
+        },
+        "notBefore" : 0,
+        "groups" : [ ]
+      }, {
+        "id" : "24762427-3cc7-4e0a-a13b-b5e516a3766b",
+        "username" : "service-account-operator-local",
+        "emailVerified" : false,
+        "enabled" : true,
+        "createdTimestamp" : 1774005870109,
+        "totp" : false,
+        "serviceAccountClientId" : "operator-local",
+        "credentials" : [ ],
+        "disableableCredentialTypes" : [ ],
+        "requiredActions" : [ ],
+        "realmRoles" : [ "default-roles-crownlabs" ],
+        "clientRoles" : {
+          "realm-management" : [ "query-clients", "view-events", "manage-users", "view-clients", "manage-events", "manage-clients" ]
+        },
+        "notBefore" : 0,
+        "groups" : [ ]
+      } ],
+      "scopeMappings" : [ {
+        "clientScope" : "offline_access",
+        "roles" : [ "offline_access" ]
+      } ],
+      "clientScopeMappings" : {
+        "account" : [ {
+          "client" : "account-console",
+          "roles" : [ "manage-account", "view-groups" ]
+        } ]
+      },
+      "clients" : [ {
+        "id" : "a40b33af-e217-440b-a5cc-7e1daf972b52",
+        "clientId" : "account",
+        "name" : "${client_account}",
+        "rootUrl" : "${authBaseUrl}",
+        "baseUrl" : "/realms/crownlabs/account/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/realms/crownlabs/account/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "false",
+          "post.logout.redirect.uris" : "+"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "9957cd7f-9a7e-4456-842e-67de118c5391",
+        "clientId" : "account-console",
+        "name" : "${client_account-console}",
+        "rootUrl" : "${authBaseUrl}",
+        "baseUrl" : "/realms/crownlabs/account/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/realms/crownlabs/account/*" ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "false",
+          "post.logout.redirect.uris" : "+",
+          "pkce.code.challenge.method" : "S256"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "protocolMappers" : [ {
+          "id" : "e9d47ae8-52d3-4ab3-b36d-bb422f813f5d",
+          "name" : "audience resolve",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-audience-resolve-mapper",
+          "consentRequired" : false,
+          "config" : { }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "b650b5a6-bf24-4c5a-a289-3bc3f3902d4e",
+        "clientId" : "admin-cli",
+        "name" : "${client_admin-cli}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : false,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : true,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "false",
+          "client.use.lightweight.access.token.enabled" : "true"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "bcb3b116-990e-41a4-a1e1-71c30a0fb11e",
+        "clientId" : "broker",
+        "name" : "${client_broker}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "true"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "9f765e91-5162-44a9-91cc-085ddea22dff",
+        "clientId" : "k8s",
+        "name" : "",
+        "description" : "",
+        "rootUrl" : "http://localhost:3000",
+        "adminUrl" : "http://localhost:3000",
+        "baseUrl" : "http://localhost:3000",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "http://localhost:3000/*" ],
+        "webOrigins" : [ "http://localhost:3000" ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : true,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "logout.confirmation.enabled" : "false",
+          "realm_client" : "false",
+          "oidc.ciba.grant.enabled" : "false",
+          "backchannel.logout.session.required" : "true",
+          "standard.token.exchange.enabled" : "false",
+          "frontchannel.logout.session.required" : "true",
+          "post.logout.redirect.uris" : "http://localhost:3000/*",
+          "display.on.consent.screen" : "false",
+          "oauth2.device.authorization.grant.enabled" : "false",
+          "pkce.code.challenge.method" : "S256",
+          "backchannel.logout.revoke.offline.tokens" : "false",
+          "dpop.bound.access.tokens" : "false"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : -1,
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "api", "groups", "k8s-audience", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "766c24f3-d227-4180-baf6-e0895d28ee86",
+        "clientId" : "operator-local",
+        "name" : "",
+        "description" : "",
+        "rootUrl" : "",
+        "adminUrl" : "",
+        "baseUrl" : "",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "secret" : "operator-local-dev-secret",
+        "redirectUris" : [ "/*" ],
+        "webOrigins" : [ "/*" ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : true,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "false",
+          "oidc.ciba.grant.enabled" : "false",
+          "client.secret.creation.time" : "1783423773",
+          "backchannel.logout.session.required" : "true",
+          "oauth2.jwt.authorization.grant.enabled" : "false",
+          "standard.token.exchange.enabled" : "false",
+          "oauth2.device.authorization.grant.enabled" : "false",
+          "backchannel.logout.revoke.offline.tokens" : "false",
+          "dpop.bound.access.tokens" : "false"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : -1,
+        "defaultClientScopes" : [ "web-origins", "service_account", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "de5debc9-500a-4540-97ae-6283298a6774",
+        "clientId" : "realm-management",
+        "name" : "${client_realm-management}",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ ],
+        "webOrigins" : [ ],
+        "notBefore" : 0,
+        "bearerOnly" : true,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : false,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "true"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : false,
+        "nodeReRegistrationTimeout" : 0,
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      }, {
+        "id" : "2fb2182c-54b3-42ff-8332-4d4ac0539c79",
+        "clientId" : "security-admin-console",
+        "name" : "${client_security-admin-console}",
+        "rootUrl" : "${authAdminUrl}",
+        "baseUrl" : "/admin/crownlabs/console/",
+        "surrogateAuthRequired" : false,
+        "enabled" : true,
+        "alwaysDisplayInConsole" : false,
+        "clientAuthenticatorType" : "client-secret",
+        "redirectUris" : [ "/admin/crownlabs/console/*" ],
+        "webOrigins" : [ "+" ],
+        "notBefore" : 0,
+        "bearerOnly" : false,
+        "consentRequired" : false,
+        "standardFlowEnabled" : true,
+        "implicitFlowEnabled" : false,
+        "directAccessGrantsEnabled" : false,
+        "serviceAccountsEnabled" : false,
+        "publicClient" : true,
+        "frontchannelLogout" : false,
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "realm_client" : "false",
+          "client.use.lightweight.access.token.enabled" : "true",
+          "post.logout.redirect.uris" : "+",
+          "pkce.code.challenge.method" : "S256"
+        },
+        "authenticationFlowBindingOverrides" : { },
+        "fullScopeAllowed" : true,
+        "nodeReRegistrationTimeout" : 0,
+        "protocolMappers" : [ {
+          "id" : "86cbab42-bc7a-49e1-a42e-cdaa9b355494",
+          "name" : "locale",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "locale",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "locale",
+            "jsonType.label" : "String"
+          }
+        } ],
+        "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "basic", "email" ],
+        "optionalClientScopes" : [ "address", "phone", "organization", "offline_access", "microprofile-jwt" ]
+      } ],
+      "clientScopes" : [ {
+        "id" : "19ad672b-19f1-4fb3-9957-3cf5f9d88e0f",
+        "name" : "role_list",
+        "description" : "SAML role list",
+        "protocol" : "saml",
+        "attributes" : {
+          "consent.screen.text" : "${samlRoleListScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "59374823-cf7d-4a7f-941a-500840bc920b",
+          "name" : "role list",
+          "protocol" : "saml",
+          "protocolMapper" : "saml-role-list-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "single" : "false",
+            "attribute.nameformat" : "Basic",
+            "attribute.name" : "Role"
+          }
+        } ]
+      }, {
+        "id" : "4d3a631a-6413-4ac8-9c99-75e8787d422f",
+        "name" : "profile",
+        "description" : "OpenID Connect built-in scope: profile",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "consent.screen.text" : "${profileScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "994b2afa-57af-45d4-8aed-780c6f811938",
+          "name" : "full name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-full-name-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "userinfo.token.claim" : "true"
+          }
+        }, {
+          "id" : "fe115f5c-30e0-4aee-aba1-0ff72bf92285",
+          "name" : "family name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "lastName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "family_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "ad0705df-ee05-45b0-94b1-cde09cce5485",
+          "name" : "gender",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "gender",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "gender",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "4722aa36-c512-48e1-9ff3-c1d6e19b3dc6",
+          "name" : "username",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "username",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "preferred_username",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "cca5be5b-0bda-45b0-aa8f-ebd32053db1f",
+          "name" : "given name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "firstName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "given_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "14e0973d-e8a0-411e-b597-09f55f3df036",
+          "name" : "picture",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "picture",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "picture",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "23b893b9-a043-40df-a344-423707bdb8e7",
+          "name" : "middle name",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "middleName",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "middle_name",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "26634cc5-6721-4e21-996f-5492708bf941",
+          "name" : "nickname",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "nickname",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "nickname",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "0fe26abc-ab63-44c4-8154-52a6854b441a",
+          "name" : "profile",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "profile",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "profile",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "9e3db685-7ad3-49e1-916f-01aa3085f8d0",
+          "name" : "updated at",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "updatedAt",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "updated_at",
+            "jsonType.label" : "long"
+          }
+        }, {
+          "id" : "3bad935b-87a2-4b6e-bc79-a979d21a8f5f",
+          "name" : "website",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "website",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "website",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "660adbde-d8b5-4222-9302-4e08cbbf8c70",
+          "name" : "birthdate",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "birthdate",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "birthdate",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "33b06040-ac41-48c2-956c-d8c6c8f0e00b",
+          "name" : "locale",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "locale",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "locale",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "d3f04840-3253-4a5c-b793-aeb80e6c9528",
+          "name" : "zoneinfo",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "zoneinfo",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "zoneinfo",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "b8e15891-8cb1-4af3-a8f1-0536db84e590",
+        "name" : "organization",
+        "description" : "Additional claims about the organization a subject belongs to",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "consent.screen.text" : "${organizationScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "265b0dcd-e34e-407d-b081-4d29ffcca541",
+          "name" : "organization",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-organization-membership-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "organization",
+            "jsonType.label" : "String",
+            "multivalued" : "true"
+          }
+        } ]
+      }, {
+        "id" : "59e996fa-7f59-458f-817d-42377d5f3d53",
+        "name" : "phone",
+        "description" : "OpenID Connect built-in scope: phone",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "consent.screen.text" : "${phoneScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "ca3f9e8f-a9e3-4aa0-8cb0-ba795c2abc56",
+          "name" : "phone number verified",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "phoneNumberVerified",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "phone_number_verified",
+            "jsonType.label" : "boolean"
+          }
+        }, {
+          "id" : "34ac4354-8fb9-4ebb-94c1-1cf099cd9bf8",
+          "name" : "phone number",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "phoneNumber",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "phone_number",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "8ebcd530-94ef-41bb-81c8-b31750c6fe71",
+        "name" : "microprofile-jwt",
+        "description" : "Microprofile - JWT built-in scope",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "fa5bbd60-d6d3-4e53-bf4a-df609ab202f7",
+          "name" : "upn",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "username",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "upn",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "b125c034-e666-41cd-a49b-7957b3e20168",
+          "name" : "groups",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "multivalued" : "true",
+            "user.attribute" : "foo",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "groups",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "3e0acd47-f904-4c35-9bec-d39b5f18ff9f",
+        "name" : "address",
+        "description" : "OpenID Connect built-in scope: address",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "consent.screen.text" : "${addressScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "08bfd14d-f092-490a-aedd-cd7ae38a1564",
+          "name" : "address",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-address-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute.formatted" : "formatted",
+            "user.attribute.country" : "country",
+            "introspection.token.claim" : "true",
+            "user.attribute.postal_code" : "postal_code",
+            "userinfo.token.claim" : "true",
+            "user.attribute.street" : "street",
+            "id.token.claim" : "true",
+            "user.attribute.region" : "region",
+            "access.token.claim" : "true",
+            "user.attribute.locality" : "locality"
+          }
+        } ]
+      }, {
+        "id" : "1cc7afec-b2d0-4bf3-93b4-5c2a9959fac8",
+        "name" : "roles",
+        "description" : "OpenID Connect scope for add user roles to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "consent.screen.text" : "${rolesScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "59dfe756-7231-4180-a648-cfc0d15194ed",
+          "name" : "audience resolve",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-audience-resolve-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true"
+          }
+        }, {
+          "id" : "49aa4740-00b0-422b-85ce-3097102c3a69",
+          "name" : "client roles",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-client-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute" : "foo",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "resource_access.${client_id}.roles",
+            "jsonType.label" : "String",
+            "multivalued" : "true"
+          }
+        }, {
+          "id" : "7745bb02-5f4f-4f5a-aa43-df8f0425b402",
+          "name" : "realm roles",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.attribute" : "foo",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "realm_access.roles",
+            "jsonType.label" : "String",
+            "multivalued" : "true"
+          }
+        } ]
+      }, {
+        "id" : "d89c17d7-9290-4c03-97b1-5b1a71f91683",
+        "name" : "web-origins",
+        "description" : "OpenID Connect scope for add allowed web origins to the access token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "consent.screen.text" : "",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "d9d03a48-eb49-4c3d-8069-810843f2b29d",
+          "name" : "allowed web origins",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-allowed-origins-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true"
+          }
+        } ]
+      }, {
+        "id" : "9048b483-4067-4fb5-9226-e34e4e44e104",
+        "name" : "saml_organization",
+        "description" : "Organization Membership",
+        "protocol" : "saml",
+        "attributes" : {
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "b1f4d440-3e3b-4d9e-9ff2-273970841c54",
+          "name" : "organization",
+          "protocol" : "saml",
+          "protocolMapper" : "saml-organization-membership-mapper",
+          "consentRequired" : false,
+          "config" : { }
+        } ]
+      }, {
+        "id" : "09deb9bc-a386-4885-b8d7-00c8e775d5b2",
+        "name" : "email",
+        "description" : "OpenID Connect built-in scope: email",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "consent.screen.text" : "${emailScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        },
+        "protocolMappers" : [ {
+          "id" : "cd5ec50e-1610-4719-b7ca-6a3057a5b110",
+          "name" : "email verified",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-property-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "emailVerified",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "email_verified",
+            "jsonType.label" : "boolean"
+          }
+        }, {
+          "id" : "9f123332-4c1a-47d1-9142-dca9e44d87eb",
+          "name" : "email",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-attribute-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "userinfo.token.claim" : "true",
+            "user.attribute" : "email",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "email",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "ff05812a-21c6-48b7-949e-6f0e9be683c0",
+        "name" : "service_account",
+        "description" : "Specific scope for a client enabled for service accounts",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "d3aab38e-73c1-461b-a2e9-506e477f4a0b",
+          "name" : "Client ID",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "client_id",
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "client_id",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "3a24d042-ce3d-4f2e-80d7-e6760dc4ab22",
+          "name" : "Client IP Address",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "clientAddress",
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "clientAddress",
+            "jsonType.label" : "String"
+          }
+        }, {
+          "id" : "a12fe8bd-e0b1-4ac5-936c-7513c8ba9b19",
+          "name" : "Client Host",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "clientHost",
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "clientHost",
+            "jsonType.label" : "String"
+          }
+        } ]
+      }, {
+        "id" : "ae78950d-5ee2-4c09-b076-8881a8a3bb60",
+        "name" : "basic",
+        "description" : "OpenID Connect scope for add all basic claims to the token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "486a9f9e-6fee-4590-8a94-58fe24964847",
+          "name" : "sub",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-sub-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true"
+          }
+        }, {
+          "id" : "8a2c9f25-6662-4e52-be59-47d73880a3c0",
+          "name" : "auth_time",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usersessionmodel-note-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "user.session.note" : "AUTH_TIME",
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true",
+            "claim.name" : "auth_time",
+            "jsonType.label" : "long"
+          }
+        } ]
+      }, {
+        "id" : "48e9b599-2319-4685-87bd-6a8d569d01b9",
+        "name" : "api",
+        "description" : "Scope required by CrownLabs frontend login request",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "false"
+        }
+      }, {
+        "id" : "e1583d53-8c42-4389-b9b9-c4ac1751520c",
+        "name" : "groups",
+        "description" : "Exposes the user's operator-local client roles (workspace-*:role) as a 'groups' claim, consumed by the Kubernetes apiserver's --oidc-groups-claim",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "2bec3ce2-d8d5-4de5-a4e1-0f0ad9a9cd36",
+          "name" : "operator-local-client-roles-to-groups",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-usermodel-client-role-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "usermodel.clientRoleMapping.clientId" : "operator-local",
+            "claim.name" : "groups",
+            "jsonType.label" : "String",
+            "multivalued" : "true",
+            "id.token.claim" : "true",
+            "access.token.claim" : "true",
+            "userinfo.token.claim" : "true"
+          }
+        } ]
+      }, {
+        "id" : "1d44e366-d8d7-40d4-a92c-51e0f9bafdbe",
+        "name" : "k8s-audience",
+        "description" : "Ensures the 'k8s' client is present in its own access token's aud claim, required by the Kubernetes apiserver's --oidc-client-id check",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "true",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "27c82112-b606-4527-baf3-a9bc0a2e22e4",
+          "name" : "k8s-self-audience",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-audience-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "included.client.audience" : "k8s",
+            "id.token.claim" : "false",
+            "access.token.claim" : "true"
+          }
+        } ]
+      }, {
+        "id" : "d1ba595a-c431-4a18-b5a3-47cc81cb2c30",
+        "name" : "offline_access",
+        "description" : "OpenID Connect built-in scope: offline_access",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "consent.screen.text" : "${offlineAccessScopeConsentText}",
+          "display.on.consent.screen" : "true"
+        }
+      }, {
+        "id" : "ac4ba8fe-f439-44fa-97eb-4fdd6f279d01",
+        "name" : "acr",
+        "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+        "protocol" : "openid-connect",
+        "attributes" : {
+          "include.in.token.scope" : "false",
+          "display.on.consent.screen" : "false"
+        },
+        "protocolMappers" : [ {
+          "id" : "67699575-35f5-42ee-ab5b-b48c8af764fd",
+          "name" : "acr loa level",
+          "protocol" : "openid-connect",
+          "protocolMapper" : "oidc-acr-mapper",
+          "consentRequired" : false,
+          "config" : {
+            "id.token.claim" : "true",
+            "introspection.token.claim" : "true",
+            "access.token.claim" : "true"
+          }
+        } ]
+      } ],
+      "defaultDefaultClientScopes" : [ "role_list", "saml_organization", "profile", "email", "roles", "web-origins", "acr", "basic" ],
+      "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt", "organization" ],
+      "browserSecurityHeaders" : {
+        "contentSecurityPolicyReportOnly" : "",
+        "xContentTypeOptions" : "nosniff",
+        "referrerPolicy" : "no-referrer",
+        "xRobotsTag" : "none",
+        "xFrameOptions" : "SAMEORIGIN",
+        "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+        "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+      },
+      "smtpServer" : { },
+      "eventsEnabled" : false,
+      "eventsListeners" : [ "jboss-logging" ],
+      "enabledEventTypes" : [ ],
+      "adminEventsEnabled" : false,
+      "adminEventsDetailsEnabled" : false,
+      "identityProviders" : [ ],
+      "identityProviderMappers" : [ ],
+      "components" : {
+        "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+          "id" : "90c9e7bb-f195-4feb-926d-be6eb4b19c9c",
+          "name" : "Trusted Hosts",
+          "providerId" : "trusted-hosts",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "host-sending-registration-request-must-match" : [ "true" ],
+            "client-uris-must-match" : [ "true" ]
+          }
+        }, {
+          "id" : "07c85567-e175-4f21-a902-408ffd719d66",
+          "name" : "Allowed Client Scopes",
+          "providerId" : "allowed-client-templates",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "allow-default-scopes" : [ "true" ]
+          }
+        }, {
+          "id" : "f4b655c4-5e41-4ab1-b43c-98965732393d",
+          "name" : "Allowed Protocol Mapper Types",
+          "providerId" : "allowed-protocol-mappers",
+          "subType" : "authenticated",
+          "subComponents" : { },
+          "config" : {
+            "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-attribute-mapper", "saml-user-property-mapper", "oidc-address-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper" ]
+          }
+        }, {
+          "id" : "ec8eece2-8cf0-4bec-a685-6aa5bdd92da7",
+          "name" : "Max Clients Limit",
+          "providerId" : "max-clients",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "max-clients" : [ "200" ]
+          }
+        }, {
+          "id" : "eeb2150c-5c34-418f-979d-60318398d75a",
+          "name" : "Allowed Registration Web Origins",
+          "providerId" : "registration-web-origins",
+          "subType" : "authenticated",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "7f4f072c-a64f-41f2-abe3-7d725f9f2db1",
+          "name" : "Allowed Protocol Mapper Types",
+          "providerId" : "allowed-protocol-mappers",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : {
+            "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "saml-user-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "saml-role-list-mapper", "oidc-full-name-mapper" ]
+          }
+        }, {
+          "id" : "2eaffa64-b42e-46e0-a385-6c55ab638226",
+          "name" : "Consent Required",
+          "providerId" : "consent-required",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "a1a18e02-34b8-4a57-bf25-84cca5e82f7d",
+          "name" : "Full Scope Disabled",
+          "providerId" : "scope",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "81cbce82-658b-4e64-bb7f-afb101966bfd",
+          "name" : "Allowed Registration Web Origins",
+          "providerId" : "registration-web-origins",
+          "subType" : "anonymous",
+          "subComponents" : { },
+          "config" : { }
+        }, {
+          "id" : "7a07a9b3-3865-4891-b22b-db632dddbf39",
+          "name" : "Allowed Client Scopes",
+          "providerId" : "allowed-client-templates",
+          "subType" : "authenticated",
+          "subComponents" : { },
+          "config" : {
+            "allow-default-scopes" : [ "true" ]
+          }
+        } ],
+        "org.keycloak.keys.KeyProvider" : [ {
+          "id" : "bae879eb-6880-4d58-938f-e4626dffa659",
+          "name" : "rsa-generated",
+          "providerId" : "rsa-generated",
+          "subComponents" : { },
+          "config" : {
+            "privateKey" : [ "MIIEpAIBAAKCAQEAsIJDlsem/YTEYRlpe0o4PSmuDIYibtFmGkE5aZy96GG29Ez36io4oPr4/nhc8QdqY1+gWZxP4AL3jFyIi1l1yAymcJK6uN7nKWQYuBzmN9fm9m0D2Z/GA5YvvjVsDCip8jmiFh0uJgBzOC/1YUspqxbGbF9bGo52c8p9HjR9du/gTSyLYEDzSaM4VZ6a6BLcUt7duyt1L9fZz3y2FXRnVVH3QeHGLzCYSEYrSWycsO39z7nBT6sT9yyyrKfHYCPWlHzei4Zb2qR9tTI5MdbEfRYevuKj5e8BTBXeWM0UpDK/1O1uGRymd0Y4UzXX73Wn1ySkLeB5yrBIxsZlF2gevwIDAQABAoIBACkL+fzP7CELpYFxH+sIbQCoNy35aXt83bIgVeIeDbnDM4EnfwWpEOc6xfmjcvWoRFDctZTxOU/+UKQHBsflI3NEodYPATYpu/cPrIHwUodNAYxv+JO8yJcf73Vbxgcj07WdOnjLC2bR9vlribQ4/vUnBDjCihSoaZpuzd7e1Qh5yCmGSqSzq2vbVko2X4u4xyRvOsLT1Y8arkCt2bU5hz70hO3bYH2ZKN1Uuw6Mzbj/KdolzKVwHB+Jv+9ic8uwFIeaWauQTBH8NolVX4115OBidUNcc75kBTTZZ0yTPTkvqK0WqhRyNpVMzoV8hLWKnzLENEq1Q8d3qak/iPlkm4UCgYEA3fFBl6308k5H2FD/Dq0SKo4A3MMYFXdPyWd08ZH3o98Rk2d6LTucR2RCRlnzUJBSi9YxUbgcVNU1f6iq9Z7uErcmQhIZ/K6h/AwYaC0DKrZrx80/LnrybMbZnzZAL1TCAQk8MaAEcn2KMjKXaSIquQIy8Rw7yEX3gciAdYcgliUCgYEAy5g0SU3k1RtTi4ff/q+fC5kAya37IPvXxRkKAOpml22N79xy5XBJ69ATPZQoSZ6Y/s6QEuIqyNjzHjOPP0my728Q1Jh/vKLSMmsUAaqxYPrBujpIjtwyQ0pov6srxLmGqwvV74Oc+AI+gjz0kPvIPtsz6eWd1PlHkcW4u8l28hMCgYEA089YCvrAhrLAjCgYkpgHe0dUeVtTU8EvCwZKK/VjQig0LNoXVq3KIrQDMALOW/ewX7YGEXhEyY1E5lVA+vI3QPM7dtixpl2/R7z/WgSDPjMkP2WYw7IgREGuFO0AamtYTwbSRIXzWJSI3Ak+SN6LqU748PRB9YsYf+qq9f8E0WUCgYEAuIX8bavhiJw5vi6p/2Ug2xwTMLc08pIO355wCKBp1zj9+bVtlTGObeGqbpdHZGIP/HEu905wxJSM1ISaghvDx2p8cJK+wzM3G2cdPN194o2i46xLct9z1rUr9vumsagMvB4AChLZQ5aVHOkuJ/Frbjyx8n2f7RT5ns77PYe8/G0CgYA4IzHr4qtHUNkrIdQ5nO+benq1hySGG6FG/musM1OPiPmpfGGZIGk2d8MoxvQcL7YszJTvcSr2PPkTNj+sd4GhS0edQM0wN0IybiRdN+0bUH4Cy+zN0GRfETOt29eP6JLbqK/OfpM3oFEbogKtBdXsEg8IReghK6mr2uPIZtZe9g==" ],
+            "keyUse" : [ "SIG" ],
+            "certificate" : [ "MIICoTCCAYkCBgGdCvSYdTANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAljcm93bmxhYnMwHhcNMjYwMzIwMTExMzE1WhcNMzYwMzIwMTExNDU1WjAUMRIwEAYDVQQDDAljcm93bmxhYnMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCwgkOWx6b9hMRhGWl7Sjg9Ka4MhiJu0WYaQTlpnL3oYbb0TPfqKjig+vj+eFzxB2pjX6BZnE/gAveMXIiLWXXIDKZwkrq43ucpZBi4HOY31+b2bQPZn8YDli++NWwMKKnyOaIWHS4mAHM4L/VhSymrFsZsX1sajnZzyn0eNH127+BNLItgQPNJozhVnproEtxS3t27K3Uv19nPfLYVdGdVUfdB4cYvMJhIRitJbJyw7f3PucFPqxP3LLKsp8dgI9aUfN6LhlvapH21Mjkx1sR9Fh6+4qPl7wFMFd5YzRSkMr/U7W4ZHKZ3RjhTNdfvdafXJKQt4HnKsEjGxmUXaB6/AgMBAAEwDQYJKoZIhvcNAQELBQADggEBADTaxILPTc1zWmoFx8qqknlX8Wq5Q00umGvYSE67QW6AFlkaFugNH3slk/32nJDxCJgZ/gnOQzLie0OPfVzDTrhJrt0c1G1nBK8ZaTf2Zu9uYDj0XoH0up+bijQx28rOB2G6kgUToG9pOMU7ck55R3MMWMj8uVcYupWagkRbac8p7ndfroAUj1g1uXOkau/EZ1ti+V1J/3WtxpPEmA5GPK0rzn4Cy4DgTCM3NuQyIC2Ar2uNQSiWNypT1RDETosGVCWR5qTYwQ/e3SgwVizi3JpATBKtxx1CN/IBAiBfYJ9XjFyMQrseSi/FGspOhEbCmdH+edIEh65Wr6d1nDMQMlM=" ],
+            "priority" : [ "100" ]
+          }
+        }, {
+          "id" : "29fe9164-976e-4175-af2f-ad8d6d117ff8",
+          "name" : "rsa-enc-generated",
+          "providerId" : "rsa-enc-generated",
+          "subComponents" : { },
+          "config" : {
+            "privateKey" : [ "MIIEogIBAAKCAQEArj/lW+YQg0Y2bpyXUc8O0snsC5txMJJUkubxVi1Z/lBL+f2GzfIX58KCOY76bKM9DiUPNRUavyjL8ZwEoamPNeV9qW3bswStxjKQB+VvFCNJCgIw/+crBMOgnON+9j4rYun9/Qaj+mUXhgyVLY0E9z/UhJb1sHPZnhknI3djQDzJhGikH2TX+lhGSEHl9HZoJgioUzw+7iE7iGBQYdsPWQKsuwO/MLHahS2ziuBoy87tmLFhY6TEtPTUC6Ff0HeDx6fSSPf9r6Vau07JeD8T8zgFO9t9n+9vC3NqMhw06v6RZWrnr+z1eu+9y3mMeNhXUD/j2Agql/FZYL9W9xQqkQIDAQABAoIBADuvRzCjLSTJ9/sLSAmNktZAs8mGBM9OUAnBcQjDn/+sIVoPrQz9z5Ji3Zg5kS2E/HTL3Nmh0PeJUdIATtXQ7mzXnqNaLdaz05H/37XUsKeFLo9vELmWxPVszKbwhZxyzwmifI0eqSwrVFNmG/LuSrUl9/UygBVgmTm+A9nyGtz1ZH9jJGhfNAuLT1LdRyaKSpMDJW9dC18VlAyYsun2fOldQB712E8rLSaqhXJtHJn2xmYTfdvp4HvyLZB07y9Bm+3Bv6PXC0+rBxJgWjfSVu/mPMu9IB3EXxHwG4YT0ccnSk2YjQ7RRuBHu6BUR9OzadI+2NYDAPGWgxYzFUXE18ECgYEA3GMtYLjYUBxWwVdt2LBLZkIHwzQxGDRn31g+JI7La5fAaHSDBzTijDtFmuAReFDtbTNt2XFWKfJbmBCyMBfyqr9mqt27CYAWt6BJw04V4vTC5I5v417EjC2dRCRgKAxjvkNvcroNbftRNsHpCf5+wCQ7THMcdxTkniUpvm+JHQMCgYEAymgfquj4l2/Nwee+aBdDz2DWGgIAz40CT5KzyOW/dWkDBnZsYc1sc32jt0PeRxIbVtRF27SLltypLtAGuoeb5Lehhpo89qnrb39KlR/7aBK+VZHv8BJnrvll9f6Y7Vw4dXjNuAYhsxcU/qSpah5w+XTn0VzwjGlrYMRdFTxAc9sCgYA6+gdwtMaeWZcV0lHBBRyIVu9A27yvn4aUjEbE/bmOJ2QED/noecyOfmYYFhJWwkFnUbX51IycWREN1pn4qM/1xZax7vhYiICLz0cuDr1oqNtm0n86t2edo69MRve8f+RJTD6M0yE452JKZwX3+LTuskN0J/HcJCkx8PwEzFBDBQKBgAzsCNmIdhZ09NXkTaunkJS0wfZ3GkYl4nfiDchNoqOESMUo2lKEIuBcrQ8OLiqrZUNt2efk5uSCwepTLZrK/ZDkiFNnlWzJ/FXp8oECwbIrQCuGXaMeCbCKC5Bg6LJ+qLwXMksFWTFtz9FSAd7cgqnqZMJhBJpyQIC1CJxKdHLxAoGATt9idhYrt/T9m1uR/13pgCanfxMYl2y8DWRX9Vzi4+O93uMPaRoDq7022D63Bgmu052hpKc/G1yiNsxdXwMfq76VDrFwr/3LfY2ue7fhva+6l7vZb0Q529HAqZPvrSRgg6IFN4DX9kB0of3SuGzloxBuIMI+PWol1VPn55JbyvU=" ],
+            "keyUse" : [ "ENC" ],
+            "certificate" : [ "MIICoTCCAYkCBgGdCvSZQzANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAljcm93bmxhYnMwHhcNMjYwMzIwMTExMzE1WhcNMzYwMzIwMTExNDU1WjAUMRIwEAYDVQQDDAljcm93bmxhYnMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCuP+Vb5hCDRjZunJdRzw7SyewLm3EwklSS5vFWLVn+UEv5/YbN8hfnwoI5jvpsoz0OJQ81FRq/KMvxnAShqY815X2pbduzBK3GMpAH5W8UI0kKAjD/5ysEw6Cc4372Piti6f39BqP6ZReGDJUtjQT3P9SElvWwc9meGScjd2NAPMmEaKQfZNf6WEZIQeX0dmgmCKhTPD7uITuIYFBh2w9ZAqy7A78wsdqFLbOK4GjLzu2YsWFjpMS09NQLoV/Qd4PHp9JI9/2vpVq7Tsl4PxPzOAU7232f728Lc2oyHDTq/pFlauev7PV6773LeYx42FdQP+PYCCqX8Vlgv1b3FCqRAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAEQ6ViO0AUxmD/RKKYRbJ/U091tjZlNshtB/umdyn/PxpjktTfP8c/AHUqDdNThBgrk/7JvsyyhO2AeIa3i7m+V5G5jVnpXoYC6k6wxtngfgAChY2QSvivIJKjVSoTT0Rh1VnaegEN5IqmD/8JVk8rNzVMvX3mNU5t9CaEW8eX+gAd/nfkKDap3DoiqjnKsoJKssKBkJHS59QTZGHp/dBPQBn25/kxty5GJjERIEFqEoV+Rdvdztrvi20NOgcIe48PLq9WWLF/fDxvMseAYbiCZoVj0ceNC6zsZi1k0ivYRL6/lXXY1NgV6VO5COqs0UZnUe1zRDqRIvXj6xK3JdQ7U=" ],
+            "priority" : [ "100" ],
+            "algorithm" : [ "RSA-OAEP" ]
+          }
+        }, {
+          "id" : "19429726-6db5-43f7-9bf9-0dd0a16ba8e3",
+          "name" : "aes-generated",
+          "providerId" : "aes-generated",
+          "subComponents" : { },
+          "config" : {
+            "kid" : [ "cf469052-a09d-4bfe-976c-e420e4394574" ],
+            "secret" : [ "nwoco3fYsC_1jmUHLrs9iA" ],
+            "priority" : [ "100" ]
+          }
+        }, {
+          "id" : "4e9c3423-7d8a-47bd-af65-aae31bf8e0cc",
+          "name" : "hmac-generated-hs512",
+          "providerId" : "hmac-generated",
+          "subComponents" : { },
+          "config" : {
+            "kid" : [ "ae06139f-c1c5-4cbb-a739-851edb9cb1e0" ],
+            "secret" : [ "TYMKmR0WrbMZudPpn5e43_HW688O_9kOrxzBjgwB4lRvdz3nlc0_dmhY73i2ryfW4ngyt97FH6wcZ5X_Xos7uvDuIDrA2KrSdkqM41o7Itqj0XvlqORBXu3JxvRudfVXp8Dk7gWV6pgSmmWRS3akqaiGNYsy3BuEzmn57R7TdGA" ],
+            "priority" : [ "100" ],
+            "algorithm" : [ "HS512" ]
+          }
+        } ]
+      },
+      "internationalizationEnabled" : false,
+      "authenticationFlows" : [ {
+        "id" : "50898646-4d94-473d-b2e6-1b77c6edd47c",
+        "alias" : "Account verification options",
+        "description" : "Method with which to verify the existing account",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "idp-email-verification",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Verify Existing Account by Re-authentication",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "5c5edcb6-f2fe-4884-9b99-6092e32b4813",
+        "alias" : "Browser - Conditional 2FA",
+        "description" : "Flow to determine if any 2FA is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorConfig" : "browser-conditional-credential",
+          "authenticator" : "conditional-credential",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "auth-otp-form",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "webauthn-authenticator",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 40,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "auth-recovery-authn-code-form",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 50,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "c4e823f6-df39-45de-b5a9-82d7bcf5de99",
+        "alias" : "Browser - Conditional Organization",
+        "description" : "Flow to determine if the organization identity-first login is to be used",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "organization",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "cf965454-5015-4bf9-855f-6e30de07f41b",
+        "alias" : "Direct Grant - Conditional OTP",
+        "description" : "Flow to determine if the OTP is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "direct-grant-validate-otp",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "11580a4b-d8ab-42bf-8979-dd484ef3db16",
+        "alias" : "First Broker Login - Conditional Organization",
+        "description" : "Flow to determine if the authenticator that adds organization members is to be used",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "idp-add-organization-member",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "45e2e586-ca5a-484e-a086-a2138a09ef40",
+        "alias" : "First broker login - Conditional 2FA",
+        "description" : "Flow to determine if any 2FA is required for the authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorConfig" : "first-broker-login-conditional-credential",
+          "authenticator" : "conditional-credential",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "auth-otp-form",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "webauthn-authenticator",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 40,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "auth-recovery-authn-code-form",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 50,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "c9e5f64e-7e25-4894-9d3b-99814b6108ef",
+        "alias" : "Handle Existing Account",
+        "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "idp-confirm-link",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Account verification options",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "fa36200d-8dd1-4c4a-9085-ed998226ecb1",
+        "alias" : "Organization",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 10,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Browser - Conditional Organization",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "6f1b721b-07f1-48f6-87bd-e3e199aed29b",
+        "alias" : "Reset - Conditional OTP",
+        "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "conditional-user-configured",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "reset-otp",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "224a9c2b-65a3-436f-8860-65451edcda83",
+        "alias" : "User creation or linking",
+        "description" : "Flow for the existing/non-existing user alternatives",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticatorConfig" : "create unique user config",
+          "authenticator" : "idp-create-user-if-unique",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Handle Existing Account",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "9f13f87c-ed16-43d3-ae23-84c89ef322f8",
+        "alias" : "Verify Existing Account by Re-authentication",
+        "description" : "Reauthentication of existing account",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "idp-username-password-form",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "First broker login - Conditional 2FA",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "cf27478a-b8d5-4554-9016-0cc4f62cf0cf",
+        "alias" : "browser",
+        "description" : "Browser based authentication",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "auth-cookie",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "auth-spnego",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "identity-provider-redirector",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 25,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 26,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Organization",
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "autheticatorFlow" : true,
+          "flowAlias" : "forms",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "6d1312ad-f40c-4072-b03d-73ff2303f370",
+        "alias" : "clients",
+        "description" : "Base authentication for clients",
+        "providerId" : "client-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "client-secret",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "client-jwt",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "client-secret-jwt",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 30,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "client-x509",
+          "authenticatorFlow" : false,
+          "requirement" : "ALTERNATIVE",
+          "priority" : 40,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "60fb32d9-e0b8-436b-abfe-0c5df96694c7",
+        "alias" : "direct grant",
+        "description" : "OpenID Connect Resource Owner Grant",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "direct-grant-validate-username",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "direct-grant-validate-password",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 30,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Direct Grant - Conditional OTP",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "21af9de3-8bfb-4189-81d0-8439e7b87fc8",
+        "alias" : "docker auth",
+        "description" : "Used by Docker clients to authenticate against the IDP",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "docker-http-basic-authenticator",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "6278066e-72c3-41ca-bd1b-dcbfb6534ecd",
+        "alias" : "first broker login",
+        "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticatorConfig" : "review profile config",
+          "authenticator" : "idp-review-profile",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "User creation or linking",
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 60,
+          "autheticatorFlow" : true,
+          "flowAlias" : "First Broker Login - Conditional Organization",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "85d82952-b490-496b-8176-0bbdb7642e3e",
+        "alias" : "forms",
+        "description" : "Username, password, otp and other auth forms.",
+        "providerId" : "basic-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "auth-username-password-form",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 20,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Browser - Conditional 2FA",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "d777701c-610f-4f95-bf92-8ca2b9c60daa",
+        "alias" : "registration",
+        "description" : "Registration flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "registration-page-form",
+          "authenticatorFlow" : true,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : true,
+          "flowAlias" : "registration form",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "909db935-681d-4845-9a96-53ff307bf634",
+        "alias" : "registration form",
+        "description" : "Registration form",
+        "providerId" : "form-flow",
+        "topLevel" : false,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "registration-user-creation",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "registration-password-action",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 50,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "registration-recaptcha-action",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 60,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "registration-terms-and-conditions",
+          "authenticatorFlow" : false,
+          "requirement" : "DISABLED",
+          "priority" : 70,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "825c9d3c-dbc3-45d8-a529-2bc7c9ab36d5",
+        "alias" : "reset credentials",
+        "description" : "Reset credentials for a user if they forgot their password or something",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "reset-credentials-choose-user",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "reset-credential-email",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 20,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticator" : "reset-password",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 30,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        }, {
+          "authenticatorFlow" : true,
+          "requirement" : "CONDITIONAL",
+          "priority" : 40,
+          "autheticatorFlow" : true,
+          "flowAlias" : "Reset - Conditional OTP",
+          "userSetupAllowed" : false
+        } ]
+      }, {
+        "id" : "d0094e35-929c-411d-a05a-e2e2b2163a7d",
+        "alias" : "saml ecp",
+        "description" : "SAML ECP Profile Authentication Flow",
+        "providerId" : "basic-flow",
+        "topLevel" : true,
+        "builtIn" : true,
+        "authenticationExecutions" : [ {
+          "authenticator" : "http-basic-authenticator",
+          "authenticatorFlow" : false,
+          "requirement" : "REQUIRED",
+          "priority" : 10,
+          "autheticatorFlow" : false,
+          "userSetupAllowed" : false
+        } ]
+      } ],
+      "authenticatorConfig" : [ {
+        "id" : "d7d88746-3ab9-4494-8598-d677fe01afad",
+        "alias" : "browser-conditional-credential",
+        "config" : {
+          "credentials" : "webauthn-passwordless"
+        }
+      }, {
+        "id" : "6dab117c-7371-4118-b971-3f861deee72a",
+        "alias" : "create unique user config",
+        "config" : {
+          "require.password.update.after.registration" : "false"
+        }
+      }, {
+        "id" : "6c583cf2-69a4-4701-89c9-9c6cbd697d2e",
+        "alias" : "first-broker-login-conditional-credential",
+        "config" : {
+          "credentials" : "webauthn-passwordless"
+        }
+      }, {
+        "id" : "a384a250-86fe-4f1b-b244-b20fd57f9e4a",
+        "alias" : "review profile config",
+        "config" : {
+          "update.profile.on.first.login" : "missing"
+        }
+      } ],
+      "requiredActions" : [ {
+        "alias" : "CONFIGURE_TOTP",
+        "name" : "Configure OTP",
+        "providerId" : "CONFIGURE_TOTP",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 10,
+        "config" : { }
+      }, {
+        "alias" : "TERMS_AND_CONDITIONS",
+        "name" : "Terms and Conditions",
+        "providerId" : "TERMS_AND_CONDITIONS",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 20,
+        "config" : { }
+      }, {
+        "alias" : "UPDATE_PASSWORD",
+        "name" : "Update Password",
+        "providerId" : "UPDATE_PASSWORD",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 30,
+        "config" : { }
+      }, {
+        "alias" : "UPDATE_PROFILE",
+        "name" : "Update Profile",
+        "providerId" : "UPDATE_PROFILE",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 40,
+        "config" : { }
+      }, {
+        "alias" : "VERIFY_EMAIL",
+        "name" : "Verify Email",
+        "providerId" : "VERIFY_EMAIL",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 50,
+        "config" : { }
+      }, {
+        "alias" : "delete_account",
+        "name" : "Delete Account",
+        "providerId" : "delete_account",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 60,
+        "config" : { }
+      }, {
+        "alias" : "UPDATE_EMAIL",
+        "name" : "Update Email",
+        "providerId" : "UPDATE_EMAIL",
+        "enabled" : false,
+        "defaultAction" : false,
+        "priority" : 70,
+        "config" : { }
+      }, {
+        "alias" : "webauthn-register",
+        "name" : "Webauthn Register",
+        "providerId" : "webauthn-register",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 80,
+        "config" : { }
+      }, {
+        "alias" : "webauthn-register-passwordless",
+        "name" : "Webauthn Register Passwordless",
+        "providerId" : "webauthn-register-passwordless",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 90,
+        "config" : { }
+      }, {
+        "alias" : "VERIFY_PROFILE",
+        "name" : "Verify Profile",
+        "providerId" : "VERIFY_PROFILE",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 100,
+        "config" : { }
+      }, {
+        "alias" : "delete_credential",
+        "name" : "Delete Credential",
+        "providerId" : "delete_credential",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 110,
+        "config" : { }
+      }, {
+        "alias" : "idp_link",
+        "name" : "Linking Identity Provider",
+        "providerId" : "idp_link",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 120,
+        "config" : { }
+      }, {
+        "alias" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+        "name" : "Recovery Authentication Codes",
+        "providerId" : "CONFIGURE_RECOVERY_AUTHN_CODES",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 130,
+        "config" : { }
+      }, {
+        "alias" : "update_user_locale",
+        "name" : "Update User Locale",
+        "providerId" : "update_user_locale",
+        "enabled" : true,
+        "defaultAction" : false,
+        "priority" : 1000,
+        "config" : { }
+      } ],
+      "browserFlow" : "browser",
+      "registrationFlow" : "registration",
+      "directGrantFlow" : "direct grant",
+      "resetCredentialsFlow" : "reset credentials",
+      "clientAuthenticationFlow" : "clients",
+      "dockerAuthenticationFlow" : "docker auth",
+      "firstBrokerLoginFlow" : "first broker login",
+      "attributes" : {
+        "cibaBackchannelTokenDeliveryMode" : "poll",
+        "cibaExpiresIn" : "120",
+        "cibaAuthRequestedUserHint" : "login_hint",
+        "oauth2DeviceCodeLifespan" : "600",
+        "oauth2DevicePollingInterval" : "5",
+        "parRequestUriLifespan" : "60",
+        "cibaInterval" : "5",
+        "realmReusableOtpCode" : "false"
+      },
+      "keycloakVersion" : "26.5.6",
+      "userManagedAccessAllowed" : false,
+      "organizationsEnabled" : false,
+      "verifiableCredentialsEnabled" : false,
+      "adminPermissionsEnabled" : false,
+      "clientProfiles" : {
+        "profiles" : [ ]
+      },
+      "clientPolicies" : {
+        "policies" : [ ]
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: keycloak-realm-import

--- a/dev-local/keycloak/manifests/keycloak.yaml
+++ b/dev-local/keycloak/manifests/keycloak.yaml
@@ -1,0 +1,230 @@
+# Keycloak + Postgres StatefulSet, based on the official Keycloak quickstart example:
+# https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/main/kubernetes/keycloak.yaml
+# (keycloak/keycloak-quickstarts repo, kubernetes/keycloak.yaml).
+#
+# Changes from that original:
+# - replicas: 2 -> 1 (a single local-dev node doesn't benefit from Keycloak's HA/
+#   Infinispan clustering, and it halves memory usage — see ../README.md section 6
+#   if RAM is still tight).
+# - args: added "--import-realm" (loads the ConfigMap-mounted realm export below).
+# - added the 'realm-import' ConfigMap volume/mount (crownlabs-realm-configmap.yaml).
+# - Service type: ClusterIP, exposed to the host via an HTTPRoute (below) through
+#   Envoy Gateway instead of a NodePort — see ../../envoy/README.md. TLS terminates
+#   at the Gateway, not here: Keycloak itself only ever speaks plain HTTP, so there's
+#   no self-managed certificate, no HTTPS container port, and no probe-scheme gotcha
+#   to work around (compare with the Gateway's own wildcard cert in
+#   ../../envoy/manifests/gateway.yaml).
+#
+# Requires the Gateway API CRDs + Envoy Gateway controller + the shared `crownlabs`
+# Gateway to already exist, see ../../envoy/README.md.
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: http
+      name: http
+  selector:
+    app: keycloak
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  parentRefs:
+    - name: crownlabs
+      sectionName: https
+  hostnames:
+    - keycloak.crownlabs.local
+  rules:
+    - backendRefs:
+        - name: keycloak
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: keycloak
+  name: keycloak-discovery
+spec:
+  selector:
+    app: keycloak
+  clusterIP: None
+  type: ClusterIP
+---
+apiVersion: apps/v1
+# Use a stateful setup to ensure that for a rolling update Pods are restarted with a rolling strategy one-by-one.
+# This prevents losing in-memory information stored redundantly in two Pods.
+kind: StatefulSet
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  serviceName: keycloak-discovery
+  # Run with one replica to save resources, or with two replicas to allow for rolling updates for configuration changes
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:26.6.4
+          # --import-realm loads any *.json realm file found in /opt/keycloak/data/import at startup.
+          # If the realm already exists in the database, the import is skipped (no data is overwritten).
+          args: ["start", "--import-realm"]
+          env:
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              value: "admin"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              value: "admin"
+            # In a production environment, add a TLS certificate to Keycloak to either end-to-end encrypt the traffic between
+            # the client or Keycloak, or to encrypt the traffic between your proxy and Keycloak.
+            # Respect the proxy headers forwarded by the reverse proxy
+            # In a production environment, verify which proxy type you are using, and restrict access to Keycloak
+            # from other sources than your proxy if you continue to use proxy headers.
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            # In this explorative setup, no strict hostname is set.
+            # For production environments, set a hostname for a secure setup.
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+            - name: 'KC_CACHE'
+              value: 'ispn'
+            # Passing the Pod's IP primary address to the JGroups clustering as this is required in IPv6 only setups
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # Instruct JGroups which DNS hostname to use to discover other Keycloak nodes
+            # Needs to be unique for each Keycloak cluster
+            - name: KC_CACHE_EMBEDDED_NETWORK_BIND_ADDRESS
+              value: '$(POD_IP)'
+            - name: 'KC_DB_URL_DATABASE'
+              value: 'keycloak'
+            - name: 'KC_DB_URL_HOST'
+              value: 'postgres'
+            - name: 'KC_DB'
+              value: 'postgres'
+            # In a production environment, use a secret to store username and password to the database
+            - name: 'KC_DB_PASSWORD'
+              value: 'keycloak'
+            - name: 'KC_DB_USERNAME'
+              value: 'keycloak'
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: jgroups
+              containerPort: 7800
+            - name: jgroups-fd
+              containerPort: 57800
+          startupProbe:
+            httpGet:
+              path: /health/started
+              port: 9000
+            periodSeconds: 1
+            failureThreshold: 600
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 9000
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2000Mi
+            requests:
+              cpu: 500m
+              memory: 1700Mi
+          volumeMounts:
+            # --import-realm reads every *.json file in this directory at startup.
+            - name: realm-import
+              mountPath: /opt/keycloak/data/import
+      volumes:
+        - name: realm-import
+          configMap:
+            # Declared in crownlabs-realm-configmap.yaml, applied alongside this
+            # file — see ../README.md.
+            name: keycloak-realm-import
+---
+# This is deployment of PostgreSQL with an ephemeral storage for testing: Once the Pod stops, the data is lost.
+# For a production setup, replace it with a database setup that persists your data.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: mirror.gcr.io/postgres:17
+          env:
+            - name: POSTGRES_USER
+              value: "keycloak"
+            - name: POSTGRES_PASSWORD
+              value: "keycloak"
+            - name: POSTGRES_DB
+              value: "keycloak"
+            - name: POSTGRES_LOG_STATEMENT
+              value: "all"
+          ports:
+            - name: postgres
+              containerPort: 5432
+          volumeMounts:
+            # Using volume mount for PostgreSQL's data folder as it is otherwise not writable
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: postgres
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+  type: ClusterIP

--- a/dev-local/keycloak/manifests/mydrive-pvcs-namespace.yaml
+++ b/dev-local/keycloak/manifests/mydrive-pvcs-namespace.yaml
@@ -1,0 +1,5 @@
+# Namespace for the operator's per-tenant "MyDrive" PVCs (--mydrive-pvcs-storage-class-name).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mydrive-pvcs

--- a/dev-local/keycloak/regenerating-the-realm-export.md
+++ b/dev-local/keycloak/regenerating-the-realm-export.md
@@ -1,19 +1,18 @@
 # Regenerating the realm export
 
-If you manually change something in the local realm (new client, new
-scope, new user, etc.) and want to freeze it for future installs,
-regenerate the export and re-wrap it into the ConfigMap manifest:
+If you manually change something in the local realm (a new client, a new scope, a new user, and so on) and you would like to freeze it for future installs, you should regenerate the export and re-wrap it into the ConfigMap manifest:
 
 ```bash
 export KUBECONFIG=~/.kube/config
 
-# runs the export while the pod is already running (kc.sh runs as a process separate
-# from the main server, so there's no need to stop Keycloak for a simple local snapshot)
+# This runs the export while the pod is already running. kc.sh runs as a process
+# separate from the main server, so you do not need to stop Keycloak for a simple
+# local snapshot.
 kubectl exec keycloak-0 -- rm -rf /tmp/export
 kubectl exec keycloak-0 -- /opt/keycloak/bin/kc.sh export --dir /tmp/export --realm crownlabs --users realm_file
 
-# copy the file out of the pod (the image has no 'tar', so 'kubectl cp' won't work: use 'cat' instead),
-# then wrap it into the ConfigMap manifest committed in this folder
+# Copy the file out of the pod. The image has no "tar", so "kubectl cp" will not work:
+# use "cat" instead. Then wrap the file into the ConfigMap manifest committed in this folder.
 kubectl exec keycloak-0 -- cat /tmp/export/crownlabs-realm.json > /tmp/crownlabs-realm.json
 {
   echo "# Generated from a \`kc.sh export\` of the crownlabs realm — do not hand-edit."
@@ -24,38 +23,30 @@ kubectl exec keycloak-0 -- cat /tmp/export/crownlabs-realm.json > /tmp/crownlabs
 rm /tmp/crownlabs-realm.json
 ```
 
-> **Note**: `kc.sh export` exits with an error (`Address already in use` on
-> port 9000) because the export process tries to start the management
-> interface on the same port already used by the running main server. **The
-> error is harmless and happens AFTER the data export has already
-> completed** (check the logs for `KC-SERVICES0035: Export finished
-> successfully` before the error). For an export without this warning, stop
-> Keycloak first (`kubectl scale statefulset keycloak --replicas=0`) as
-> recommended by the [official documentation](https://www.keycloak.org/server/importExport).
+> **Note**: `kc.sh export` exits with an error (`Address already in use` on port 9000).
+> This happens because the export process tries to start the management interface on the same port the running main server already uses.
+> **The error is harmless, and happens after the data export has already completed.**
+> Check the logs for `KC-SERVICES0035: Export finished successfully` before the error, to confirm this.
+> For an export without this warning, stop Keycloak first (`kubectl scale statefulset keycloak --replicas=0`), as recommended by the [official documentation](https://www.keycloak.org/server/importExport).
 
-**Before committing a new export**, always check that any newly
-auto-generated Keycloak client secrets are pinned to a known value (as done
-for `operator-local-dev-secret`) instead of ending up in the repo as a
-random string:
+**Before you commit a new export**, always check that any newly auto-generated Keycloak client secret is pinned to a known value, the same way `operator-local-dev-secret` is, instead of ending up in the repository as a random string:
 
 ```bash
-TOKEN=$(curl -s -X POST http://localhost:30090/realms/master/protocol/openid-connect/token \
+TOKEN=$(curl -sk -X POST https://keycloak.crownlabs.local/realms/master/protocol/openid-connect/token \
   -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" \
   | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
-CLIENT_UUID=$(curl -s "http://localhost:30090/admin/realms/crownlabs/clients?clientId=<client-id>" \
+CLIENT_UUID=$(curl -sk "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients?clientId=<client-id>" \
   -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['id'])")
-curl -s -X PUT "http://localhost:30090/admin/realms/crownlabs/clients/$CLIENT_UUID" \
+curl -sk -X PUT "https://keycloak.crownlabs.local/admin/realms/crownlabs/clients/$CLIENT_UUID" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"secret": "<your-chosen-known-value>"}'
 ```
 
-If the cluster is already running and you just want to push a freshly
-regenerated export (without reinstalling everything):
+If the cluster is already running, and you just want to push a freshly regenerated export without reinstalling everything:
 
 ```bash
 kubectl apply -f dev-local/keycloak/manifests/crownlabs-realm-configmap.yaml
 ```
 
-`--import-realm` **does not overwrite** an already-existing realm — this
-only updates the ConfigMap for future installs (or after deleting the
-existing realm).
+`--import-realm` **does not overwrite** an already-existing realm.
+This command only updates the ConfigMap for future installs, or for after you delete the existing realm.

--- a/dev-local/keycloak/regenerating-the-realm-export.md
+++ b/dev-local/keycloak/regenerating-the-realm-export.md
@@ -1,0 +1,61 @@
+# Regenerating the realm export
+
+If you manually change something in the local realm (new client, new
+scope, new user, etc.) and want to freeze it for future installs,
+regenerate the export and re-wrap it into the ConfigMap manifest:
+
+```bash
+export KUBECONFIG=~/.kube/config
+
+# runs the export while the pod is already running (kc.sh runs as a process separate
+# from the main server, so there's no need to stop Keycloak for a simple local snapshot)
+kubectl exec keycloak-0 -- rm -rf /tmp/export
+kubectl exec keycloak-0 -- /opt/keycloak/bin/kc.sh export --dir /tmp/export --realm crownlabs --users realm_file
+
+# copy the file out of the pod (the image has no 'tar', so 'kubectl cp' won't work: use 'cat' instead),
+# then wrap it into the ConfigMap manifest committed in this folder
+kubectl exec keycloak-0 -- cat /tmp/export/crownlabs-realm.json > /tmp/crownlabs-realm.json
+{
+  echo "# Generated from a \`kc.sh export\` of the crownlabs realm — do not hand-edit."
+  echo "# See regenerating-the-realm-export.md to refresh this file."
+  kubectl create configmap keycloak-realm-import \
+    --from-file=crownlabs-realm.json=/tmp/crownlabs-realm.json --dry-run=client -o yaml
+} > dev-local/keycloak/manifests/crownlabs-realm-configmap.yaml
+rm /tmp/crownlabs-realm.json
+```
+
+> **Note**: `kc.sh export` exits with an error (`Address already in use` on
+> port 9000) because the export process tries to start the management
+> interface on the same port already used by the running main server. **The
+> error is harmless and happens AFTER the data export has already
+> completed** (check the logs for `KC-SERVICES0035: Export finished
+> successfully` before the error). For an export without this warning, stop
+> Keycloak first (`kubectl scale statefulset keycloak --replicas=0`) as
+> recommended by the [official documentation](https://www.keycloak.org/server/importExport).
+
+**Before committing a new export**, always check that any newly
+auto-generated Keycloak client secrets are pinned to a known value (as done
+for `operator-local-dev-secret`) instead of ending up in the repo as a
+random string:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:30090/realms/master/protocol/openid-connect/token \
+  -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+CLIENT_UUID=$(curl -s "http://localhost:30090/admin/realms/crownlabs/clients?clientId=<client-id>" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['id'])")
+curl -s -X PUT "http://localhost:30090/admin/realms/crownlabs/clients/$CLIENT_UUID" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"secret": "<your-chosen-known-value>"}'
+```
+
+If the cluster is already running and you just want to push a freshly
+regenerated export (without reinstalling everything):
+
+```bash
+kubectl apply -f dev-local/keycloak/manifests/crownlabs-realm-configmap.yaml
+```
+
+`--import-realm` **does not overwrite** an already-existing realm — this
+only updates the ConfigMap for future installs (or after deleting the
+existing realm).

--- a/dev-local/local-development.md
+++ b/dev-local/local-development.md
@@ -1,45 +1,37 @@
 # Local development with Keycloak
 
-This guide explains how to bring up the whole CrownLabs stack locally (Keycloak, qlkube, frontend, operators) against an already-existing k3s cluster. Follow the steps in order: each component depends on the previous one.
+This guide explains how to bring up the whole CrownLabs stack locally (Keycloak, qlkube, frontend, operators), on top of an already-existing k3s cluster.
+Follow the steps in order: each component depends on the previous one.
 
 ## Prerequisites
 
-- The base k3s cluster, Envoy Gateway, Keycloak, and the CrownLabs operator
-  already set up — see [`base-k3s/README.md`](base-k3s/README.md),
-  [`envoy/README.md`](envoy/README.md), [`keycloak/README.md`](keycloak/README.md)
-  and [`operators/README.md`](operators/README.md), in that order.
-- Node.js (version pinned in `frontend/.nvmrc` and `qlkube/.nvmrc`).
+- The base k3s cluster, Envoy Gateway, Keycloak, and the CrownLabs operator, already set up. See [`base-k3s/README.md`](base-k3s/README.md), [`envoy/README.md`](envoy/README.md), [`keycloak/README.md`](keycloak/README.md), and [`operators/README.md`](operators/README.md), in that order.
+- Node.js (the version pinned in `frontend/.nvmrc` and `qlkube/.nvmrc`).
 
-The CrownLabs frontend dashboard itself is **not** exposed through Envoy Gateway — it
-only ever runs as a local `npm start` dev server on `localhost:3000`, same as qlkube.
-The Gateway is for services that need a stable, browser-reachable hostname without a
-dev server in front of them (Keycloak now, [Mailpit](mailpit/README.md) later).
+The CrownLabs frontend dashboard itself is **not** exposed through Envoy Gateway.
+It only ever runs as a local `npm start` dev server, on `localhost:3000`, the same as qlkube.
+The Gateway is for services that need a stable, browser-reachable hostname, without a dev server in front of them (Keycloak now, [Mailpit](mailpit/README.md) later).
 
 ## 1. Base k3s cluster, Envoy Gateway, Keycloak, and the operator
 
-Covered on their own, in order:
+These are covered on their own, in order:
 
-1. [`base-k3s/README.md`](base-k3s/README.md) — installing k3s and getting `kubectl` access.
-2. [`envoy/README.md`](envoy/README.md) — the single Envoy Gateway every locally-exposed
-   service (Keycloak now) is reachable through, at `https://<service>.crownlabs.local`.
-3. [`keycloak/README.md`](keycloak/README.md) — Keycloak (realm, clients, scopes, base
-   users) and, if you want the Kubernetes apiserver to enforce real per-user RBAC
-   instead of everything running as cluster-admin under `kubectl proxy`, the OIDC
-   integration with k3s.
-4. [`operators/README.md`](operators/README.md) — base RBAC and running the CrownLabs main operator.
+1. [`base-k3s/README.md`](base-k3s/README.md): install k3s, and get `kubectl` access.
+2. [`envoy/README.md`](envoy/README.md): set up the single Envoy Gateway every locally-exposed service (Keycloak, for now) is reachable through, at `https://<service>.crownlabs.local`.
+3. [`keycloak/README.md`](keycloak/README.md): set up Keycloak (realm, clients, scopes, base users). If you also want the Kubernetes API server to enforce real per-user RBAC, instead of everything running as cluster-admin under `kubectl proxy`, this also covers the OIDC integration with k3s.
+4. [`operators/README.md`](operators/README.md): set up base RBAC, and run the CrownLabs main operator.
 
-Follow those first; come back here once the main operator is up and reconciling.
+Follow those first. Come back here once the main operator is up and reconciling.
 
 ## 2. qlkube
 
 qlkube can talk to the cluster in two ways:
 
-- **`kubectl proxy`** (`IN_CLUSTER=false`, plain `npm run dev`) — the simplest option, but `kubectl proxy` always authenticates with its own kubeconfig credentials and ignores whatever bearer token the client sends, so every request runs as cluster-admin regardless of who is logged into the frontend. Fine for quick UI iteration when you don't care about RBAC.
-- **Direct apiserver connection** (`USE_LOCAL_CLUSTER=true`, `npm run dev-local-cluster`) — bypasses `kubectl proxy` and talks straight to the real apiserver, forwarding the caller's token as-is so the apiserver's own OIDC authenticator enforces per-user RBAC. Requires the k3s OIDC integration from [`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md) to be set up first, plus a bootstrap token for the one-off startup schema discovery call (see that same doc, Step 4).
+- **`kubectl proxy`** (`IN_CLUSTER=false`, plain `npm run dev`): the simplest option. `kubectl proxy` always authenticates with its own kubeconfig credentials, and ignores whatever bearer token the client sends, so every request runs as cluster-admin, no matter who is logged into the frontend. This is fine for quick UI iteration, when you do not care about RBAC.
+- **Direct API server connection** (`USE_LOCAL_CLUSTER=true`, `npm run dev-local-cluster`): this bypasses `kubectl proxy`, and talks straight to the real API server, forwarding the caller's token as-is, so the API server's own OIDC authenticator enforces per-user RBAC. This requires the k3s OIDC integration from [`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md) to be set up first, plus a bootstrap token for the one-off startup schema discovery call (see the same document, step 4).
 
-Either way, qlkube itself is unaffected by the move to Envoy Gateway — it keeps running
-locally and keeps talking to the apiserver's own port (`localhost:6443`) or through
-`kubectl proxy`, neither of which goes through the Gateway.
+Either way, qlkube itself is unaffected by the move to Envoy Gateway.
+It keeps running locally, and keeps talking to the API server's own port (`localhost:6443`) or through `kubectl proxy`. Neither of these goes through the Gateway.
 
 Option A — `kubectl proxy`:
 
@@ -53,27 +45,31 @@ npm install
 IN_CLUSTER=false CROWNLABS_QLKUBE_PORT=8085 npm run dev
 ```
 
-Option B — direct apiserver connection:
+Option B — direct API server connection:
 
 ```bash
-export LOCAL_K8S_BOOTSTRAP_TOKEN=$(kubectl create token qlkube-local -n default --duration=87600h)  # see apiserver-oidc-integration.md Step 5 for the qlkube-local ServiceAccount setup
+# See apiserver-oidc-integration.md step 5 for the qlkube-local ServiceAccount setup.
+export LOCAL_K8S_BOOTSTRAP_TOKEN=$(kubectl create token qlkube-local -n default --duration=87600h)
 cd qlkube
 npm install
 CROWNLABS_QLKUBE_PORT=8085 npm run dev-local-cluster
 ```
 
-Either way, the GraphQL playground/endpoint is at `http://localhost:8085/graph` (not the root — the path is configurable via `BASE_URL`).
+Either way, the GraphQL playground and endpoint are at `http://localhost:8085/graph`, not at the root. You can configure the path with `BASE_URL`.
 
 Verify:
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8085/graph/schema
-# expected: 200
+# Expected: 200.
 ```
 
 ### qlkube's local configuration files
 
-`qlkube/src/wrappers.js` and `qlkube/src/subscriptions.js` are **development** files: in production they're overwritten by the configuration Helm generates. If you get GraphQL errors like `Cannot query field "workspaceWrapperTenantV1alpha2"` or `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"` during local development, it means these files don't include every wrapper/subscription the frontend needs. Check the `*Wrapper*` fields referenced in `frontend/src/graphql-components/**` and make sure every referenced type (e.g. `TenantCrownlabsPolitoItTenantRef`, `WorkspacesListItem`) has a matching entry in `wrappers.js`, and every resource needed as a subscription (e.g. `tenants`) is listed in `subscriptions.js`.
+`qlkube/src/wrappers.js` and `qlkube/src/subscriptions.js` are **development** files.
+In production, Helm overwrites them with its own generated configuration.
+If you get GraphQL errors like `Cannot query field "workspaceWrapperTenantV1alpha2"`, or `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"`, during local development, it means these files do not include every wrapper or subscription the frontend needs.
+Check the `*Wrapper*` fields referenced in `frontend/src/graphql-components/**`, and make sure every referenced type (for example, `TenantCrownlabsPolitoItTenantRef`, `WorkspacesListItem`) has a matching entry in `wrappers.js`, and every resource needed as a subscription (for example, `tenants`) is listed in `subscriptions.js`.
 
 ## 3. Frontend
 
@@ -82,7 +78,7 @@ cd frontend
 cp .env.example .env
 ```
 
-Edit `frontend/.env` (never committed, it's in `.gitignore`) with the local endpoints:
+Edit `frontend/.env` (this file is never committed, since it is in `.gitignore`) with the local endpoints:
 
 ```bash
 VITE_APP_CROWNLABS_OIDC_AUTHORITY=https://keycloak.crownlabs.local/realms/crownlabs
@@ -90,22 +86,19 @@ VITE_APP_CROWNLABS_OIDC_CLIENT_ID=k8s
 VITE_APP_CROWNLABS_GRAPHQL_URL=http://localhost:8085/graph
 ```
 
-On WSL2, use `https://keycloak.crownlabs.local:8443/realms/crownlabs` for
-`VITE_APP_CROWNLABS_OIDC_AUTHORITY` instead — the Gateway bridge port from
-[`envoy/README.md`](envoy/README.md) step 5. This must exactly match whatever URL the
-browser actually reaches Keycloak through — see
-[`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md) Step 5.
+On WSL2, use `https://keycloak.crownlabs.local:8443/realms/crownlabs` for `VITE_APP_CROWNLABS_OIDC_AUTHORITY` instead: this is the Gateway bridge port from [`envoy/README.md`](envoy/README.md) step 5.
+This must exactly match the URL the browser actually uses to reach Keycloak. See step 5 in [`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md).
 
-The other variables (`VITE_APP_MYDRIVE_*`, `VITE_APP_CROWNLABS_IMAGELIST_*`, etc.) can stay as they are in `.env.example`.
+The other variables (`VITE_APP_MYDRIVE_*`, `VITE_APP_CROWNLABS_IMAGELIST_*`, and so on) can stay as they are in `.env.example`.
 
 ```bash
 npm install
 npm start
 ```
 
-The frontend is on `http://localhost:3000`.
+The frontend runs at `http://localhost:3000`.
 
-> **Don't edit `frontend/.env.example`** with local values: it's the shared template committed to the repo (used in production/by other developers). Local customizations only go in `.env`.
+> **Do not edit `frontend/.env.example`** with local values. It is the shared template committed to the repository, used in production and by other developers. Keep local customizations in `.env` only.
 
 ### If you change the GraphQL schema (wrappers.js, subscriptions.js, or frontend queries)
 
@@ -118,11 +111,8 @@ GRAPHQL_URL=http://localhost:8085/graph npm run generate
 
 ## 4. instance-operator
 
-The CrownLabs **main** operator (`Tenant`/`Workspace`/Keycloak roles) is
-already up at this point — it's a prerequisite covered in
-[`operators/README.md`](operators/README.md) (section 1 above). The
-separate **instance-operator** (manages `Instance` resources: deployment,
-VM, PVC, exposure) is a `local-development.md`-only step:
+The CrownLabs **main** operator (which manages `Tenant`, `Workspace`, and Keycloak roles) is already up at this point: it is a prerequisite, covered in [`operators/README.md`](operators/README.md) (section 1 above).
+The separate **instance-operator** manages `Instance` resources (deployment, VM, PVC, exposure). Starting it is a `local-development.md`-only step:
 
 ```bash
 cd operators
@@ -130,28 +120,32 @@ export KUBECONFIG=~/.kube/config
 make run-instance-local
 ```
 
-This target also applies the CRDs and the samples (`operators/samples/`) before starting the operator.
+This target also applies the CRDs and the samples (`operators/samples/`) before it starts the operator.
 
 ## 5. If the machine is low on RAM
 
-`keycloak.yaml` already ships with a single replica by default (high availability isn't needed for solo local development). If you scaled it up to test Keycloak's HA/Infinispan clustering and want to scale back down to free up RAM — a local cluster with Keycloak HA + Postgres + several test instances can easily saturate a k3s single-node's memory (e.g. ~8 GiB under WSL2):
+`keycloak.yaml` already ships with a single replica by default, since high availability is not needed for solo local development.
+If you scaled it up to test Keycloak's HA/Infinispan clustering, and now want to scale back down to free up RAM, use the command below.
+A local cluster with Keycloak HA, Postgres, and several test instances can easily saturate a k3s single node's memory (for example, around 8 GiB under WSL2):
 
 ```bash
 kubectl scale statefulset keycloak --replicas=1
 ```
 
-The pod with the lowest index (`keycloak-0`) is always the last one to go when scaling a StatefulSet down, so `https://keycloak.crownlabs.local` (routed through the Gateway to the `keycloak` Service, not tied to any specific pod) keeps working unchanged before, during and after the scale-down.
+When you scale a StatefulSet down, the pod with the lowest index (`keycloak-0`) is always the last one to go.
+This means `https://keycloak.crownlabs.local` keeps working unchanged before, during, and after the scale-down, since it routes through the Gateway to the `keycloak` Service, and is not tied to any specific pod.
 
 ## 6. Login
 
-Open `http://localhost:3000` and log in with the test user's credentials (see [`keycloak/README.md`](keycloak/README.md) for the default `john.doe` / `johndoe123`).
+Open `http://localhost:3000`, and log in with the test user's credentials.
+See [`keycloak/README.md`](keycloak/README.md) for the default `john.doe` / `johndoe123`.
 
 ## Port summary
 
 | Service | Local port | Command |
 |---|---|---|
-| Envoy Gateway (everything behind `*.crownlabs.local`, incl. Keycloak) | 80/443 (`:8443` on WSL2, bridged) | already exposed (`ServiceLB`, see [`envoy/README.md`](envoy/README.md)); WSL2: `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` |
-| kubectl proxy (apiserver, option A) | 8001 | `kubectl proxy --port=8001` |
+| Envoy Gateway (everything behind `*.crownlabs.local`, including Keycloak) | 80/443 (`:8443` on WSL2, bridged) | Already exposed (`ServiceLB`, see [`envoy/README.md`](envoy/README.md)). On WSL2: `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` |
+| kubectl proxy (API server, option A) | 8001 | `kubectl proxy --port=8001` |
 | qlkube (GraphQL) | 8085, path `/graph` | `CROWNLABS_QLKUBE_PORT=8085 npm run dev` (or `dev-local-cluster`) |
 | Frontend | 3000 | `npm start` |
 | instance-operator | 8080/8081 (default) | `make run-instance-local` |
@@ -161,12 +155,12 @@ Open `http://localhost:3000` and log in with the test user's credentials (see [`
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `invalid_scope: Invalid scopes: openid profile email api` at login | Client scope `api` missing from the realm | Should already be present if you installed from `keycloak/manifests/`; otherwise create it (Admin Console → Client Scopes) and add it as a default scope on the `k8s` client |
-| `Cannot query field "workspaceWrapperTenantV1alpha2"` / `"tenantV1alpha2Wrapper"` | Missing wrapper in `qlkube/src/wrappers.js` | See section 2, "qlkube's local configuration files" |
-| `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"` | Missing `tenants` resource in `qlkube/src/subscriptions.js` | See section 2 |
-| Login OK but empty dashboard, tenant always "not ready" | Keycloak user not verified (`emailVerified: false`) and/or main operator not running | Verify the user in Keycloak, run the main operator (`operators/README.md`) |
-| `bind: address already in use` restarting a port-forward/operator | A previous process (often the compiled Go binary, not the wrapper script) is still alive | `ss -tlnp \| grep <port>` to find the real PID, then `kill -9 <pid>` |
-| Refresh token rejected (`400` on `/protocol/openid-connect/token`, Keycloak log `"Token is not active"`) | With more than 1 Keycloak replica, the Service can route a request to a different pod than the one that issued the token (Infinispan session cache isn't perfectly synced) | Scale down to 1 replica (section 5, and the default) |
-| `PersistentVolumeClaim ... spec.resources[storage]: Invalid value: "0"` | Template with `persistent: true` but no `disk` set | Set a `disk` value in the template |
-| `Service "..." is invalid: spec.ports: Required value` | `Container`/`Standalone` environment with `guiEnabled: false` (bug fixed in `operators/pkg/forge/services.go`) | Confirm the fix is present in the branch you're using |
-| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket; WSL2's `localhostForwarding` only relays real sockets — tested and confirmed true in both `networkingMode` settings (`NAT` and `mirrored`), switching to mirrored does **not** fix it | `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` (a *different* port than 80/443 themselves — reusing them gets hijacked by kube-proxy's own iptables rules and times out) — see `envoy/README.md` step 5 |
+| `invalid_scope: Invalid scopes: openid profile email api` at login | The `api` client scope is missing from the realm | This should already be present if you installed from `keycloak/manifests/`. Otherwise, create it (Admin Console → Client Scopes), and add it as a default scope on the `k8s` client |
+| `Cannot query field "workspaceWrapperTenantV1alpha2"` / `"tenantV1alpha2Wrapper"` | A wrapper is missing in `qlkube/src/wrappers.js` | See section 2, "qlkube's local configuration files" |
+| `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"` | The `tenants` resource is missing in `qlkube/src/subscriptions.js` | See section 2 |
+| Login works, but the dashboard is empty, and the tenant is always "not ready" | The Keycloak user is not verified (`emailVerified: false`), or the main operator is not running | Verify the user in Keycloak, and run the main operator (`operators/README.md`) |
+| `bind: address already in use` restarting a port-forward or operator | A previous process (often the compiled Go binary, not the wrapper script) is still alive | Run `ss -tlnp \| grep <port>` to find the real PID, then `kill -9 <pid>` |
+| Refresh token rejected (`400` on `/protocol/openid-connect/token`, Keycloak log says `"Token is not active"`) | With more than 1 Keycloak replica, the Service can route a request to a different pod than the one that issued the token (the Infinispan session cache is not perfectly synced) | Scale down to 1 replica (section 5, and the default) |
+| `PersistentVolumeClaim ... spec.resources[storage]: Invalid value: "0"` | A template has `persistent: true`, but no `disk` value set | Set a `disk` value in the template |
+| `Service "..." is invalid: spec.ports: Required value` | A `Container`/`Standalone` environment has `guiEnabled: false` (a bug, fixed in `operators/pkg/forge/services.go`) | Confirm the fix is present in the branch you are using |
+| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket. WSL2's `localhostForwarding` only relays real sockets. We tested this on both `networkingMode` settings (`NAT` and `mirrored`): switching to `mirrored` does **not** fix it | Run `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` (a port different from 80/443 themselves: reusing them gets hijacked by kube-proxy's own `iptables` rules, and times out). See `envoy/README.md` step 5 |

--- a/dev-local/local-development.md
+++ b/dev-local/local-development.md
@@ -1,0 +1,172 @@
+# Local development with Keycloak
+
+This guide explains how to bring up the whole CrownLabs stack locally (Keycloak, qlkube, frontend, operators) against an already-existing k3s cluster. Follow the steps in order: each component depends on the previous one.
+
+## Prerequisites
+
+- The base k3s cluster, Envoy Gateway, Keycloak, and the CrownLabs operator
+  already set up — see [`base-k3s/README.md`](base-k3s/README.md),
+  [`envoy/README.md`](envoy/README.md), [`keycloak/README.md`](keycloak/README.md)
+  and [`operators/README.md`](operators/README.md), in that order.
+- Node.js (version pinned in `frontend/.nvmrc` and `qlkube/.nvmrc`).
+
+The CrownLabs frontend dashboard itself is **not** exposed through Envoy Gateway — it
+only ever runs as a local `npm start` dev server on `localhost:3000`, same as qlkube.
+The Gateway is for services that need a stable, browser-reachable hostname without a
+dev server in front of them (Keycloak now, [Mailpit](mailpit/README.md) later).
+
+## 1. Base k3s cluster, Envoy Gateway, Keycloak, and the operator
+
+Covered on their own, in order:
+
+1. [`base-k3s/README.md`](base-k3s/README.md) — installing k3s and getting `kubectl` access.
+2. [`envoy/README.md`](envoy/README.md) — the single Envoy Gateway every locally-exposed
+   service (Keycloak now) is reachable through, at `https://<service>.crownlabs.local`.
+3. [`keycloak/README.md`](keycloak/README.md) — Keycloak (realm, clients, scopes, base
+   users) and, if you want the Kubernetes apiserver to enforce real per-user RBAC
+   instead of everything running as cluster-admin under `kubectl proxy`, the OIDC
+   integration with k3s.
+4. [`operators/README.md`](operators/README.md) — base RBAC and running the CrownLabs main operator.
+
+Follow those first; come back here once the main operator is up and reconciling.
+
+## 2. qlkube
+
+qlkube can talk to the cluster in two ways:
+
+- **`kubectl proxy`** (`IN_CLUSTER=false`, plain `npm run dev`) — the simplest option, but `kubectl proxy` always authenticates with its own kubeconfig credentials and ignores whatever bearer token the client sends, so every request runs as cluster-admin regardless of who is logged into the frontend. Fine for quick UI iteration when you don't care about RBAC.
+- **Direct apiserver connection** (`USE_LOCAL_CLUSTER=true`, `npm run dev-local-cluster`) — bypasses `kubectl proxy` and talks straight to the real apiserver, forwarding the caller's token as-is so the apiserver's own OIDC authenticator enforces per-user RBAC. Requires the k3s OIDC integration from [`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md) to be set up first, plus a bootstrap token for the one-off startup schema discovery call (see that same doc, Step 4).
+
+Either way, qlkube itself is unaffected by the move to Envoy Gateway — it keeps running
+locally and keeps talking to the apiserver's own port (`localhost:6443`) or through
+`kubectl proxy`, neither of which goes through the Gateway.
+
+Option A — `kubectl proxy`:
+
+```bash
+kubectl proxy --port=8001
+```
+
+```bash
+cd qlkube
+npm install
+IN_CLUSTER=false CROWNLABS_QLKUBE_PORT=8085 npm run dev
+```
+
+Option B — direct apiserver connection:
+
+```bash
+export LOCAL_K8S_BOOTSTRAP_TOKEN=$(kubectl create token qlkube-local -n default --duration=87600h)  # see apiserver-oidc-integration.md Step 5 for the qlkube-local ServiceAccount setup
+cd qlkube
+npm install
+CROWNLABS_QLKUBE_PORT=8085 npm run dev-local-cluster
+```
+
+Either way, the GraphQL playground/endpoint is at `http://localhost:8085/graph` (not the root — the path is configurable via `BASE_URL`).
+
+Verify:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8085/graph/schema
+# expected: 200
+```
+
+### qlkube's local configuration files
+
+`qlkube/src/wrappers.js` and `qlkube/src/subscriptions.js` are **development** files: in production they're overwritten by the configuration Helm generates. If you get GraphQL errors like `Cannot query field "workspaceWrapperTenantV1alpha2"` or `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"` during local development, it means these files don't include every wrapper/subscription the frontend needs. Check the `*Wrapper*` fields referenced in `frontend/src/graphql-components/**` and make sure every referenced type (e.g. `TenantCrownlabsPolitoItTenantRef`, `WorkspacesListItem`) has a matching entry in `wrappers.js`, and every resource needed as a subscription (e.g. `tenants`) is listed in `subscriptions.js`.
+
+## 3. Frontend
+
+```bash
+cd frontend
+cp .env.example .env
+```
+
+Edit `frontend/.env` (never committed, it's in `.gitignore`) with the local endpoints:
+
+```bash
+VITE_APP_CROWNLABS_OIDC_AUTHORITY=https://keycloak.crownlabs.local/realms/crownlabs
+VITE_APP_CROWNLABS_OIDC_CLIENT_ID=k8s
+VITE_APP_CROWNLABS_GRAPHQL_URL=http://localhost:8085/graph
+```
+
+On WSL2, use `https://keycloak.crownlabs.local:8443/realms/crownlabs` for
+`VITE_APP_CROWNLABS_OIDC_AUTHORITY` instead — the Gateway bridge port from
+[`envoy/README.md`](envoy/README.md) step 5. This must exactly match whatever URL the
+browser actually reaches Keycloak through — see
+[`keycloak/apiserver-oidc-integration.md`](keycloak/apiserver-oidc-integration.md) Step 5.
+
+The other variables (`VITE_APP_MYDRIVE_*`, `VITE_APP_CROWNLABS_IMAGELIST_*`, etc.) can stay as they are in `.env.example`.
+
+```bash
+npm install
+npm start
+```
+
+The frontend is on `http://localhost:3000`.
+
+> **Don't edit `frontend/.env.example`** with local values: it's the shared template committed to the repo (used in production/by other developers). Local customizations only go in `.env`.
+
+### If you change the GraphQL schema (wrappers.js, subscriptions.js, or frontend queries)
+
+Regenerate the TypeScript types from qlkube's live schema:
+
+```bash
+cd frontend
+GRAPHQL_URL=http://localhost:8085/graph npm run generate
+```
+
+## 4. instance-operator
+
+The CrownLabs **main** operator (`Tenant`/`Workspace`/Keycloak roles) is
+already up at this point — it's a prerequisite covered in
+[`operators/README.md`](operators/README.md) (section 1 above). The
+separate **instance-operator** (manages `Instance` resources: deployment,
+VM, PVC, exposure) is a `local-development.md`-only step:
+
+```bash
+cd operators
+export KUBECONFIG=~/.kube/config
+make run-instance-local
+```
+
+This target also applies the CRDs and the samples (`operators/samples/`) before starting the operator.
+
+## 5. If the machine is low on RAM
+
+`keycloak.yaml` already ships with a single replica by default (high availability isn't needed for solo local development). If you scaled it up to test Keycloak's HA/Infinispan clustering and want to scale back down to free up RAM — a local cluster with Keycloak HA + Postgres + several test instances can easily saturate a k3s single-node's memory (e.g. ~8 GiB under WSL2):
+
+```bash
+kubectl scale statefulset keycloak --replicas=1
+```
+
+The pod with the lowest index (`keycloak-0`) is always the last one to go when scaling a StatefulSet down, so `https://keycloak.crownlabs.local` (routed through the Gateway to the `keycloak` Service, not tied to any specific pod) keeps working unchanged before, during and after the scale-down.
+
+## 6. Login
+
+Open `http://localhost:3000` and log in with the test user's credentials (see [`keycloak/README.md`](keycloak/README.md) for the default `john.doe` / `johndoe123`).
+
+## Port summary
+
+| Service | Local port | Command |
+|---|---|---|
+| Envoy Gateway (everything behind `*.crownlabs.local`, incl. Keycloak) | 80/443 (`:8443` on WSL2, bridged) | already exposed (`ServiceLB`, see [`envoy/README.md`](envoy/README.md)); WSL2: `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` |
+| kubectl proxy (apiserver, option A) | 8001 | `kubectl proxy --port=8001` |
+| qlkube (GraphQL) | 8085, path `/graph` | `CROWNLABS_QLKUBE_PORT=8085 npm run dev` (or `dev-local-cluster`) |
+| Frontend | 3000 | `npm start` |
+| instance-operator | 8080/8081 (default) | `make run-instance-local` |
+| main operator | 18080/18081/18082 | `make run-operator-local` |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `invalid_scope: Invalid scopes: openid profile email api` at login | Client scope `api` missing from the realm | Should already be present if you installed from `keycloak/manifests/`; otherwise create it (Admin Console → Client Scopes) and add it as a default scope on the `k8s` client |
+| `Cannot query field "workspaceWrapperTenantV1alpha2"` / `"tenantV1alpha2Wrapper"` | Missing wrapper in `qlkube/src/wrappers.js` | See section 2, "qlkube's local configuration files" |
+| `Cannot query field "itPolitoCrownlabsV1alpha2TenantUpdate" on type "Subscription"` | Missing `tenants` resource in `qlkube/src/subscriptions.js` | See section 2 |
+| Login OK but empty dashboard, tenant always "not ready" | Keycloak user not verified (`emailVerified: false`) and/or main operator not running | Verify the user in Keycloak, run the main operator (`operators/README.md`) |
+| `bind: address already in use` restarting a port-forward/operator | A previous process (often the compiled Go binary, not the wrapper script) is still alive | `ss -tlnp \| grep <port>` to find the real PID, then `kill -9 <pid>` |
+| Refresh token rejected (`400` on `/protocol/openid-connect/token`, Keycloak log `"Token is not active"`) | With more than 1 Keycloak replica, the Service can route a request to a different pod than the one that issued the token (Infinispan session cache isn't perfectly synced) | Scale down to 1 replica (section 5, and the default) |
+| `PersistentVolumeClaim ... spec.resources[storage]: Invalid value: "0"` | Template with `persistent: true` but no `disk` set | Set a `disk` value in the template |
+| `Service "..." is invalid: spec.ports: Required value` | `Container`/`Standalone` environment with `guiEnabled: false` (bug fixed in `operators/pkg/forge/services.go`) | Confirm the fix is present in the branch you're using |
+| Browser: `ERR_CONNECTION_REFUSED` on `https://keycloak.crownlabs.local/...` (WSL2 only) | The Gateway's `LoadBalancer` Service has no real listening socket; WSL2's `localhostForwarding` only relays real sockets — tested and confirmed true in both `networkingMode` settings (`NAT` and `mirrored`), switching to mirrored does **not** fix it | `kubectl port-forward -n envoy-gateway-system svc/<gateway-service> 8443:443` (a *different* port than 80/443 themselves — reusing them gets hijacked by kube-proxy's own iptables rules and times out) — see `envoy/README.md` step 5 |

--- a/dev-local/mailpit/README.md
+++ b/dev-local/mailpit/README.md
@@ -1,0 +1,75 @@
+# Mailpit — local fake mail server
+
+[Mailpit](https://mailpit.axllent.org/) is a fake SMTP server + web UI: anything sent to
+its SMTP port shows up in a browser inbox instead of actually being delivered. Useful
+for testing any CrownLabs component that sends real email (e.g. tenant notifications)
+against a local cluster, without needing a real mail provider.
+
+## Prerequisites
+
+- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md) set up (Gateway API CRDs, the controller, the
+  shared `crownlabs` Gateway) — Mailpit's web UI is exposed entirely through the
+  `HTTPRoute` in `manifests/mailpit.yaml`, which needs that `Gateway` to already exist.
+
+## Deploy
+
+```bash
+kubectl apply -f dev-local/mailpit/manifests
+kubectl rollout status deployment/mailpit
+```
+
+This creates:
+- The `mailpit` `Deployment` (image `axllent/mailpit`). No persistence — Mailpit
+  defaults to an in-memory message store when `MP_DATABASE` isn't set, same ephemeral
+  tradeoff already made for Postgres in `../keycloak/manifests/keycloak.yaml`. No auth
+  (`MP_SMTP_AUTH_ACCEPT_ANY=1`) — this is local dev only.
+- `Service mailpit-smtp` (port 1025) — **ClusterIP only, not exposed through the
+  Gateway**. SMTP isn't HTTP, so it can't go behind an `HTTPRoute`; this is consumed
+  in-cluster by whatever CrownLabs component ends up sending mail
+  (`mailpit-smtp.default.svc.cluster.local:1025`).
+- `Service mailpit` (port 8025, the web UI) + an `HTTPRoute` routing
+  `mail.crownlabs.local` to it through the shared `crownlabs` Gateway — same pattern as
+  [`../keycloak/manifests/keycloak.yaml`](../keycloak/manifests/keycloak.yaml)'s own
+  `HTTPRoute`.
+
+## `/etc/hosts`
+
+Add the hostname alongside Keycloak's (see [`../envoy/README.md`](../envoy/README.md)
+step 4 — same WSL2 caveat applies: the Windows-side hosts file needs this too, not just
+WSL2's):
+
+```bash
+echo "127.0.0.1 mail.crownlabs.local" | sudo tee -a /etc/hosts
+```
+
+(WSL2 browser: `Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 mail.crownlabs.local"` from an elevated PowerShell.)
+
+## Test it
+
+**Send a test message** — from anywhere inside the cluster (no auth, no TLS on the SMTP
+side):
+
+```bash
+kubectl run mailtest --rm -i --restart=Never --image=alpine --quiet -- sh -c '
+apk add --no-cache netcat-openbsd >/dev/null 2>&1
+printf "HELO test\r\nMAIL FROM:<test@crownlabs.local>\r\nRCPT TO:<john.doe@crownlabs.local>\r\nDATA\r\nSubject: Test\r\n\r\nHello from a test message.\r\n.\r\nQUIT\r\n" \
+  | nc -w 3 mailpit-smtp.default.svc.cluster.local 1025
+'
+# expected: "250 2.0.0 Ok: queued as <id>" in the output
+```
+
+**See it arrive** — open `https://mail.crownlabs.local` (WSL2: append `:8443`, same
+bridge as Keycloak, see [`../envoy/README.md`](../envoy/README.md) step 5) in a browser:
+the message shows up in the inbox immediately, no refresh needed (Mailpit pushes new
+messages over websocket/SSE). Or hit the API directly:
+
+```bash
+curl -sk https://mail.crownlabs.local/api/v1/messages   # WSL2: :8443
+```
+
+## Next
+
+- [`../envoy/README.md`](../envoy/README.md) — the shared Gateway this routes through.
+- [Mailpit's runtime options](https://mailpit.axllent.org/docs/configuration/runtime-options/)
+  if you need to tweak retention, add basic auth, etc.

--- a/dev-local/mailpit/README.md
+++ b/dev-local/mailpit/README.md
@@ -1,15 +1,15 @@
 # Mailpit — local fake mail server
 
-[Mailpit](https://mailpit.axllent.org/) is a fake SMTP server + web UI: anything sent to
-its SMTP port shows up in a browser inbox instead of actually being delivered. Useful
-for testing any CrownLabs component that sends real email (e.g. tenant notifications)
-against a local cluster, without needing a real mail provider.
+[Mailpit](https://mailpit.axllent.org/) is a fake SMTP server with a web UI.
+Anything sent to its SMTP port shows up in a browser inbox, instead of actually being delivered.
+This is useful for testing any CrownLabs component that sends real email (for example, tenant notifications) against a local cluster, without needing a real mail provider.
 
 ## Prerequisites
 
-- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
-- [Envoy Gateway](../envoy/README.md) set up (Gateway API CRDs, the controller, the
-  shared `crownlabs` Gateway) — Mailpit's web UI is exposed entirely through the
+- The base k3s cluster. See [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md) set up: the Gateway API CRDs, the controller, and the
+  shared `crownlabs` Gateway.
+  - Mailpit's web UI exposed entirely through the
   `HTTPRoute` in `manifests/mailpit.yaml`, which needs that `Gateway` to already exist.
 
 ## Deploy
@@ -20,35 +20,27 @@ kubectl rollout status deployment/mailpit
 ```
 
 This creates:
-- The `mailpit` `Deployment` (image `axllent/mailpit`). No persistence — Mailpit
-  defaults to an in-memory message store when `MP_DATABASE` isn't set, same ephemeral
-  tradeoff already made for Postgres in `../keycloak/manifests/keycloak.yaml`. No auth
-  (`MP_SMTP_AUTH_ACCEPT_ANY=1`) — this is local dev only.
-- `Service mailpit-smtp` (port 1025) — **ClusterIP only, not exposed through the
-  Gateway**. SMTP isn't HTTP, so it can't go behind an `HTTPRoute`; this is consumed
-  in-cluster by whatever CrownLabs component ends up sending mail
-  (`mailpit-smtp.default.svc.cluster.local:1025`).
-- `Service mailpit` (port 8025, the web UI) + an `HTTPRoute` routing
-  `mail.crownlabs.local` to it through the shared `crownlabs` Gateway — same pattern as
-  [`../keycloak/manifests/keycloak.yaml`](../keycloak/manifests/keycloak.yaml)'s own
-  `HTTPRoute`.
+- The `mailpit` `Deployment` (image `axllent/mailpit`). It has no persistence: Mailpit defaults to an in-memory message store when `MP_DATABASE` is not set, the same ephemeral tradeoff already made for Postgres in `../keycloak/manifests/keycloak.yaml`. It has no authentication (`MP_SMTP_AUTH_ACCEPT_ANY=1`), since this is local development only.
+- `Service mailpit-smtp` (port 1025). This is **ClusterIP only, and not exposed through the Gateway**. SMTP is not HTTP, so it cannot go behind an `HTTPRoute`. Whatever CrownLabs component ends up sending mail consumes this in-cluster, at `mailpit-smtp.default.svc.cluster.local:1025`.
+- `Service mailpit` (port 8025, the web UI), and an `HTTPRoute` that routes `mail.crownlabs.local` to it through the shared `crownlabs` Gateway. This is the same pattern used by [`../keycloak/manifests/keycloak.yaml`](../keycloak/manifests/keycloak.yaml)'s own `HTTPRoute`.
 
 ## `/etc/hosts`
 
-Add the hostname alongside Keycloak's (see [`../envoy/README.md`](../envoy/README.md)
-step 4 — same WSL2 caveat applies: the Windows-side hosts file needs this too, not just
-WSL2's):
+Add the hostname alongside Keycloak's.
+See [`../envoy/README.md`](../envoy/README.md) step 4: the same WSL2 caveat applies, and the Windows-side hosts file needs this too, not just WSL2's.
 
 ```bash
 echo "127.0.0.1 mail.crownlabs.local" | sudo tee -a /etc/hosts
 ```
 
-(WSL2 browser: `Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 mail.crownlabs.local"` from an elevated PowerShell.)
+On the WSL2 browser, run this from an elevated PowerShell instead:
+```powershell
+Add-Content -Path C:\Windows\System32\drivers\etc\hosts -Value "127.0.0.1 mail.crownlabs.local"
+```
 
 ## Test it
 
-**Send a test message** — from anywhere inside the cluster (no auth, no TLS on the SMTP
-side):
+**Send a test message**, from anywhere inside the cluster. There is no authentication, and no TLS, on the SMTP side:
 
 ```bash
 kubectl run mailtest --rm -i --restart=Never --image=alpine --quiet -- sh -c '
@@ -56,20 +48,18 @@ apk add --no-cache netcat-openbsd >/dev/null 2>&1
 printf "HELO test\r\nMAIL FROM:<test@crownlabs.local>\r\nRCPT TO:<john.doe@crownlabs.local>\r\nDATA\r\nSubject: Test\r\n\r\nHello from a test message.\r\n.\r\nQUIT\r\n" \
   | nc -w 3 mailpit-smtp.default.svc.cluster.local 1025
 '
-# expected: "250 2.0.0 Ok: queued as <id>" in the output
+# Expected: "250 2.0.0 Ok: queued as <id>" in the output.
 ```
 
-**See it arrive** — open `https://mail.crownlabs.local` (WSL2: append `:8443`, same
-bridge as Keycloak, see [`../envoy/README.md`](../envoy/README.md) step 5) in a browser:
-the message shows up in the inbox immediately, no refresh needed (Mailpit pushes new
-messages over websocket/SSE). Or hit the API directly:
+**See it arrive.** Open `https://mail.crownlabs.local` in a browser (on WSL2, append `:8443`; this is the same bridge used for Keycloak, see [`../envoy/README.md`](../envoy/README.md) step 5).
+The message shows up in the inbox immediately, with no refresh needed, since Mailpit pushes new messages over WebSocket/SSE.
+Or hit the API directly:
 
 ```bash
-curl -sk https://mail.crownlabs.local/api/v1/messages   # WSL2: :8443
+curl -sk https://mail.crownlabs.local/api/v1/messages   # On WSL2: :8443
 ```
 
 ## Next
 
-- [`../envoy/README.md`](../envoy/README.md) — the shared Gateway this routes through.
-- [Mailpit's runtime options](https://mailpit.axllent.org/docs/configuration/runtime-options/)
-  if you need to tweak retention, add basic auth, etc.
+- [`../envoy/README.md`](../envoy/README.md): the shared Gateway this routes through.
+- [Mailpit's runtime options](https://mailpit.axllent.org/docs/configuration/runtime-options/), if you need to tweak retention, add basic authentication, and so on.

--- a/dev-local/mailpit/manifests/mailpit.yaml
+++ b/dev-local/mailpit/manifests/mailpit.yaml
@@ -1,0 +1,108 @@
+# Mailpit: fake SMTP server + web UI for local email testing. No persistence
+# (Mailpit defaults to an in-memory message store when MP_DATABASE isn't
+# set — fine for local dev, same ephemeral tradeoff already made for
+# Postgres in ../../keycloak/manifests/keycloak.yaml).
+#
+# Two Services, deliberately not symmetric:
+# - 'mailpit-smtp' (1025) stays ClusterIP-only. SMTP isn't HTTP, so it can't
+#   go behind an HTTPRoute — it's consumed in-cluster by whatever CrownLabs
+#   component ends up sending mail.
+# - 'mailpit' (8025, the web UI) is ClusterIP too, but gets routed through
+#   the shared Gateway via the HTTPRoute below — see ../../envoy/README.md.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailpit-smtp
+  labels:
+    app: mailpit
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 1025
+      targetPort: smtp
+      name: smtp
+  selector:
+    app: mailpit
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailpit
+  labels:
+    app: mailpit
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 8025
+      targetPort: http
+      name: http
+  selector:
+    app: mailpit
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mailpit
+  labels:
+    app: mailpit
+spec:
+  parentRefs:
+    - name: crownlabs
+      sectionName: https
+  hostnames:
+    - mail.crownlabs.local
+  rules:
+    - backendRefs:
+        - name: mailpit
+          port: 8025
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailpit
+  labels:
+    app: mailpit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mailpit
+  template:
+    metadata:
+      labels:
+        app: mailpit
+    spec:
+      containers:
+        - name: mailpit
+          image: axllent/mailpit:latest
+          env:
+            # No auth needed for local dev: accept any SMTP credentials
+            # (or none) instead of tracking a set of fake ones.
+            - name: MP_SMTP_AUTH_ACCEPT_ANY
+              value: "1"
+            - name: MP_SMTP_AUTH_ALLOW_INSECURE
+              value: "1"
+          ports:
+            - name: smtp
+              containerPort: 1025
+            - name: http
+              containerPort: 8025
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8025
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8025
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi

--- a/dev-local/operators/README.md
+++ b/dev-local/operators/README.md
@@ -1,0 +1,133 @@
+# CrownLabs operator — local setup
+
+Base RBAC and running the CrownLabs main operator against the local realm,
+so `Tenant`/`Workspace` resources actually reconcile (personal namespace,
+`mydrive`, Keycloak `RoleBinding`s) instead of sitting there unowned.
+
+## Prerequisites
+
+- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md), Keycloak, and the k3s apiserver OIDC
+  integration — see [`../keycloak/README.md`](../keycloak/README.md). The
+  operator needs the realm's `operator-local` client secret and the CA
+  certificate extracted in that guide's Step 2.
+- `helm` (to render the base RBAC resources from the real chart, below).
+- Go >= 1.25.
+
+## 1. Base CrownLabs RBAC (`ClusterRole`/`ClusterRoleBinding`)
+
+The operator's per-tenant/per-workspace `RoleBinding`s reference base
+`ClusterRole`s (`crownlabs-manage-tenants`, `crownlabs-manage-instances`,
+`crownlabs-view-workspaces`, ...) that are normally installed by the main
+Helm chart — but are missing here since these local steps run the operator
+directly via `go run`/`make`, not through Helm. Render them straight from
+the real chart (`deploy/crownlabs`) instead of keeping a hand-maintained
+copy that can drift from it:
+
+```bash
+cd dev-local/keycloak   # the chart's clusterroles/clusterrolebindings templates
+                        # are rendered relative to this folder's location
+helm dependency build ../../deploy/crownlabs   # one-time; only needed if deploy/crownlabs/charts is empty
+helm template -s templates/clusterroles.yaml -s templates/clusterrolebindings.yaml ../../deploy/crownlabs | kubectl apply -f -
+```
+
+Purely additive: creating a `ClusterRole` grants nothing by itself until
+something is bound to it, so applying this is always safe, and safe to
+re-run any time the chart's RBAC templates change.
+
+## 2. Run the CrownLabs operator
+
+```bash
+export SSL_CERT_FILE=~/certs/crownlabs-ca.crt   # the operator's Go HTTP client must trust the Gateway's self-signed cert too (see ../keycloak/README.md Step 2)
+
+cd operators
+make run-operator-local KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret
+```
+
+`KEYCLOAK_URL` defaults to `https://keycloak.crownlabs.local` (the Gateway's
+`HTTPRoute` hostname, see [`../envoy/README.md`](../envoy/README.md)).
+
+> **On WSL2**: also override `KEYCLOAK_URL` to the Gateway's port-forward bridge
+> (Keycloak isn't reachable from WSL2 itself either, not just from the Windows
+> browser — see `../envoy/README.md` step 5 for why):
+> ```bash
+> make run-operator-local KEYCLOAK_URL=https://keycloak.crownlabs.local:8443 KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret
+> ```
+
+`run-operator-local` (in `operators/Makefile`) already sets
+`KEYCLOAK_URL`/`KEYCLOAK_REALM`/`KEYCLOAK_CLIENT_ID`/`KEYCLOAK_TARGET_CLIENT`
+to match the local realm, and `MYDRIVE_STORAGE_CLASS=local-path` (k3s's
+default storage class — override if yours differs). Only
+`KEYCLOAK_CLIENT_SECRET` needs to be passed explicitly (it's per-realm-install,
+so there's no sensible default to bake in — see `../keycloak/README.md` for
+the value this realm export ships with).
+
+Applying CRDs and `operators/samples/` is a prerequisite of the target
+(same pattern as `run-instance-local`), so **sample `Tenant`/`Workspace`/
+`Template` resources are created automatically** — no separate step needed.
+If you'd rather test with a real Keycloak user instead of (or in addition
+to) the samples, create a matching `Tenant` by hand, e.g. for `john.doe`:
+
+```bash
+kubectl apply -f - <<'EOF'
+apiVersion: crownlabs.polito.it/v1alpha2
+kind: Tenant
+metadata:
+  name: john.doe
+  labels:
+    crownlabs.polito.it/operator-selector: local
+spec:
+  email: john.doe@example.com
+  firstName: John
+  lastName: Doe
+  workspaces: []
+EOF
+```
+
+The operator starts reconciling automatically.
+
+> **Gotcha**: `run-operator-local` (and `run-instance-local`) re-apply
+> `operators/samples/` on every run. `kubectl apply` does a 3-way merge
+> against the *last-applied-configuration* it recorded — not against
+> whatever the object currently looks like — so any field you changed
+> out-of-band with `kubectl patch` (e.g. adding a `Workspace` enrollment to
+> `Tenant.spec.workspaces` per Step 7 of
+> `../keycloak/apiserver-oidc-integration.md`) gets **silently reverted** to
+> whatever `operators/samples/tenant.yml` says the next time this target
+> runs, since that patch was never reflected in the sample file. Symptom: a
+> `403 Forbidden` on a namespace/role that worked a moment ago. Fix:
+> re-apply the `kubectl patch`, or (if it's a mapping you want to keep
+> permanently) add it to the sample file itself instead of patching the
+> live object.
+
+### Forcing a reconciliation
+
+The operator doesn't watch Keycloak in real time (no active webhook
+locally). If you change something on the Keycloak side (e.g. verify a user)
+and want the operator to pick it up immediately, force a new reconciliation
+with a harmless annotation:
+
+```bash
+kubectl annotate tenant.crownlabs.polito.it <tenant-name> crownlabs.polito.it/force-reconcile="$(date +%s)" --overwrite
+```
+
+## Final checks
+
+```bash
+kubectl get pods -A
+# everything Running/Completed, no CrashLoopBackOff
+
+kubectl get tenants
+kubectl describe tenant <tenant-name>
+# status.ready: true, no reconciliation errors
+```
+
+Expected end state:
+- ✅ Base `ClusterRole`/`ClusterRoleBinding`s applied.
+- ✅ CrownLabs operator running, `Tenant`/`Workspace` reconciled.
+
+## Next
+
+For qlkube (talking directly to the real apiserver instead of through
+`kubectl proxy`) and the frontend, see
+[`../local-development.md`](../local-development.md).

--- a/dev-local/operators/README.md
+++ b/dev-local/operators/README.md
@@ -1,72 +1,60 @@
 # CrownLabs operator — local setup
 
-Base RBAC and running the CrownLabs main operator against the local realm,
-so `Tenant`/`Workspace` resources actually reconcile (personal namespace,
-`mydrive`, Keycloak `RoleBinding`s) instead of sitting there unowned.
+This guide explains how to set up base RBAC, and how to run the CrownLabs main operator against the local realm.
+Without this, `Tenant` and `Workspace` resources never reconcile: no personal namespace, no `mydrive`, and no Keycloak `RoleBinding`s. They just sit there, unowned.
 
 ## Prerequisites
 
-- The base k3s cluster — see [`../base-k3s/README.md`](../base-k3s/README.md).
-- [Envoy Gateway](../envoy/README.md), Keycloak, and the k3s apiserver OIDC
-  integration — see [`../keycloak/README.md`](../keycloak/README.md). The
-  operator needs the realm's `operator-local` client secret and the CA
-  certificate extracted in that guide's Step 2.
+- The base k3s cluster. See [`../base-k3s/README.md`](../base-k3s/README.md).
+- [Envoy Gateway](../envoy/README.md), Keycloak, and the k3s API server OIDC integration. See [`../keycloak/README.md`](../keycloak/README.md).
+  The operator needs the realm's `operator-local` client secret, and the CA certificate you extracted in that guide's step 2.
 - `helm` (to render the base RBAC resources from the real chart, below).
 - Go >= 1.25.
 
 ## 1. Base CrownLabs RBAC (`ClusterRole`/`ClusterRoleBinding`)
 
-The operator's per-tenant/per-workspace `RoleBinding`s reference base
-`ClusterRole`s (`crownlabs-manage-tenants`, `crownlabs-manage-instances`,
-`crownlabs-view-workspaces`, ...) that are normally installed by the main
-Helm chart — but are missing here since these local steps run the operator
-directly via `go run`/`make`, not through Helm. Render them straight from
-the real chart (`deploy/crownlabs`) instead of keeping a hand-maintained
-copy that can drift from it:
+The operator's per-tenant and per-workspace `RoleBinding`s reference base `ClusterRole`s (`crownlabs-manage-tenants`, `crownlabs-manage-instances`, `crownlabs-view-workspaces`, and others).
+The main Helm chart normally installs these, but they are missing here, because these local steps run the operator directly with `go run`/`make`, not through Helm.
+Render them straight from the real chart (`deploy/crownlabs`), instead of keeping a hand-maintained copy that can drift from it:
 
 ```bash
-cd dev-local/keycloak   # the chart's clusterroles/clusterrolebindings templates
-                        # are rendered relative to this folder's location
-helm dependency build ../../deploy/crownlabs   # one-time; only needed if deploy/crownlabs/charts is empty
+cd dev-local/keycloak   # The chart's clusterroles/clusterrolebindings templates
+                        # are rendered relative to this folder's location.
+helm dependency build ../../deploy/crownlabs   # One-time step; only needed if deploy/crownlabs/charts is empty.
 helm template -s templates/clusterroles.yaml -s templates/clusterrolebindings.yaml ../../deploy/crownlabs | kubectl apply -f -
 ```
 
-Purely additive: creating a `ClusterRole` grants nothing by itself until
-something is bound to it, so applying this is always safe, and safe to
-re-run any time the chart's RBAC templates change.
+These RBAC definitions are purely additive.
+Creating a `ClusterRole` grants nothing by itself, until something is bound to it.
+This means applying them is always safe, and safe to re-run any time the chart's RBAC templates change.
 
 ## 2. Run the CrownLabs operator
 
 ```bash
-export SSL_CERT_FILE=~/certs/crownlabs-ca.crt   # the operator's Go HTTP client must trust the Gateway's self-signed cert too (see ../keycloak/README.md Step 2)
+# The operator's Go HTTP client must also trust the Gateway's self-signed certificate.
+# See ../keycloak/README.md step 2.
+export SSL_CERT_FILE=~/certs/crownlabs-ca.crt
 
 cd operators
 make run-operator-local KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret
 ```
 
-`KEYCLOAK_URL` defaults to `https://keycloak.crownlabs.local` (the Gateway's
-`HTTPRoute` hostname, see [`../envoy/README.md`](../envoy/README.md)).
+`KEYCLOAK_URL` defaults to `https://keycloak.crownlabs.local` (the Gateway's `HTTPRoute` hostname, see [`../envoy/README.md`](../envoy/README.md)).
 
-> **On WSL2**: also override `KEYCLOAK_URL` to the Gateway's port-forward bridge
-> (Keycloak isn't reachable from WSL2 itself either, not just from the Windows
-> browser — see `../envoy/README.md` step 5 for why):
+> **On WSL2**: also override `KEYCLOAK_URL` to the Gateway's port-forward bridge.
+> Keycloak is not reachable from WSL2 itself either, not just from the Windows browser.
+> See `../envoy/README.md` step 5 for why.
 > ```bash
 > make run-operator-local KEYCLOAK_URL=https://keycloak.crownlabs.local:8443 KEYCLOAK_CLIENT_SECRET=operator-local-dev-secret
 > ```
 
-`run-operator-local` (in `operators/Makefile`) already sets
-`KEYCLOAK_URL`/`KEYCLOAK_REALM`/`KEYCLOAK_CLIENT_ID`/`KEYCLOAK_TARGET_CLIENT`
-to match the local realm, and `MYDRIVE_STORAGE_CLASS=local-path` (k3s's
-default storage class — override if yours differs). Only
-`KEYCLOAK_CLIENT_SECRET` needs to be passed explicitly (it's per-realm-install,
-so there's no sensible default to bake in — see `../keycloak/README.md` for
-the value this realm export ships with).
+`run-operator-local` (in `operators/Makefile`) already sets `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`, and `KEYCLOAK_TARGET_CLIENT` to match the local realm.
+It also sets `MYDRIVE_STORAGE_CLASS=local-path` (k3s's default storage class; override this if yours is different).
+Only `KEYCLOAK_CLIENT_SECRET` needs to be passed explicitly. This value is specific to each realm install, so there is no sensible default to bake in. See `../keycloak/README.md` for the value this realm export ships with.
 
-Applying CRDs and `operators/samples/` is a prerequisite of the target
-(same pattern as `run-instance-local`), so **sample `Tenant`/`Workspace`/
-`Template` resources are created automatically** — no separate step needed.
-If you'd rather test with a real Keycloak user instead of (or in addition
-to) the samples, create a matching `Tenant` by hand, e.g. for `john.doe`:
+Applying the CRDs and `operators/samples/` is a prerequisite of this target, the same way it is for `run-instance-local`.
+This means **sample `Tenant`, `Workspace`, and `Template` resources are created automatically**: you do not need a separate step for them.
+If you would rather test with a real Keycloak user, instead of the samples, or alongside them, create a matching `Tenant` by hand. For example, for `john.doe`:
 
 ```bash
 kubectl apply -f - <<'EOF'
@@ -86,26 +74,17 @@ EOF
 
 The operator starts reconciling automatically.
 
-> **Gotcha**: `run-operator-local` (and `run-instance-local`) re-apply
-> `operators/samples/` on every run. `kubectl apply` does a 3-way merge
-> against the *last-applied-configuration* it recorded — not against
-> whatever the object currently looks like — so any field you changed
-> out-of-band with `kubectl patch` (e.g. adding a `Workspace` enrollment to
-> `Tenant.spec.workspaces` per Step 7 of
-> `../keycloak/apiserver-oidc-integration.md`) gets **silently reverted** to
-> whatever `operators/samples/tenant.yml` says the next time this target
-> runs, since that patch was never reflected in the sample file. Symptom: a
-> `403 Forbidden` on a namespace/role that worked a moment ago. Fix:
-> re-apply the `kubectl patch`, or (if it's a mapping you want to keep
-> permanently) add it to the sample file itself instead of patching the
-> live object.
+> **Gotcha**: `run-operator-local` (and `run-instance-local`) re-apply `operators/samples/` on every run.
+> `kubectl apply` does a 3-way merge against the *last-applied-configuration* it recorded, not against whatever the object currently looks like.
+> So, if you changed a field out-of-band with `kubectl patch` (for example, adding a `Workspace` enrollment to `Tenant.spec.workspaces`, per step 7 of `../keycloak/apiserver-oidc-integration.md`), that change is never reflected in the sample file.
+> The next time this target runs, `operators/samples/tenant.yml` **silently reverts your change**.
+> Symptom: a `403 Forbidden` on a namespace or role that worked a moment ago.
+> Fix: re-apply the `kubectl patch`. If it is a mapping you want to keep permanently, add it to the sample file itself, instead of patching the live object.
 
 ### Forcing a reconciliation
 
-The operator doesn't watch Keycloak in real time (no active webhook
-locally). If you change something on the Keycloak side (e.g. verify a user)
-and want the operator to pick it up immediately, force a new reconciliation
-with a harmless annotation:
+The operator does not watch Keycloak in real time: there is no active webhook locally.
+If you change something on the Keycloak side (for example, verifying a user), and you want the operator to pick it up immediately, force a new reconciliation with a harmless annotation:
 
 ```bash
 kubectl annotate tenant.crownlabs.polito.it <tenant-name> crownlabs.polito.it/force-reconcile="$(date +%s)" --overwrite
@@ -115,19 +94,17 @@ kubectl annotate tenant.crownlabs.polito.it <tenant-name> crownlabs.polito.it/fo
 
 ```bash
 kubectl get pods -A
-# everything Running/Completed, no CrashLoopBackOff
+# Expected: everything is Running or Completed, with no CrashLoopBackOff.
 
 kubectl get tenants
 kubectl describe tenant <tenant-name>
-# status.ready: true, no reconciliation errors
+# Expected: status.ready is true, with no reconciliation errors.
 ```
 
 Expected end state:
 - ✅ Base `ClusterRole`/`ClusterRoleBinding`s applied.
-- ✅ CrownLabs operator running, `Tenant`/`Workspace` reconciled.
+- ✅ CrownLabs operator running, with `Tenant` and `Workspace` reconciled.
 
 ## Next
 
-For qlkube (talking directly to the real apiserver instead of through
-`kubectl proxy`) and the frontend, see
-[`../local-development.md`](../local-development.md).
+For qlkube (which talks directly to the real API server, instead of through `kubectl proxy`) and for the frontend, see [`../local-development.md`](../local-development.md).

--- a/operators/Makefile
+++ b/operators/Makefile
@@ -146,6 +146,18 @@ run-operator: generate ## Run the main operator locally
 				--enable-imagelist=true\
 				--mydrive-pvcs-storage-class-name=$(MYDRIVE_STORAGE_CLASS)
 
+# The double target below is used to set Keycloak defaults for the dev-local
+# Keycloak setup (see ../dev-local/keycloak/README.md) without touching
+# run-operator's own defaults. KEYCLOAK_CLIENT_SECRET has no default: it is
+# per-realm-install and must still be passed explicitly, e.g.:
+#   make run-operator-local KEYCLOAK_CLIENT_SECRET="$SECRET"
+.PHONY: run-operator-local
+run-operator-local: KEYCLOAK_URL=https://keycloak.crownlabs.local
+run-operator-local: KEYCLOAK_REALM=crownlabs
+run-operator-local: KEYCLOAK_CLIENT_ID=operator-local
+run-operator-local: KEYCLOAK_TARGET_CLIENT=operator-local
+run-operator-local: install-local samples-res-local run-operator ## Prepare, then run the main operator locally against the dev-local Keycloak (requires KEYCLOAK_CLIENT_SECRET).
+
 .PHONY: install-local
 install-local: manifests ## Install CrownLabs & support CRDs.
 	kubectl apply -f deploy/crds --wait


### PR DESCRIPTION
Added fundamental instructions, components, and dedicated configurations for building and developing CrownLabs on a local machine:
- Keycloak (realm import, OIDC apiserver integration)
- A shared Envoy Gateway fronting locally-exposed dev-local services (replacing per-service NodePorts)
- A Mailpit stub.