### PR TITLE
Gateway API: Simplified constants for HTTPRoute rewrite endpoints

### DIFF
--- a/operators/pkg/forge/httproutes.go
+++ b/operators/pkg/forge/httproutes.go
@@ -32,11 +32,8 @@ const (
 	// DefaultTimeoutSeconds -> the default timeout as a Gateway API Duration string (GEP-2257 format).
 	DefaultTimeoutSeconds = "3600s"
 
-	// StandaloneRewriteEndpoint -> the endpoint used to rewrite standalone GUI URLs.
-	StandaloneRewriteEndpoint = ""
-
-	// GUIRewriteEndpoint -> the endpoint used to rewrite CloudVM/VM GUI URLs.
-	GUIRewriteEndpoint = ""
+	// URLRewriteEndpoint -> the endpoint used to rewrite GUI URLs.
+	URLRewriteEndpoint = ""
 )
 
 // HTTPRouteTemplate groups the minimal parameters required to forge an HTTPRouteSpec.
@@ -157,17 +154,21 @@ func HTTPRouteRuleFilters(environment *clv1alpha2.Environment) []gatewayv1.HTTPR
 	if environment == nil {
 		return nil
 	}
+
+	filters := []gatewayv1.HTTPRouteFilter{URLRewriteFilter(URLRewriteEndpoint)}
+
 	switch environment.EnvironmentType {
 	case clv1alpha2.ClassStandalone, clv1alpha2.ClassContainer:
-		if !environment.RewriteURL {
-			return nil
+		if environment.RewriteURL {
+			return filters
 		}
-		return []gatewayv1.HTTPRouteFilter{URLRewriteFilter(StandaloneRewriteEndpoint)}
 	case clv1alpha2.ClassCloudVM, clv1alpha2.ClassLocalVM, clv1alpha2.ClassVM:
-		return []gatewayv1.HTTPRouteFilter{URLRewriteFilter(GUIRewriteEndpoint)}
+		return filters
 	default:
 		return nil
 	}
+
+	return nil
 }
 
 // URLRewriteFilter returns an URLRewrite filter for the given target endpoint.

--- a/operators/pkg/forge/httproutes_test.go
+++ b/operators/pkg/forge/httproutes_test.go
@@ -137,7 +137,7 @@ var _ = Describe("HTTPRoute helpers", func() {
 				Expect(filters).To(HaveLen(1))
 				f := filters[0]
 				Expect(f.Type).To(Equal(gatewayv1.HTTPRouteFilterURLRewrite))
-				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.StandaloneRewriteEndpoint))
+				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.URLRewriteEndpoint))
 			})
 
 			It("returns GUI rewrite when requested and environment is cloud VM", func() {
@@ -145,7 +145,7 @@ var _ = Describe("HTTPRoute helpers", func() {
 				Expect(filters).To(HaveLen(1))
 				f := filters[0]
 				Expect(f.Type).To(Equal(gatewayv1.HTTPRouteFilterURLRewrite))
-				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.GUIRewriteEndpoint))
+				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.URLRewriteEndpoint))
 			})
 
 			It("returns GUI rewrite when requested and environment is local VM", func() {
@@ -153,7 +153,7 @@ var _ = Describe("HTTPRoute helpers", func() {
 				Expect(filters).To(HaveLen(1))
 				f := filters[0]
 				Expect(f.Type).To(Equal(gatewayv1.HTTPRouteFilterURLRewrite))
-				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.GUIRewriteEndpoint))
+				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.URLRewriteEndpoint))
 			})
 
 			It("returns GUI rewrite when requested and environment is VM", func() {
@@ -161,7 +161,7 @@ var _ = Describe("HTTPRoute helpers", func() {
 				Expect(filters).To(HaveLen(1))
 				f := filters[0]
 				Expect(f.Type).To(Equal(gatewayv1.HTTPRouteFilterURLRewrite))
-				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.GUIRewriteEndpoint))
+				Expect(*f.URLRewrite.Path.ReplacePrefixMatch).To(Equal(forge.URLRewriteEndpoint))
 			})
 
 			It("returns nil for unknown environment type", func() {


### PR DESCRIPTION
This PR simplifies the rewrite‑endpoint constants and refactors the HTTPRouteRuleFilters logic to simplify the logic and ensure consistent, predictable rewrite behavior across all environment types. 

Overall, it improves clarity and maintainability.

Related to #1143
