### PR TITLE
Refactor workspace manager permissions and role bindings

### DIFF
--- a/deploy/crownlabs/templates/clusterroles.yaml
+++ b/deploy/crownlabs/templates/clusterroles.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-instances
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -22,6 +23,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-instances
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -45,6 +47,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-instance-snapshots
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -63,6 +66,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-instance-snapshots
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
@@ -87,6 +91,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-templates
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -104,6 +109,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-templates
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
@@ -127,6 +133,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-tenants
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -144,6 +151,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-tenants
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -164,6 +172,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-workspaces
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -181,6 +190,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-workspaces
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -203,6 +213,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-view-image-lists
   labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -220,6 +231,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-image-lists
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
 - apiGroups:

--- a/deploy/crownlabs/templates/clusterroles.yaml
+++ b/deploy/crownlabs/templates/clusterroles.yaml
@@ -63,6 +63,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-instance-snapshots
   labels:
+    crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -103,6 +104,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-templates
   labels:
+    crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -409,6 +411,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-sharedvolumes
   labels:
+    crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:
   - apiGroups:
@@ -424,4 +427,17 @@ rules:
       - patch
       - delete
       - deletecollection
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crownlabs-workspace-manager
+  labels:
+    {{- include "crownlabs.labels" . | nindent 4 }}
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        crownlabs.polito.it/aggregate-to-workspace-manager: "true"
+rules: []
 {{- end }}

--- a/deploy/crownlabs/templates/clusterroles.yaml
+++ b/deploy/crownlabs/templates/clusterroles.yaml
@@ -423,6 +423,7 @@ kind: ClusterRole
 metadata:
   name: crownlabs-manage-sharedvolumes
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
     crownlabs.polito.it/aggregate-to-workspace-manager: "true"
     {{- include "crownlabs.labels" . | nindent 4 }}
 rules:

--- a/operators/deploy/operator/templates/clusterrole.yaml
+++ b/operators/deploy/operator/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "operator.labels" . | nindent 4 }}
 rules:
 - apiGroups: ["crownlabs.polito.it"]
-  resources: ["workspaces", "workspaces/status", "tenants", "tenants/status", "instances", "instances/status", "templates", "templates/status", "imagelists", "imagelists/status", "sharedvolumes", "sharedvolumes/status"]
+  resources: ["workspaces", "workspaces/status", "tenants", "tenants/status", "instances", "instances/status", "instancesnapshots", "instancesnapshots/status", "templates", "templates/status", "imagelists", "imagelists/status", "sharedvolumes", "sharedvolumes/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
   
 - apiGroups: [""]

--- a/operators/pkg/controller/tenant/personal_workspace.go
+++ b/operators/pkg/controller/tenant/personal_workspace.go
@@ -57,14 +57,6 @@ func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *clv1alpha2
 		}
 	}
 
-	// Migration: delete old RoleBinding if it exists
-	oldRB := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: forge.ManageTemplatesRoleName, Namespace: tn.Status.PersonalNamespace.Name}}
-	if err := utils.EnforceObjectAbsence(ctx, r.Client, &oldRB, "old personal workspace manage-templates role binding"); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/operators/pkg/controller/tenant/personal_workspace.go
+++ b/operators/pkg/controller/tenant/personal_workspace.go
@@ -37,11 +37,11 @@ func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *clv1alpha2
 		log.Info("Tenant namespace does not exist, skipping personal workspace handling")
 		return nil
 	}
