### PR TITLE
Fix node selector

### DIFF
--- a/frontend/src/components/common/NodeSelectorIcon/NodeSelectorIcon.tsx
+++ b/frontend/src/components/common/NodeSelectorIcon/NodeSelectorIcon.tsx
@@ -13,7 +13,7 @@ const NodeSelectorIcon: FC<INodeSelectorIconProps> = ({ ...props }) => {
   const { nodeSelector, isOnWorkspace } = props;
 
   const displaySel = Object.entries(nodeSelector)
-    .filter(([k, v]) => k.includes('crownlabsPolitoIt'))
+    .filter(([k]) => k.includes('crownlabsPolitoIt'))
     .map(([k, v]) => `${cleanupLabels(k)}=${v}`)
     .join('\n');
 

--- a/frontend/src/components/common/NodeSelectorIcon/NodeSelectorIcon.tsx
+++ b/frontend/src/components/common/NodeSelectorIcon/NodeSelectorIcon.tsx
@@ -13,8 +13,9 @@ const NodeSelectorIcon: FC<INodeSelectorIconProps> = ({ ...props }) => {
   const { nodeSelector, isOnWorkspace } = props;
 
   const displaySel = Object.entries(nodeSelector)
+    .filter(([k, v]) => k.includes('crownlabsPolitoIt'))
     .map(([k, v]) => `${cleanupLabels(k)}=${v}`)
-    .join(',');
+    .join('\n');
 
   const tooltipText = !isOnWorkspace
     ? `This instance started on a node with ${displaySel}`

--- a/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTable/TemplatesTable.tsx
@@ -40,7 +40,7 @@ export interface ITemplatesTableProps {
   deleteTemplateLoading: boolean;
   createInstance: (
     id: string,
-    labelSelector?: JSON,
+    labelSelector?: Record<string, string>,
   ) => Promise<
     FetchResult<
       CreateInstanceMutation,

--- a/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableLogic/TemplatesTableLogic.tsx
@@ -185,14 +185,17 @@ const TemplatesTableLogic: FC<ITemplateTableLogicProps> = ({ ...props }) => {
       onError: apolloErrorCatcher,
     });
 
-  const createInstance = (templateId: string, labelSelector?: JSON) =>
+  const createInstance = (
+    templateId: string,
+    labelSelector?: Record<string, string>,
+  ) =>
     createInstanceMutation({
       variables: {
         templateId,
         tenantNamespace,
         tenantId: userId ?? '',
         workspaceNamespace,
-        nodeSelector: labelSelector as Record<string, string> | undefined,
+        nodeSelector: labelSelector,
       },
     }).catch(error => {
       console.error('TemplatesTableLogic createInstance error:', error);

--- a/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
+++ b/frontend/src/components/workspaces/Templates/TemplatesTableRow/TemplatesTableRow.tsx
@@ -52,7 +52,7 @@ export interface ITemplatesTableRowProps {
   editTemplate: (template: Template) => void;
   createInstance: (
     id: string,
-    labelSelector?: JSON,
+    labelSelector?: Record<string, string>,
   ) => Promise<
     FetchResult<
       CreateInstanceMutation,
@@ -599,7 +599,7 @@ const TemplatesTableRow: FC<ITemplatesTableRowProps> = ({
                       disabled: loadingLabels,
                       onClick: () => {
                         setCreateDisabled(true);
-                        createInstance(template.id, JSON.parse(key))
+                        createInstance(template.id, { [key]: value })
                           .then(() => {
                             refreshClock();
                             setTimeout(setCreateDisabled, 400, false);


### PR DESCRIPTION
# Description

Node selector for starting instances now works properly.
Also, the tooltip of an active instance has been cleared from labels not coming from Crownlabs.