### PR TITLE
Fix: fixed bug with utils column disalignment 

### DIFF
--- a/frontend/src/components/activePage/TableInstance/RowInstanceActions/RowInstanceActionsExtended.tsx
+++ b/frontend/src/components/activePage/TableInstance/RowInstanceActions/RowInstanceActionsExtended.tsx
@@ -123,7 +123,7 @@ const RowInstanceActionsExtended: FC<IRowInstanceActionsExtendedProps> = ({
   );
   return (
     <>
-      <div className="inline-flex border-box justify-center xl:pl-4">
+      <div className="hidden sm:flex items-center border-box justify-center xl:pl-4 sm:w-12 xl:w-56">
         <Popover placement="top" content={infoContent} trigger="click">
           <Button shape="circle" className="hidden sm:block mr-3">
             <InfoOutlined />

--- a/frontend/src/components/activePage/TableInstance/RowInstanceHeader/RowInstanceHeader.tsx
+++ b/frontend/src/components/activePage/TableInstance/RowInstanceHeader/RowInstanceHeader.tsx
@@ -200,7 +200,7 @@ const RowInstanceHeader: FC<IRowInstanceHeaderProps> = ({ ...props }) => {
                 : 'lg:w-1/2 xl:w-7/12'
             }`}
           >
-            <div className="flex items-center justify-center hidden sm:block w-12 xl:w-40 text-center">
+            <div className="flex items-center justify-center hidden sm:block w-12 xl:w-56 text-center">
               <Text strong>Utils</Text>
             </div>
 


### PR DESCRIPTION
This pull request makes minor UI adjustments to the table instance components to improve layout consistency, particularly for the "Utils" column and its associated actions on larger screens.

Layout and Responsiveness Improvements:

* Increased the width of the "Utils" column container from `xl:w-40` to `xl:w-56` in `RowInstanceHeader.tsx` for better alignment and consistency.
* Updated the action buttons container in `RowInstanceActionsExtended.tsx` to use `sm:w-12 xl:w-56` and improved responsive visibility, ensuring a consistent look across screen sizes.