-	manageTemplatesRB := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: forge.ManageTemplatesRoleName, Namespace: tn.Status.PersonalNamespace.Name}}
+	managerRB := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: forge.WorkspaceManagerRoleName, Namespace: tn.Status.PersonalNamespace.Name}}
 	if tn.Spec.PersonalWorkspace != nil {
-		forge.ConfigurePersonalWorkspaceManageTemplatesBinding(tn, &manageTemplatesRB, forge.UpdateTenantResourceCommonLabels(manageTemplatesRB.Labels, r.TargetLabel))
-		res, err := ctrl.CreateOrUpdate(ctx, r.Client, &manageTemplatesRB, func() error {
-			return ctrl.SetControllerReference(tn, &manageTemplatesRB, r.Scheme)
+		forge.ConfigurePersonalWorkspaceManagerBinding(tn, &managerRB, forge.UpdateTenantResourceCommonLabels(managerRB.Labels, r.TargetLabel))
+		res, err := ctrl.CreateOrUpdate(ctx, r.Client, &managerRB, func() error {
+			return ctrl.SetControllerReference(tn, &managerRB, r.Scheme)
 		})
 		if err != nil {
 			tn.Status.FailingWorkspaces = append(tn.Status.FailingWorkspaces, "personal-workspace")
@@ -52,10 +52,19 @@ func (r *Reconciler) handlePersonalWorkspace(ctx context.Context, tn *clv1alpha2
 		log.Info(fmt.Sprintf("Personal Workspace role binding %s", res))
 	} else {
 		tn.Status.PersonalWorkspaceCreated = false
-		if err := utils.EnforceObjectAbsence(ctx, r.Client, &manageTemplatesRB, "personal workspace role binding"); err != nil {
+		if err := utils.EnforceObjectAbsence(ctx, r.Client, &managerRB, "personal workspace role binding"); err != nil {
 			return err
 		}
 	}
+
+	// Migration: delete old RoleBinding if it exists
+	oldRB := rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: forge.ManageTemplatesRoleName, Namespace: tn.Status.PersonalNamespace.Name}}
+	if err := utils.EnforceObjectAbsence(ctx, r.Client, &oldRB, "old personal workspace manage-templates role binding"); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/operators/pkg/controller/tenant/personal_workspace_test.go
+++ b/operators/pkg/controller/tenant/personal_workspace_test.go
@@ -51,11 +51,11 @@ var _ = Describe("Personal workspace handling", func() {
 			})
 			It("Should create the manage templates role binding for the tenant", func() {
 				rb := &rbacv1.RoleBinding{}
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeTrue(), timeout, interval)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-workspace-manager", Namespace: tnPersonalNamespace}, rb, BeTrue(), timeout, interval)
 
 				Expect(rb.Labels).To(HaveKeyWithValue("crownlabs.polito.it/managed-by", "tenant"))
 				Expect(rb.Labels).To(HaveKeyWithValue("crownlabs.polito.it/operator-selector", tenantReconciler.TargetLabel.GetValue()))
-				Expect(rb.RoleRef.Name).To(Equal("crownlabs-manage-templates"))
+				Expect(rb.RoleRef.Name).To(Equal("crownlabs-workspace-manager"))
 				Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
 				Expect(len(rb.Subjects)).To(Equal(1))
 				Expect(rb.Subjects[0].Kind).To(Equal("User"))
@@ -70,7 +70,7 @@ var _ = Describe("Personal workspace handling", func() {
 				BeforeEach(func() {
 					builder = *builder.WithInterceptorFuncs(interceptor.Funcs{
 						Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-							if rb, ok := obj.(*rbacv1.RoleBinding); ok && rb.Name == "crownlabs-manage-templates" && rb.Namespace == tnPersonalNamespace {
+							if rb, ok := obj.(*rbacv1.RoleBinding); ok && rb.Name == "crownlabs-workspace-manager" && rb.Namespace == tnPersonalNamespace {
 								return errors.New("error creating role binding")
 							}
 							return client.Create(ctx, obj, opts...)
@@ -90,7 +90,7 @@ var _ = Describe("Personal workspace handling", func() {
 		When("Personal workspace is disabled", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-workspace-manager", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
 				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
@@ -101,7 +101,7 @@ var _ = Describe("Personal workspace handling", func() {
 				BeforeEach(func() {
 					builder = *builder.WithInterceptorFuncs(interceptor.Funcs{
 						Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-							if rb, ok := obj.(*rbacv1.RoleBinding); ok && rb.Name == "crownlabs-manage-templates" && rb.Namespace == tnPersonalNamespace {
+							if rb, ok := obj.(*rbacv1.RoleBinding); ok && rb.Name == "crownlabs-workspace-manager" && rb.Namespace == tnPersonalNamespace {
 								return errors.New("error deleting role binding")
 							}
 							return client.Delete(ctx, obj, opts...)
@@ -129,7 +129,7 @@ var _ = Describe("Personal workspace handling", func() {
 		When("Personal workspace is enabled", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-workspace-manager", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
 				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())
@@ -140,7 +140,7 @@ var _ = Describe("Personal workspace handling", func() {
 		When("Personal workspace is disabled", func() {
 			It("Should not have the manage templates role binding", func() {
 				rb := &rbacv1.RoleBinding{}
-				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-manage-templates", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
+				DoesEventuallyExists(ctx, cl, client.ObjectKey{Name: "crownlabs-workspace-manager", Namespace: tnPersonalNamespace}, rb, BeFalse(), timeout, interval)
 				updatedTenant := &clv1alpha2.Tenant{}
 				err := cl.Get(ctx, types.NamespacedName{Name: tnResource.Name}, updatedTenant)
 				Expect(err).ToNot(HaveOccurred())

--- a/operators/pkg/controller/workspace/rolebinding.go
+++ b/operators/pkg/controller/workspace/rolebinding.go
@@ -48,18 +48,6 @@ func (r *Reconciler) enforceRoleBindings(
 		return fmt.Errorf("error while managing Manager Aggregated RoleBinding for workspace %s: %w", ws.Name, err)
 	}
 
-	// Delete old RoleBindings (Migration)
-	if err := r.deleteSingleRb(ctx, namespace, forge.ManageTemplatesRoleName); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("error deleting old Manager Manage Templates RoleBinding: %w", err)
-		}
-	}
-	if err := r.deleteSingleRb(ctx, namespace, forge.ManageSharedVolumesRoleName); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("error deleting old Manager Manage SharedVolumes RoleBinding: %w", err)
-		}
-	}
-
 	return nil
 }
 
@@ -83,20 +71,6 @@ func (r *Reconciler) enforceRoleBindingsAbsence(
 	if err := r.deleteSingleRb(ctx, namespace, forge.WorkspaceManagerRoleName); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("error deleting Manager Aggregated RoleBinding: %w", err)
-		}
-	}
-
-	// Delete Manager Manage Templates RoleBinding (Migration cleanup)
-	if err := r.deleteSingleRb(ctx, namespace, forge.ManageTemplatesRoleName); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("error deleting Manager Manage Templates RoleBinding: %w", err)
-		}
-	}
-
-	// Delete Manager Manage SharedVolumes RoleBinding (Migration cleanup)
-	if err := r.deleteSingleRb(ctx, namespace, forge.ManageSharedVolumesRoleName); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("error deleting Manager Manage SharedVolumes RoleBinding: %w", err)
 		}
 	}
 

--- a/operators/pkg/controller/workspace/rolebinding.go
+++ b/operators/pkg/controller/workspace/rolebinding.go
@@ -43,14 +43,21 @@ func (r *Reconciler) enforceRoleBindings(
 		return fmt.Errorf("error while managing User View Templates RoleBinding for workspace %s: %w", ws.Name, err)
 	}
 
-	// Enforce Manager Manage Templates RoleBinding
-	if err := r.enforceManagerManageTemplatesRoleBinding(ctx, ws, namespace); err != nil {
-		return fmt.Errorf("error while managing Manager Manage Templates RoleBinding for workspace %s: %w", ws.Name, err)
+	// Enforce Manager Aggregated RoleBinding
+	if err := r.enforceManagerAggregatedRoleBinding(ctx, ws, namespace); err != nil {
+		return fmt.Errorf("error while managing Manager Aggregated RoleBinding for workspace %s: %w", ws.Name, err)
 	}
 
-	// Enforce Manager Manage SharedVolumes RoleBinding
-	if err := r.enforceManagerManageSharedVolumesRoleBinding(ctx, ws, namespace); err != nil {
-		return fmt.Errorf("error while managing Manager Manage SharedVolumes RoleBinding for workspace %s: %w", ws.Name, err)
+	// Delete old RoleBindings (Migration)
+	if err := r.deleteSingleRb(ctx, namespace, forge.ManageTemplatesRoleName); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("error deleting old Manager Manage Templates RoleBinding: %w", err)
+		}
+	}
+	if err := r.deleteSingleRb(ctx, namespace, forge.ManageSharedVolumesRoleName); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("error deleting old Manager Manage SharedVolumes RoleBinding: %w", err)
+		}
 	}
 
 	return nil
@@ -72,14 +79,21 @@ func (r *Reconciler) enforceRoleBindingsAbsence(
 		}
 	}
 
-	// Delete Manager Manage Templates RoleBinding
+	// Delete Manager Aggregated RoleBinding
+	if err := r.deleteSingleRb(ctx, namespace, forge.WorkspaceManagerRoleName); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("error deleting Manager Aggregated RoleBinding: %w", err)
+		}
+	}
+
+	// Delete Manager Manage Templates RoleBinding (Migration cleanup)
 	if err := r.deleteSingleRb(ctx, namespace, forge.ManageTemplatesRoleName); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("error deleting Manager Manage Templates RoleBinding: %w", err)
 		}
 	}
 
-	// Delete Manager Manage SharedVolumes RoleBinding
+	// Delete Manager Manage SharedVolumes RoleBinding (Migration cleanup)
 	if err := r.deleteSingleRb(ctx, namespace, forge.ManageSharedVolumesRoleName); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("error deleting Manager Manage SharedVolumes RoleBinding: %w", err)
@@ -136,15 +150,15 @@ func (r *Reconciler) enforceUserViewTemplatesRoleBinding(
 	return nil
 }
 
-// enforceManagerManageTemplatesRoleBinding creates or updates the RoleBinding for Manager Manage Templates.
-func (r *Reconciler) enforceManagerManageTemplatesRoleBinding(
+// enforceManagerAggregatedRoleBinding creates or updates the RoleBinding for Workspace Managers.
+func (r *Reconciler) enforceManagerAggregatedRoleBinding(
 	ctx context.Context,
 	ws *clv1alpha1.Workspace,
 	namespace string,
 ) error {
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      forge.ManageTemplatesRoleName,
+			Name:      forge.WorkspaceManagerRoleName,
 			Namespace: namespace,
 		},
 	}
@@ -154,39 +168,11 @@ func (r *Reconciler) enforceManagerManageTemplatesRoleBinding(
 		rb.Labels = forge.UpdateWorkspaceResourceCommonLabels(rb.Labels, r.TargetLabel)
 
 		// Configure the RoleBinding
-		forge.ConfigureWorkspaceManagerManageTemplatesBinding(ws, rb, rb.Labels)
+		forge.ConfigureWorkspaceManagerAggregatedBinding(ws, rb, rb.Labels)
 
 		return ctrlutil.SetControllerReference(ws, rb, r.Scheme)
 	}); err != nil {
-		return fmt.Errorf("error while creating/updating Manager Manage Templates RoleBinding: %w", err)
-	}
-
-	return nil
-}
-
-// enforceManagerManageSharedVolumesRoleBinding creates or updates the RoleBinding for Manager Manage SharedVolumes.
-func (r *Reconciler) enforceManagerManageSharedVolumesRoleBinding(
-	ctx context.Context,
-	ws *clv1alpha1.Workspace,
-	namespace string,
-) error {
-	rb := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      forge.ManageSharedVolumesRoleName,
-			Namespace: namespace,
-		},
-	}
-
-	if _, err := ctrlutil.CreateOrUpdate(ctx, r.Client, rb, func() error {
-		// Update labels
-		rb.Labels = forge.UpdateWorkspaceResourceCommonLabels(rb.Labels, r.TargetLabel)
-
-		// Configure the RoleBinding
-		forge.ConfigureWorkspaceManagerManageSharedVolumesBinding(ws, rb, rb.Labels)
-
-		return ctrlutil.SetControllerReference(ws, rb, r.Scheme)
-	}); err != nil {
-		return fmt.Errorf("error while creating/updating Manager Manage SharedVolumes RoleBinding: %w", err)
+		return fmt.Errorf("error while creating/updating Manager Aggregated RoleBinding: %w", err)
 	}
 
 	return nil

--- a/operators/pkg/controller/workspace/rolebinding_test.go
+++ b/operators/pkg/controller/workspace/rolebinding_test.go
@@ -52,50 +52,6 @@ var roleBindingResources = []*rbacv1.RoleBinding{
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "crownlabs-manage-templates",
-			Namespace: "workspace-" + wsName,
-			Labels: map[string]string{
-				"crownlabs.polito.it/operator-selector": "test",
-				"crownlabs.polito.it/managed-by":        "workspace",
-			},
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:     "Group",
-				Name:     "kubernetes:workspace-" + wsName + ":manager",
-				APIGroup: "rbac.authorization.k8s.io",
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "crownlabs-manage-templates",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	},
-	{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "crownlabs-manage-sharedvolumes",
-			Namespace: "workspace-" + wsName,
-			Labels: map[string]string{
-				"crownlabs.polito.it/operator-selector": "test",
-				"crownlabs.polito.it/managed-by":        "workspace",
-			},
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:     "Group",
-				Name:     "kubernetes:workspace-" + wsName + ":manager",
-				APIGroup: "rbac.authorization.k8s.io",
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     "crownlabs-manage-sharedvolumes",
-			APIGroup: "rbac.authorization.k8s.io",
-		},
-	},
 }
 
 var _ = Describe("RoleBinding", func() {
@@ -114,42 +70,6 @@ var _ = Describe("RoleBinding", func() {
 			Expect(rb.Subjects).To(ContainElement(rbacv1.Subject{
 				Kind:     "Group",
 				Name:     "kubernetes:workspace-" + wsName + ":user",
-				APIGroup: "rbac.authorization.k8s.io",
-			}))
-		})
-
-		It("Should create a rolebinding for the workspace managers to manage templates", func() {
-			rb := &rbacv1.RoleBinding{}
-
-			DoesEventuallyExists(ctx, cl, client.ObjectKey{
-				Name:      "crownlabs-manage-templates",
-				Namespace: "workspace-" + wsName,
-			}, rb, BeTrue(), timeout, interval)
-			Expect(rb.RoleRef.Name).To(Equal("crownlabs-manage-templates"))
-			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-			Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-			Expect(rb.Subjects).To(HaveLen(1))
-			Expect(rb.Subjects).To(ContainElement(rbacv1.Subject{
-				Kind:     "Group",
-				Name:     "kubernetes:workspace-" + wsName + ":manager",
-				APIGroup: "rbac.authorization.k8s.io",
-			}))
-		})
-
-		It("Should create a rolebinding for the workspace managers to manage sharedvolumes", func() {
-			rb := &rbacv1.RoleBinding{}
-
-			DoesEventuallyExists(ctx, cl, client.ObjectKey{
-				Name:      "crownlabs-manage-sharedvolumes",
-				Namespace: "workspace-" + wsName,
-			}, rb, BeTrue(), timeout, interval)
-			Expect(rb.RoleRef.Name).To(Equal("crownlabs-manage-sharedvolumes"))
-			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-			Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-			Expect(rb.Subjects).To(HaveLen(1))
-			Expect(rb.Subjects).To(ContainElement(rbacv1.Subject{
-				Kind:     "Group",
-				Name:     "kubernetes:workspace-" + wsName + ":manager",
 				APIGroup: "rbac.authorization.k8s.io",
 			}))
 		})

--- a/operators/pkg/forge/rolebinding.go
+++ b/operators/pkg/forge/rolebinding.go
@@ -31,6 +31,9 @@ const (
 	// ManageTemplatesRoleName -> the name of the ClusterRole for managing templates in workspaces.
 	ManageTemplatesRoleName = "crownlabs-manage-templates"
 
+	// WorkspaceManagerRoleName -> the name of the ClusterRole for managers in workspaces.
+	WorkspaceManagerRoleName = "crownlabs-workspace-manager"
+
 	// ManageSharedVolumesRoleName -> the name of the ClusterRole for managing shared volumes in workspaces.
 	ManageSharedVolumesRoleName = "crownlabs-manage-sharedvolumes"
 )
@@ -60,8 +63,8 @@ func ConfigureWorkspaceUserViewTemplatesBinding(ws *clv1alpha1.Workspace, rb *rb
 	}
 }
 
-// ConfigureWorkspaceManagerManageTemplatesBinding configures a RoleBinding for a workspace manager to manage templates.
-func ConfigureWorkspaceManagerManageTemplatesBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
+// ConfigureWorkspaceManagerAggregatedBinding configures a RoleBinding for a workspace manager to access all manager privileges.
+func ConfigureWorkspaceManagerAggregatedBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
@@ -73,32 +76,7 @@ func ConfigureWorkspaceManagerManageTemplatesBinding(ws *clv1alpha1.Workspace, r
 	// Configure RoleRef
 	rb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     ManageTemplatesRoleName,
-		APIGroup: rbacv1.GroupName,
-	}
-
-	// Configure Subjects
-	rb.Subjects = []rbacv1.Subject{
-		{
-			Kind:     rbacv1.GroupKind,
-			Name:     fmt.Sprintf("kubernetes:%s", WorkspaceRoleName(ws.Name, clv1alpha2.Manager)),
-			APIGroup: rbacv1.GroupName,
-		},
-	}
-}
-
-// ConfigureWorkspaceManagerManageSharedVolumesBinding configures a RoleBinding for a workspace manager to manage shared volumes.
-func ConfigureWorkspaceManagerManageSharedVolumesBinding(ws *clv1alpha1.Workspace, rb *rbacv1.RoleBinding, labels map[string]string) {
-	// Set labels
-	if rb.Labels == nil {
-		rb.Labels = make(map[string]string)
-	}
-	maps.Copy(rb.Labels, labels)
-
-	// Configure RoleRef
-	rb.RoleRef = rbacv1.RoleRef{
-		Kind:     "ClusterRole",
-		Name:     ManageSharedVolumesRoleName,
+		Name:     WorkspaceManagerRoleName,
 		APIGroup: rbacv1.GroupName,
 	}
 

--- a/operators/pkg/forge/rolebinding.go
+++ b/operators/pkg/forge/rolebinding.go
@@ -28,14 +28,8 @@ const (
 	// ViewTemplatesRoleName -> the name of the ClusterRole for viewing templates in workspaces.
 	ViewTemplatesRoleName = "crownlabs-view-templates"
 
-	// ManageTemplatesRoleName -> the name of the ClusterRole for managing templates in workspaces.
-	ManageTemplatesRoleName = "crownlabs-manage-templates"
-
 	// WorkspaceManagerRoleName -> the name of the ClusterRole for managers in workspaces.
 	WorkspaceManagerRoleName = "crownlabs-workspace-manager"
-
-	// ManageSharedVolumesRoleName -> the name of the ClusterRole for managing shared volumes in workspaces.
-	ManageSharedVolumesRoleName = "crownlabs-manage-sharedvolumes"
 )
 
 // ConfigureWorkspaceUserViewTemplatesBinding configures a RoleBinding for a workspace user to view templates.

--- a/operators/pkg/forge/rolebinding.go
+++ b/operators/pkg/forge/rolebinding.go
@@ -90,8 +90,8 @@ func ConfigureWorkspaceManagerAggregatedBinding(ws *clv1alpha1.Workspace, rb *rb
 	}
 }
 
-// ConfigurePersonalWorkspaceManageTemplatesBinding configures a RoleBinding for a tenant to manage templates.
-func ConfigurePersonalWorkspaceManageTemplatesBinding(tn *clv1alpha2.Tenant, rb *rbacv1.RoleBinding, labels map[string]string) {
+// ConfigurePersonalWorkspaceManagerBinding configures a RoleBinding for a tenant to access all manager privileges in their personal workspace.
+func ConfigurePersonalWorkspaceManagerBinding(tn *clv1alpha2.Tenant, rb *rbacv1.RoleBinding, labels map[string]string) {
 	// Set the labels
 	if rb.Labels == nil {
 		rb.Labels = make(map[string]string)
@@ -104,7 +104,7 @@ func ConfigurePersonalWorkspaceManageTemplatesBinding(tn *clv1alpha2.Tenant, rb 
 	// Configure the role binding spec
 	rb.RoleRef = rbacv1.RoleRef{
 		Kind:     "ClusterRole",
-		Name:     ManageTemplatesRoleName,
+		Name:     WorkspaceManagerRoleName,
 		APIGroup: rbacv1.GroupName,
 	}
 	rb.Subjects = []rbacv1.Subject{

--- a/operators/pkg/forge/rolebinding_test.go
+++ b/operators/pkg/forge/rolebinding_test.go
@@ -165,12 +165,12 @@ var _ = Describe("RoleBinding forging", func() {
 		})
 	})
 
-	Describe("The forge.ConfigurePersonalWorkspaceManageTemplatesBinding function", func() {
+	Describe("The forge.ConfigurePersonalWorkspaceManagerBinding function", func() {
 		var rb *rbacv1.RoleBinding
 		BeforeEach(func() {
 			rb = &rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-manage-templates",
+					Name:      "test-workspace-manager",
 					Namespace: "default",
 				},
 			}
@@ -178,7 +178,7 @@ var _ = Describe("RoleBinding forging", func() {
 
 		Context("When the RoleBinding has no labels", func() {
 			It("Should set the correct labels, RoleRef and Subject", func() {
-				forge.ConfigurePersonalWorkspaceManageTemplatesBinding(tenant, rb, labels)
+				forge.ConfigurePersonalWorkspaceManagerBinding(tenant, rb, labels)
 
 				// Check labels
 				for k, v := range labels {
@@ -188,7 +188,7 @@ var _ = Describe("RoleBinding forging", func() {
 				Expect(rb.Namespace).To(Equal("tenant-" + tenant.Name))
 				// Check RoleRef
 				Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-				Expect(rb.RoleRef.Name).To(Equal(forge.ManageTemplatesRoleName))
+				Expect(rb.RoleRef.Name).To(Equal(forge.WorkspaceManagerRoleName))
 				Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
 
 				// Check Subject
@@ -207,7 +207,7 @@ var _ = Describe("RoleBinding forging", func() {
 			})
 
 			It("Should keep existing labels, add new ones, and set correct Namespace, RoleRef and Subject ", func() {
-				forge.ConfigurePersonalWorkspaceManageTemplatesBinding(tenant, rb, labels)
+				forge.ConfigurePersonalWorkspaceManagerBinding(tenant, rb, labels)
 
 				Expect(rb.Labels).To(HaveKeyWithValue("existing", "label"))
 				for k, v := range labels {
@@ -217,7 +217,7 @@ var _ = Describe("RoleBinding forging", func() {
 				Expect(rb.Namespace).To(Equal("tenant-" + tenant.Name))
 				// Check RoleRef
 				Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-				Expect(rb.RoleRef.Name).To(Equal(forge.ManageTemplatesRoleName))
+				Expect(rb.RoleRef.Name).To(Equal(forge.WorkspaceManagerRoleName))
 				Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
 
 				// Check Subject

--- a/operators/pkg/forge/rolebinding_test.go
+++ b/operators/pkg/forge/rolebinding_test.go
@@ -111,7 +111,7 @@ var _ = Describe("RoleBinding forging", func() {
 		})
 	})
 
-	Describe("The forge.ConfigureWorkspaceManagerManageTemplatesBinding function", func() {
+	Describe("The forge.ConfigureWorkspaceManagerAggregatedBinding function", func() {
 		var (
 			rb *rbacv1.RoleBinding
 		)
@@ -119,7 +119,7 @@ var _ = Describe("RoleBinding forging", func() {
 		BeforeEach(func() {
 			rb = &rbacv1.RoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-manage-templates",
+					Name:      "test-workspace-manager",
 					Namespace: "default",
 				},
 			}
@@ -127,7 +127,7 @@ var _ = Describe("RoleBinding forging", func() {
 
 		Context("When the RoleBinding has no labels", func() {
 			It("Should set the correct labels, RoleRef and Subject", func() {
-				forge.ConfigureWorkspaceManagerManageTemplatesBinding(workspace, rb, labels)
+				forge.ConfigureWorkspaceManagerAggregatedBinding(workspace, rb, labels)
 
 				// Check labels
 				for k, v := range labels {
@@ -136,7 +136,7 @@ var _ = Describe("RoleBinding forging", func() {
 
 				// Check RoleRef
 				Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-				Expect(rb.RoleRef.Name).To(Equal(forge.ManageTemplatesRoleName))
+				Expect(rb.RoleRef.Name).To(Equal(forge.WorkspaceManagerRoleName))
 				Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
 
 				// Check Subject
@@ -155,61 +155,7 @@ var _ = Describe("RoleBinding forging", func() {
 			})
 
 			It("Should keep existing labels and add new ones", func() {
-				forge.ConfigureWorkspaceManagerManageTemplatesBinding(workspace, rb, labels)
-
-				Expect(rb.Labels).To(HaveKeyWithValue("existing", "label"))
-				for k, v := range labels {
-					Expect(rb.Labels).To(HaveKeyWithValue(k, v))
-				}
-			})
-		})
-	})
-
-	Describe("The forge.ConfigureWorkspaceManagerManageSharedVolumesBinding function", func() {
-		var (
-			rb *rbacv1.RoleBinding
-		)
-
-		BeforeEach(func() {
-			rb = &rbacv1.RoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-manage-sharedvolumes",
-					Namespace: "default",
-				},
-			}
-		})
-
-		Context("When the RoleBinding has no labels", func() {
-			It("Should set the correct labels, RoleRef and Subject", func() {
-				forge.ConfigureWorkspaceManagerManageSharedVolumesBinding(workspace, rb, labels)
-
-				// Check labels
-				for k, v := range labels {
-					Expect(rb.Labels).To(HaveKeyWithValue(k, v))
-				}
-
-				// Check RoleRef
-				Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
-				Expect(rb.RoleRef.Name).To(Equal(forge.ManageSharedVolumesRoleName))
-				Expect(rb.RoleRef.APIGroup).To(Equal("rbac.authorization.k8s.io"))
-
-				// Check Subject
-				Expect(rb.Subjects).To(HaveLen(1))
-				Expect(rb.Subjects[0].Kind).To(Equal("Group"))
-				Expect(rb.Subjects[0].Name).To(Equal("kubernetes:workspace-test-workspace:manager"))
-				Expect(rb.Subjects[0].APIGroup).To(Equal("rbac.authorization.k8s.io"))
-			})
-		})
-
-		Context("When the RoleBinding already has labels", func() {
-			BeforeEach(func() {
-				rb.Labels = map[string]string{
-					"existing": "label",
-				}
-			})
-
-			It("Should keep existing labels and add new ones", func() {
-				forge.ConfigureWorkspaceManagerManageSharedVolumesBinding(workspace, rb, labels)
+				forge.ConfigureWorkspaceManagerAggregatedBinding(workspace, rb, labels)
 
 				Expect(rb.Labels).To(HaveKeyWithValue("existing", "label"))
 				for k, v := range labels {


### PR DESCRIPTION
**Description**
This PR refactors workspace manager permissions by aggregating them into a single ClusterRole (crownlabs-workspace-manager), rather than creating multiple separate RoleBindings per namespace.

**Changes**

- ClusterRoles: Added a new aggregated ClusterRole that collects manager permissions (templates, shared volumes, instance snapshots) via label selector.
- Workspaces: The workspace controller now enforces a single RoleBinding to the new aggregated role and cleans up the old bindings.
- Personal Workspaces: The tenant controller is aligned to use the exact same aggregated RoleBinding for personal workspaces, granting tenants consistent access to resources like shared volumes. Old bindings are automatically migrated and removed.

[https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles)

This PR is related to #1179 